### PR TITLE
Reformat count operator

### DIFF
--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -3393,26 +3393,51 @@ var g = &grammar{
 		{
 			name: "CountOp",
 			pos:  position{line: 483, col: 1, offset: 11587},
-			expr: &actionExpr{
+			expr: &choiceExpr{
 				pos: position{line: 484, col: 5, offset: 11599},
-				run: (*parser).callonCountOp1,
-				expr: &seqExpr{
-					pos: position{line: 484, col: 5, offset: 11599},
-					exprs: []any{
-						&ruleRefExpr{
-							pos:  position{line: 484, col: 5, offset: 11599},
-							name: "COUNT",
+				alternatives: []any{
+					&actionExpr{
+						pos: position{line: 484, col: 5, offset: 11599},
+						run: (*parser).callonCountOp2,
+						expr: &seqExpr{
+							pos: position{line: 484, col: 5, offset: 11599},
+							exprs: []any{
+								&ruleRefExpr{
+									pos:  position{line: 484, col: 5, offset: 11599},
+									name: "COUNT",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 484, col: 11, offset: 11605},
+									name: "_",
+								},
+								&labeledExpr{
+									pos:   position{line: 484, col: 13, offset: 11607},
+									label: "rec",
+									expr: &ruleRefExpr{
+										pos:  position{line: 484, col: 17, offset: 11611},
+										name: "Record",
+									},
+								},
+							},
 						},
-						&ruleRefExpr{
-							pos:  position{line: 484, col: 11, offset: 11605},
-							name: "_",
-						},
-						&labeledExpr{
-							pos:   position{line: 484, col: 13, offset: 11607},
-							label: "rec",
-							expr: &ruleRefExpr{
-								pos:  position{line: 484, col: 17, offset: 11611},
-								name: "Record",
+					},
+					&actionExpr{
+						pos: position{line: 491, col: 5, offset: 11753},
+						run: (*parser).callonCountOp8,
+						expr: &seqExpr{
+							pos: position{line: 491, col: 5, offset: 11753},
+							exprs: []any{
+								&ruleRefExpr{
+									pos:  position{line: 491, col: 5, offset: 11753},
+									name: "COUNT",
+								},
+								&andExpr{
+									pos: position{line: 491, col: 11, offset: 11759},
+									expr: &ruleRefExpr{
+										pos:  position{line: 491, col: 12, offset: 11760},
+										name: "EndOfOp",
+									},
+								},
 							},
 						},
 					},
@@ -3423,26 +3448,26 @@ var g = &grammar{
 		},
 		{
 			name: "CutOp",
-			pos:  position{line: 491, col: 1, offset: 11729},
+			pos:  position{line: 498, col: 1, offset: 11863},
 			expr: &actionExpr{
-				pos: position{line: 492, col: 5, offset: 11739},
+				pos: position{line: 499, col: 5, offset: 11873},
 				run: (*parser).callonCutOp1,
 				expr: &seqExpr{
-					pos: position{line: 492, col: 5, offset: 11739},
+					pos: position{line: 499, col: 5, offset: 11873},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 492, col: 5, offset: 11739},
+							pos:  position{line: 499, col: 5, offset: 11873},
 							name: "CUT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 492, col: 9, offset: 11743},
+							pos:  position{line: 499, col: 9, offset: 11877},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 492, col: 11, offset: 11745},
+							pos:   position{line: 499, col: 11, offset: 11879},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 492, col: 16, offset: 11750},
+								pos:  position{line: 499, col: 16, offset: 11884},
 								name: "Assignments",
 							},
 						},
@@ -3454,26 +3479,26 @@ var g = &grammar{
 		},
 		{
 			name: "DistinctOp",
-			pos:  position{line: 500, col: 1, offset: 11898},
+			pos:  position{line: 507, col: 1, offset: 12032},
 			expr: &actionExpr{
-				pos: position{line: 501, col: 5, offset: 11913},
+				pos: position{line: 508, col: 5, offset: 12047},
 				run: (*parser).callonDistinctOp1,
 				expr: &seqExpr{
-					pos: position{line: 501, col: 5, offset: 11913},
+					pos: position{line: 508, col: 5, offset: 12047},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 501, col: 5, offset: 11913},
+							pos:  position{line: 508, col: 5, offset: 12047},
 							name: "DISTINCT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 501, col: 14, offset: 11922},
+							pos:  position{line: 508, col: 14, offset: 12056},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 501, col: 16, offset: 11924},
+							pos:   position{line: 508, col: 16, offset: 12058},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 501, col: 18, offset: 11926},
+								pos:  position{line: 508, col: 18, offset: 12060},
 								name: "Expr",
 							},
 						},
@@ -3485,26 +3510,26 @@ var g = &grammar{
 		},
 		{
 			name: "DropOp",
-			pos:  position{line: 509, col: 1, offset: 12066},
+			pos:  position{line: 516, col: 1, offset: 12200},
 			expr: &actionExpr{
-				pos: position{line: 510, col: 5, offset: 12077},
+				pos: position{line: 517, col: 5, offset: 12211},
 				run: (*parser).callonDropOp1,
 				expr: &seqExpr{
-					pos: position{line: 510, col: 5, offset: 12077},
+					pos: position{line: 517, col: 5, offset: 12211},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 510, col: 5, offset: 12077},
+							pos:  position{line: 517, col: 5, offset: 12211},
 							name: "DROP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 510, col: 10, offset: 12082},
+							pos:  position{line: 517, col: 10, offset: 12216},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 510, col: 12, offset: 12084},
+							pos:   position{line: 517, col: 12, offset: 12218},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 510, col: 17, offset: 12089},
+								pos:  position{line: 517, col: 17, offset: 12223},
 								name: "Lvals",
 							},
 						},
@@ -3516,38 +3541,38 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOp",
-			pos:  position{line: 518, col: 1, offset: 12233},
+			pos:  position{line: 525, col: 1, offset: 12367},
 			expr: &choiceExpr{
-				pos: position{line: 519, col: 5, offset: 12244},
+				pos: position{line: 526, col: 5, offset: 12378},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 519, col: 5, offset: 12244},
+						pos: position{line: 526, col: 5, offset: 12378},
 						run: (*parser).callonHeadOp2,
 						expr: &seqExpr{
-							pos: position{line: 519, col: 5, offset: 12244},
+							pos: position{line: 526, col: 5, offset: 12378},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 519, col: 6, offset: 12245},
+									pos: position{line: 526, col: 6, offset: 12379},
 									alternatives: []any{
 										&ruleRefExpr{
-											pos:  position{line: 519, col: 6, offset: 12245},
+											pos:  position{line: 526, col: 6, offset: 12379},
 											name: "HEAD",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 519, col: 13, offset: 12252},
+											pos:  position{line: 526, col: 13, offset: 12386},
 											name: "LIMIT",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 519, col: 20, offset: 12259},
+									pos:  position{line: 526, col: 20, offset: 12393},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 519, col: 22, offset: 12261},
+									pos:   position{line: 526, col: 22, offset: 12395},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 519, col: 28, offset: 12267},
+										pos:  position{line: 526, col: 28, offset: 12401},
 										name: "Expr",
 									},
 								},
@@ -3555,19 +3580,19 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 526, col: 5, offset: 12401},
+						pos: position{line: 533, col: 5, offset: 12535},
 						run: (*parser).callonHeadOp10,
 						expr: &seqExpr{
-							pos: position{line: 526, col: 5, offset: 12401},
+							pos: position{line: 533, col: 5, offset: 12535},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 526, col: 5, offset: 12401},
+									pos:  position{line: 533, col: 5, offset: 12535},
 									name: "HEAD",
 								},
 								&andExpr{
-									pos: position{line: 526, col: 10, offset: 12406},
+									pos: position{line: 533, col: 10, offset: 12540},
 									expr: &ruleRefExpr{
-										pos:  position{line: 526, col: 11, offset: 12407},
+										pos:  position{line: 533, col: 11, offset: 12541},
 										name: "EndOfOp",
 									},
 								},
@@ -3581,29 +3606,29 @@ var g = &grammar{
 		},
 		{
 			name: "TailOp",
-			pos:  position{line: 533, col: 1, offset: 12508},
+			pos:  position{line: 540, col: 1, offset: 12642},
 			expr: &choiceExpr{
-				pos: position{line: 534, col: 5, offset: 12519},
+				pos: position{line: 541, col: 5, offset: 12653},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 534, col: 5, offset: 12519},
+						pos: position{line: 541, col: 5, offset: 12653},
 						run: (*parser).callonTailOp2,
 						expr: &seqExpr{
-							pos: position{line: 534, col: 5, offset: 12519},
+							pos: position{line: 541, col: 5, offset: 12653},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 534, col: 5, offset: 12519},
+									pos:  position{line: 541, col: 5, offset: 12653},
 									name: "TAIL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 534, col: 10, offset: 12524},
+									pos:  position{line: 541, col: 10, offset: 12658},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 534, col: 12, offset: 12526},
+									pos:   position{line: 541, col: 12, offset: 12660},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 534, col: 18, offset: 12532},
+										pos:  position{line: 541, col: 18, offset: 12666},
 										name: "Expr",
 									},
 								},
@@ -3611,19 +3636,19 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 541, col: 5, offset: 12666},
+						pos: position{line: 548, col: 5, offset: 12800},
 						run: (*parser).callonTailOp8,
 						expr: &seqExpr{
-							pos: position{line: 541, col: 5, offset: 12666},
+							pos: position{line: 548, col: 5, offset: 12800},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 541, col: 5, offset: 12666},
+									pos:  position{line: 548, col: 5, offset: 12800},
 									name: "TAIL",
 								},
 								&andExpr{
-									pos: position{line: 541, col: 10, offset: 12671},
+									pos: position{line: 548, col: 10, offset: 12805},
 									expr: &ruleRefExpr{
-										pos:  position{line: 541, col: 11, offset: 12672},
+										pos:  position{line: 548, col: 11, offset: 12806},
 										name: "EndOfOp",
 									},
 								},
@@ -3637,26 +3662,26 @@ var g = &grammar{
 		},
 		{
 			name: "SkipOp",
-			pos:  position{line: 548, col: 1, offset: 12773},
+			pos:  position{line: 555, col: 1, offset: 12907},
 			expr: &actionExpr{
-				pos: position{line: 549, col: 5, offset: 12784},
+				pos: position{line: 556, col: 5, offset: 12918},
 				run: (*parser).callonSkipOp1,
 				expr: &seqExpr{
-					pos: position{line: 549, col: 5, offset: 12784},
+					pos: position{line: 556, col: 5, offset: 12918},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 549, col: 5, offset: 12784},
+							pos:  position{line: 556, col: 5, offset: 12918},
 							name: "SKIP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 549, col: 10, offset: 12789},
+							pos:  position{line: 556, col: 10, offset: 12923},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 549, col: 12, offset: 12791},
+							pos:   position{line: 556, col: 12, offset: 12925},
 							label: "count",
 							expr: &ruleRefExpr{
-								pos:  position{line: 549, col: 18, offset: 12797},
+								pos:  position{line: 556, col: 18, offset: 12931},
 								name: "Expr",
 							},
 						},
@@ -3668,26 +3693,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereOp",
-			pos:  position{line: 557, col: 1, offset: 12928},
+			pos:  position{line: 564, col: 1, offset: 13062},
 			expr: &actionExpr{
-				pos: position{line: 558, col: 5, offset: 12940},
+				pos: position{line: 565, col: 5, offset: 13074},
 				run: (*parser).callonWhereOp1,
 				expr: &seqExpr{
-					pos: position{line: 558, col: 5, offset: 12940},
+					pos: position{line: 565, col: 5, offset: 13074},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 558, col: 5, offset: 12940},
+							pos:  position{line: 565, col: 5, offset: 13074},
 							name: "WHERE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 558, col: 11, offset: 12946},
+							pos:  position{line: 565, col: 11, offset: 13080},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 558, col: 13, offset: 12948},
+							pos:   position{line: 565, col: 13, offset: 13082},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 558, col: 18, offset: 12953},
+								pos:  position{line: 565, col: 18, offset: 13087},
 								name: "Expr",
 							},
 						},
@@ -3699,26 +3724,26 @@ var g = &grammar{
 		},
 		{
 			name: "UniqOp",
-			pos:  position{line: 566, col: 1, offset: 13084},
+			pos:  position{line: 573, col: 1, offset: 13218},
 			expr: &choiceExpr{
-				pos: position{line: 567, col: 5, offset: 13095},
+				pos: position{line: 574, col: 5, offset: 13229},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 567, col: 5, offset: 13095},
+						pos: position{line: 574, col: 5, offset: 13229},
 						run: (*parser).callonUniqOp2,
 						expr: &seqExpr{
-							pos: position{line: 567, col: 5, offset: 13095},
+							pos: position{line: 574, col: 5, offset: 13229},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 567, col: 5, offset: 13095},
+									pos:  position{line: 574, col: 5, offset: 13229},
 									name: "UNIQ",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 567, col: 10, offset: 13100},
+									pos:  position{line: 574, col: 10, offset: 13234},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 567, col: 12, offset: 13102},
+									pos:        position{line: 574, col: 12, offset: 13236},
 									val:        "-c",
 									ignoreCase: false,
 									want:       "\"-c\"",
@@ -3727,19 +3752,19 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 570, col: 5, offset: 13191},
+						pos: position{line: 577, col: 5, offset: 13325},
 						run: (*parser).callonUniqOp7,
 						expr: &seqExpr{
-							pos: position{line: 570, col: 5, offset: 13191},
+							pos: position{line: 577, col: 5, offset: 13325},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 570, col: 5, offset: 13191},
+									pos:  position{line: 577, col: 5, offset: 13325},
 									name: "UNIQ",
 								},
 								&andExpr{
-									pos: position{line: 570, col: 10, offset: 13196},
+									pos: position{line: 577, col: 10, offset: 13330},
 									expr: &ruleRefExpr{
-										pos:  position{line: 570, col: 11, offset: 13197},
+										pos:  position{line: 577, col: 11, offset: 13331},
 										name: "EndOfOp",
 									},
 								},
@@ -3753,26 +3778,26 @@ var g = &grammar{
 		},
 		{
 			name: "PutOp",
-			pos:  position{line: 574, col: 1, offset: 13273},
+			pos:  position{line: 581, col: 1, offset: 13407},
 			expr: &actionExpr{
-				pos: position{line: 575, col: 5, offset: 13283},
+				pos: position{line: 582, col: 5, offset: 13417},
 				run: (*parser).callonPutOp1,
 				expr: &seqExpr{
-					pos: position{line: 575, col: 5, offset: 13283},
+					pos: position{line: 582, col: 5, offset: 13417},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 575, col: 5, offset: 13283},
+							pos:  position{line: 582, col: 5, offset: 13417},
 							name: "PUT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 575, col: 9, offset: 13287},
+							pos:  position{line: 582, col: 9, offset: 13421},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 575, col: 11, offset: 13289},
+							pos:   position{line: 582, col: 11, offset: 13423},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 575, col: 16, offset: 13294},
+								pos:  position{line: 582, col: 16, offset: 13428},
 								name: "Assignments",
 							},
 						},
@@ -3784,59 +3809,59 @@ var g = &grammar{
 		},
 		{
 			name: "RenameOp",
-			pos:  position{line: 583, col: 1, offset: 13448},
+			pos:  position{line: 590, col: 1, offset: 13582},
 			expr: &actionExpr{
-				pos: position{line: 584, col: 5, offset: 13461},
+				pos: position{line: 591, col: 5, offset: 13595},
 				run: (*parser).callonRenameOp1,
 				expr: &seqExpr{
-					pos: position{line: 584, col: 5, offset: 13461},
+					pos: position{line: 591, col: 5, offset: 13595},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 584, col: 5, offset: 13461},
+							pos:  position{line: 591, col: 5, offset: 13595},
 							name: "RENAME",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 584, col: 12, offset: 13468},
+							pos:  position{line: 591, col: 12, offset: 13602},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 584, col: 14, offset: 13470},
+							pos:   position{line: 591, col: 14, offset: 13604},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 584, col: 20, offset: 13476},
+								pos:  position{line: 591, col: 20, offset: 13610},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 584, col: 31, offset: 13487},
+							pos:   position{line: 591, col: 31, offset: 13621},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 584, col: 36, offset: 13492},
+								pos: position{line: 591, col: 36, offset: 13626},
 								expr: &actionExpr{
-									pos: position{line: 584, col: 37, offset: 13493},
+									pos: position{line: 591, col: 37, offset: 13627},
 									run: (*parser).callonRenameOp9,
 									expr: &seqExpr{
-										pos: position{line: 584, col: 37, offset: 13493},
+										pos: position{line: 591, col: 37, offset: 13627},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 584, col: 37, offset: 13493},
+												pos:  position{line: 591, col: 37, offset: 13627},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 584, col: 40, offset: 13496},
+												pos:        position{line: 591, col: 40, offset: 13630},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 584, col: 44, offset: 13500},
+												pos:  position{line: 591, col: 44, offset: 13634},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 584, col: 47, offset: 13503},
+												pos:   position{line: 591, col: 47, offset: 13637},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 584, col: 50, offset: 13506},
+													pos:  position{line: 591, col: 50, offset: 13640},
 													name: "Assignment",
 												},
 											},
@@ -3853,21 +3878,21 @@ var g = &grammar{
 		},
 		{
 			name: "FuseOp",
-			pos:  position{line: 593, col: 1, offset: 13732},
+			pos:  position{line: 600, col: 1, offset: 13866},
 			expr: &actionExpr{
-				pos: position{line: 594, col: 5, offset: 13743},
+				pos: position{line: 601, col: 5, offset: 13877},
 				run: (*parser).callonFuseOp1,
 				expr: &seqExpr{
-					pos: position{line: 594, col: 5, offset: 13743},
+					pos: position{line: 601, col: 5, offset: 13877},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 594, col: 5, offset: 13743},
+							pos:  position{line: 601, col: 5, offset: 13877},
 							name: "FUSE",
 						},
 						&andExpr{
-							pos: position{line: 594, col: 10, offset: 13748},
+							pos: position{line: 601, col: 10, offset: 13882},
 							expr: &ruleRefExpr{
-								pos:  position{line: 594, col: 11, offset: 13749},
+								pos:  position{line: 601, col: 11, offset: 13883},
 								name: "EndOfOp",
 							},
 						},
@@ -3879,41 +3904,41 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOp",
-			pos:  position{line: 598, col: 1, offset: 13825},
+			pos:  position{line: 605, col: 1, offset: 13959},
 			expr: &choiceExpr{
-				pos: position{line: 599, col: 5, offset: 13836},
+				pos: position{line: 606, col: 5, offset: 13970},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 599, col: 5, offset: 13836},
+						pos: position{line: 606, col: 5, offset: 13970},
 						run: (*parser).callonJoinOp2,
 						expr: &seqExpr{
-							pos: position{line: 599, col: 5, offset: 13836},
+							pos: position{line: 606, col: 5, offset: 13970},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 599, col: 5, offset: 13836},
+									pos:  position{line: 606, col: 5, offset: 13970},
 									name: "CROSS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 599, col: 11, offset: 13842},
+									pos:  position{line: 606, col: 11, offset: 13976},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 599, col: 13, offset: 13844},
+									pos:  position{line: 606, col: 13, offset: 13978},
 									name: "JOIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 599, col: 18, offset: 13849},
+									pos:   position{line: 606, col: 18, offset: 13983},
 									label: "rightInput",
 									expr: &ruleRefExpr{
-										pos:  position{line: 599, col: 29, offset: 13860},
+										pos:  position{line: 606, col: 29, offset: 13994},
 										name: "JoinRightInput",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 599, col: 44, offset: 13875},
+									pos:   position{line: 606, col: 44, offset: 14009},
 									label: "alias",
 									expr: &ruleRefExpr{
-										pos:  position{line: 599, col: 50, offset: 13881},
+										pos:  position{line: 606, col: 50, offset: 14015},
 										name: "OptJoinAlias",
 									},
 								},
@@ -3921,48 +3946,48 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 613, col: 5, offset: 14188},
+						pos: position{line: 620, col: 5, offset: 14322},
 						run: (*parser).callonJoinOp11,
 						expr: &seqExpr{
-							pos: position{line: 613, col: 5, offset: 14188},
+							pos: position{line: 620, col: 5, offset: 14322},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 613, col: 5, offset: 14188},
+									pos:   position{line: 620, col: 5, offset: 14322},
 									label: "style",
 									expr: &ruleRefExpr{
-										pos:  position{line: 613, col: 11, offset: 14194},
+										pos:  position{line: 620, col: 11, offset: 14328},
 										name: "JoinStyle",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 613, col: 21, offset: 14204},
+									pos:  position{line: 620, col: 21, offset: 14338},
 									name: "JOIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 613, col: 26, offset: 14209},
+									pos:   position{line: 620, col: 26, offset: 14343},
 									label: "rightInput",
 									expr: &ruleRefExpr{
-										pos:  position{line: 613, col: 37, offset: 14220},
+										pos:  position{line: 620, col: 37, offset: 14354},
 										name: "JoinRightInput",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 613, col: 52, offset: 14235},
+									pos:   position{line: 620, col: 52, offset: 14369},
 									label: "alias",
 									expr: &ruleRefExpr{
-										pos:  position{line: 613, col: 58, offset: 14241},
+										pos:  position{line: 620, col: 58, offset: 14375},
 										name: "OptJoinAlias",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 613, col: 71, offset: 14254},
+									pos:  position{line: 620, col: 71, offset: 14388},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 613, col: 73, offset: 14256},
+									pos:   position{line: 620, col: 73, offset: 14390},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 613, col: 75, offset: 14258},
+										pos:  position{line: 620, col: 75, offset: 14392},
 										name: "JoinCond",
 									},
 								},
@@ -3976,83 +4001,83 @@ var g = &grammar{
 		},
 		{
 			name: "JoinStyle",
-			pos:  position{line: 629, col: 1, offset: 14597},
+			pos:  position{line: 636, col: 1, offset: 14731},
 			expr: &choiceExpr{
-				pos: position{line: 630, col: 5, offset: 14611},
+				pos: position{line: 637, col: 5, offset: 14745},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 630, col: 5, offset: 14611},
+						pos: position{line: 637, col: 5, offset: 14745},
 						run: (*parser).callonJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 630, col: 5, offset: 14611},
+							pos: position{line: 637, col: 5, offset: 14745},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 630, col: 5, offset: 14611},
+									pos:  position{line: 637, col: 5, offset: 14745},
 									name: "ANTI",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 630, col: 10, offset: 14616},
+									pos:  position{line: 637, col: 10, offset: 14750},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 631, col: 5, offset: 14646},
+						pos: position{line: 638, col: 5, offset: 14780},
 						run: (*parser).callonJoinStyle6,
 						expr: &seqExpr{
-							pos: position{line: 631, col: 5, offset: 14646},
+							pos: position{line: 638, col: 5, offset: 14780},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 631, col: 5, offset: 14646},
+									pos:  position{line: 638, col: 5, offset: 14780},
 									name: "INNER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 631, col: 11, offset: 14652},
+									pos:  position{line: 638, col: 11, offset: 14786},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 632, col: 5, offset: 14682},
+						pos: position{line: 639, col: 5, offset: 14816},
 						run: (*parser).callonJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 632, col: 5, offset: 14682},
+							pos: position{line: 639, col: 5, offset: 14816},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 632, col: 5, offset: 14682},
+									pos:  position{line: 639, col: 5, offset: 14816},
 									name: "LEFT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 632, col: 11, offset: 14688},
+									pos:  position{line: 639, col: 11, offset: 14822},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 633, col: 5, offset: 14717},
+						pos: position{line: 640, col: 5, offset: 14851},
 						run: (*parser).callonJoinStyle14,
 						expr: &seqExpr{
-							pos: position{line: 633, col: 5, offset: 14717},
+							pos: position{line: 640, col: 5, offset: 14851},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 633, col: 5, offset: 14717},
+									pos:  position{line: 640, col: 5, offset: 14851},
 									name: "RIGHT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 633, col: 11, offset: 14723},
+									pos:  position{line: 640, col: 11, offset: 14857},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 634, col: 5, offset: 14753},
+						pos: position{line: 641, col: 5, offset: 14887},
 						run: (*parser).callonJoinStyle18,
 						expr: &litMatcher{
-							pos:        position{line: 634, col: 5, offset: 14753},
+							pos:        position{line: 641, col: 5, offset: 14887},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -4065,33 +4090,33 @@ var g = &grammar{
 		},
 		{
 			name: "OptJoinAlias",
-			pos:  position{line: 636, col: 1, offset: 14781},
+			pos:  position{line: 643, col: 1, offset: 14915},
 			expr: &choiceExpr{
-				pos: position{line: 637, col: 5, offset: 14798},
+				pos: position{line: 644, col: 5, offset: 14932},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 637, col: 5, offset: 14798},
+						pos: position{line: 644, col: 5, offset: 14932},
 						run: (*parser).callonOptJoinAlias2,
 						expr: &seqExpr{
-							pos: position{line: 637, col: 5, offset: 14798},
+							pos: position{line: 644, col: 5, offset: 14932},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 637, col: 5, offset: 14798},
+									pos:  position{line: 644, col: 5, offset: 14932},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 637, col: 7, offset: 14800},
+									pos:  position{line: 644, col: 7, offset: 14934},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 637, col: 10, offset: 14803},
+									pos:  position{line: 644, col: 10, offset: 14937},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 637, col: 12, offset: 14805},
+									pos:   position{line: 644, col: 12, offset: 14939},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 637, col: 14, offset: 14807},
+										pos:  position{line: 644, col: 14, offset: 14941},
 										name: "JoinAlias",
 									},
 								},
@@ -4099,10 +4124,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 638, col: 5, offset: 14839},
+						pos: position{line: 645, col: 5, offset: 14973},
 						run: (*parser).callonOptJoinAlias9,
 						expr: &litMatcher{
-							pos:        position{line: 638, col: 5, offset: 14839},
+							pos:        position{line: 645, col: 5, offset: 14973},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -4115,59 +4140,59 @@ var g = &grammar{
 		},
 		{
 			name: "JoinAlias",
-			pos:  position{line: 640, col: 1, offset: 14863},
+			pos:  position{line: 647, col: 1, offset: 14997},
 			expr: &actionExpr{
-				pos: position{line: 641, col: 5, offset: 14877},
+				pos: position{line: 648, col: 5, offset: 15011},
 				run: (*parser).callonJoinAlias1,
 				expr: &seqExpr{
-					pos: position{line: 641, col: 5, offset: 14877},
+					pos: position{line: 648, col: 5, offset: 15011},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 641, col: 5, offset: 14877},
+							pos:        position{line: 648, col: 5, offset: 15011},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 641, col: 9, offset: 14881},
+							pos:  position{line: 648, col: 9, offset: 15015},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 641, col: 12, offset: 14884},
+							pos:   position{line: 648, col: 12, offset: 15018},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 641, col: 17, offset: 14889},
+								pos:  position{line: 648, col: 17, offset: 15023},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 641, col: 28, offset: 14900},
+							pos:  position{line: 648, col: 28, offset: 15034},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 641, col: 31, offset: 14903},
+							pos:        position{line: 648, col: 31, offset: 15037},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 641, col: 35, offset: 14907},
+							pos:  position{line: 648, col: 35, offset: 15041},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 641, col: 38, offset: 14910},
+							pos:   position{line: 648, col: 38, offset: 15044},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 641, col: 44, offset: 14916},
+								pos:  position{line: 648, col: 44, offset: 15050},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 641, col: 55, offset: 14927},
+							pos:  position{line: 648, col: 55, offset: 15061},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 641, col: 58, offset: 14930},
+							pos:        position{line: 648, col: 58, offset: 15064},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -4180,44 +4205,44 @@ var g = &grammar{
 		},
 		{
 			name: "JoinRightInput",
-			pos:  position{line: 649, col: 1, offset: 15068},
+			pos:  position{line: 656, col: 1, offset: 15202},
 			expr: &choiceExpr{
-				pos: position{line: 650, col: 5, offset: 15087},
+				pos: position{line: 657, col: 5, offset: 15221},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 650, col: 5, offset: 15087},
+						pos: position{line: 657, col: 5, offset: 15221},
 						run: (*parser).callonJoinRightInput2,
 						expr: &seqExpr{
-							pos: position{line: 650, col: 5, offset: 15087},
+							pos: position{line: 657, col: 5, offset: 15221},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 650, col: 5, offset: 15087},
+									pos:  position{line: 657, col: 5, offset: 15221},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 650, col: 8, offset: 15090},
+									pos:        position{line: 657, col: 8, offset: 15224},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 650, col: 12, offset: 15094},
+									pos:  position{line: 657, col: 12, offset: 15228},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 650, col: 15, offset: 15097},
+									pos:   position{line: 657, col: 15, offset: 15231},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 650, col: 17, offset: 15099},
+										pos:  position{line: 657, col: 17, offset: 15233},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 650, col: 21, offset: 15103},
+									pos:  position{line: 657, col: 21, offset: 15237},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 650, col: 24, offset: 15106},
+									pos:        position{line: 657, col: 24, offset: 15240},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4226,10 +4251,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 651, col: 5, offset: 15132},
+						pos: position{line: 658, col: 5, offset: 15266},
 						run: (*parser).callonJoinRightInput11,
 						expr: &litMatcher{
-							pos:        position{line: 651, col: 5, offset: 15132},
+							pos:        position{line: 658, col: 5, offset: 15266},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -4242,37 +4267,37 @@ var g = &grammar{
 		},
 		{
 			name: "ShapesOp",
-			pos:  position{line: 653, col: 1, offset: 15156},
+			pos:  position{line: 660, col: 1, offset: 15290},
 			expr: &actionExpr{
-				pos: position{line: 654, col: 5, offset: 15169},
+				pos: position{line: 661, col: 5, offset: 15303},
 				run: (*parser).callonShapesOp1,
 				expr: &seqExpr{
-					pos: position{line: 654, col: 5, offset: 15169},
+					pos: position{line: 661, col: 5, offset: 15303},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 654, col: 5, offset: 15169},
+							pos:  position{line: 661, col: 5, offset: 15303},
 							name: "SHAPES",
 						},
 						&labeledExpr{
-							pos:   position{line: 654, col: 12, offset: 15176},
+							pos:   position{line: 661, col: 12, offset: 15310},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 654, col: 17, offset: 15181},
+								pos: position{line: 661, col: 17, offset: 15315},
 								expr: &actionExpr{
-									pos: position{line: 654, col: 18, offset: 15182},
+									pos: position{line: 661, col: 18, offset: 15316},
 									run: (*parser).callonShapesOp6,
 									expr: &seqExpr{
-										pos: position{line: 654, col: 18, offset: 15182},
+										pos: position{line: 661, col: 18, offset: 15316},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 654, col: 18, offset: 15182},
+												pos:  position{line: 661, col: 18, offset: 15316},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 654, col: 20, offset: 15184},
+												pos:   position{line: 661, col: 20, offset: 15318},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 654, col: 22, offset: 15186},
+													pos:  position{line: 661, col: 22, offset: 15320},
 													name: "Lval",
 												},
 											},
@@ -4289,28 +4314,28 @@ var g = &grammar{
 		},
 		{
 			name: "AssignmentOp",
-			pos:  position{line: 667, col: 1, offset: 15629},
+			pos:  position{line: 674, col: 1, offset: 15763},
 			expr: &actionExpr{
-				pos: position{line: 668, col: 5, offset: 15646},
+				pos: position{line: 675, col: 5, offset: 15780},
 				run: (*parser).callonAssignmentOp1,
 				expr: &seqExpr{
-					pos: position{line: 668, col: 5, offset: 15646},
+					pos: position{line: 675, col: 5, offset: 15780},
 					exprs: []any{
 						&andExpr{
-							pos: position{line: 668, col: 5, offset: 15646},
+							pos: position{line: 675, col: 5, offset: 15780},
 							expr: &seqExpr{
-								pos: position{line: 668, col: 7, offset: 15648},
+								pos: position{line: 675, col: 7, offset: 15782},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 668, col: 7, offset: 15648},
+										pos:  position{line: 675, col: 7, offset: 15782},
 										name: "Lval",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 668, col: 12, offset: 15653},
+										pos:  position{line: 675, col: 12, offset: 15787},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 668, col: 15, offset: 15656},
+										pos:        position{line: 675, col: 15, offset: 15790},
 										val:        ":=",
 										ignoreCase: false,
 										want:       "\":=\"",
@@ -4319,10 +4344,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 668, col: 21, offset: 15662},
+							pos:   position{line: 675, col: 21, offset: 15796},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 668, col: 23, offset: 15664},
+								pos:  position{line: 675, col: 23, offset: 15798},
 								name: "Assignments",
 							},
 						},
@@ -4334,36 +4359,36 @@ var g = &grammar{
 		},
 		{
 			name: "LoadOp",
-			pos:  position{line: 676, col: 1, offset: 15836},
+			pos:  position{line: 683, col: 1, offset: 15970},
 			expr: &actionExpr{
-				pos: position{line: 677, col: 5, offset: 15847},
+				pos: position{line: 684, col: 5, offset: 15981},
 				run: (*parser).callonLoadOp1,
 				expr: &seqExpr{
-					pos: position{line: 677, col: 5, offset: 15847},
+					pos: position{line: 684, col: 5, offset: 15981},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 677, col: 5, offset: 15847},
+							pos:  position{line: 684, col: 5, offset: 15981},
 							name: "LOAD",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 677, col: 10, offset: 15852},
+							pos:  position{line: 684, col: 10, offset: 15986},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 677, col: 12, offset: 15854},
+							pos:   position{line: 684, col: 12, offset: 15988},
 							label: "pool",
 							expr: &ruleRefExpr{
-								pos:  position{line: 677, col: 17, offset: 15859},
+								pos:  position{line: 684, col: 17, offset: 15993},
 								name: "Text",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 677, col: 22, offset: 15864},
+							pos:   position{line: 684, col: 22, offset: 15998},
 							label: "args",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 677, col: 27, offset: 15869},
+								pos: position{line: 684, col: 27, offset: 16003},
 								expr: &ruleRefExpr{
-									pos:  position{line: 677, col: 27, offset: 15869},
+									pos:  position{line: 684, col: 27, offset: 16003},
 									name: "CommitishOpArgs",
 								},
 							},
@@ -4376,26 +4401,26 @@ var g = &grammar{
 		},
 		{
 			name: "OutputOp",
-			pos:  position{line: 686, col: 1, offset: 16051},
+			pos:  position{line: 693, col: 1, offset: 16185},
 			expr: &actionExpr{
-				pos: position{line: 687, col: 5, offset: 16064},
+				pos: position{line: 694, col: 5, offset: 16198},
 				run: (*parser).callonOutputOp1,
 				expr: &seqExpr{
-					pos: position{line: 687, col: 5, offset: 16064},
+					pos: position{line: 694, col: 5, offset: 16198},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 687, col: 5, offset: 16064},
+							pos:  position{line: 694, col: 5, offset: 16198},
 							name: "OUTPUT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 687, col: 12, offset: 16071},
+							pos:  position{line: 694, col: 12, offset: 16205},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 687, col: 14, offset: 16073},
+							pos:   position{line: 694, col: 14, offset: 16207},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 687, col: 19, offset: 16078},
+								pos:  position{line: 694, col: 19, offset: 16212},
 								name: "Identifier",
 							},
 						},
@@ -4407,37 +4432,37 @@ var g = &grammar{
 		},
 		{
 			name: "DebugOp",
-			pos:  position{line: 695, col: 1, offset: 16216},
+			pos:  position{line: 702, col: 1, offset: 16350},
 			expr: &actionExpr{
-				pos: position{line: 696, col: 5, offset: 16228},
+				pos: position{line: 703, col: 5, offset: 16362},
 				run: (*parser).callonDebugOp1,
 				expr: &seqExpr{
-					pos: position{line: 696, col: 5, offset: 16228},
+					pos: position{line: 703, col: 5, offset: 16362},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 696, col: 5, offset: 16228},
+							pos:  position{line: 703, col: 5, offset: 16362},
 							name: "DEBUG",
 						},
 						&labeledExpr{
-							pos:   position{line: 696, col: 11, offset: 16234},
+							pos:   position{line: 703, col: 11, offset: 16368},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 696, col: 16, offset: 16239},
+								pos: position{line: 703, col: 16, offset: 16373},
 								expr: &actionExpr{
-									pos: position{line: 696, col: 17, offset: 16240},
+									pos: position{line: 703, col: 17, offset: 16374},
 									run: (*parser).callonDebugOp6,
 									expr: &seqExpr{
-										pos: position{line: 696, col: 17, offset: 16240},
+										pos: position{line: 703, col: 17, offset: 16374},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 696, col: 17, offset: 16240},
+												pos:  position{line: 703, col: 17, offset: 16374},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 696, col: 19, offset: 16242},
+												pos:   position{line: 703, col: 19, offset: 16376},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 696, col: 21, offset: 16244},
+													pos:  position{line: 703, col: 21, offset: 16378},
 													name: "Expr",
 												},
 											},
@@ -4454,26 +4479,26 @@ var g = &grammar{
 		},
 		{
 			name: "FromOp",
-			pos:  position{line: 707, col: 1, offset: 16441},
+			pos:  position{line: 714, col: 1, offset: 16575},
 			expr: &actionExpr{
-				pos: position{line: 708, col: 5, offset: 16452},
+				pos: position{line: 715, col: 5, offset: 16586},
 				run: (*parser).callonFromOp1,
 				expr: &seqExpr{
-					pos: position{line: 708, col: 5, offset: 16452},
+					pos: position{line: 715, col: 5, offset: 16586},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 708, col: 5, offset: 16452},
+							pos:  position{line: 715, col: 5, offset: 16586},
 							name: "FROM",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 708, col: 10, offset: 16457},
+							pos:  position{line: 715, col: 10, offset: 16591},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 708, col: 12, offset: 16459},
+							pos:   position{line: 715, col: 12, offset: 16593},
 							label: "item",
 							expr: &ruleRefExpr{
-								pos:  position{line: 708, col: 17, offset: 16464},
+								pos:  position{line: 715, col: 17, offset: 16598},
 								name: "FromItem",
 							},
 						},
@@ -4485,51 +4510,51 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTableExprs",
-			pos:  position{line: 716, col: 1, offset: 16600},
+			pos:  position{line: 723, col: 1, offset: 16734},
 			expr: &actionExpr{
-				pos: position{line: 717, col: 5, offset: 16618},
+				pos: position{line: 724, col: 5, offset: 16752},
 				run: (*parser).callonSQLTableExprs1,
 				expr: &seqExpr{
-					pos: position{line: 717, col: 5, offset: 16618},
+					pos: position{line: 724, col: 5, offset: 16752},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 717, col: 5, offset: 16618},
+							pos:   position{line: 724, col: 5, offset: 16752},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 717, col: 11, offset: 16624},
+								pos:  position{line: 724, col: 11, offset: 16758},
 								name: "JoinedTable",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 717, col: 23, offset: 16636},
+							pos:   position{line: 724, col: 23, offset: 16770},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 717, col: 28, offset: 16641},
+								pos: position{line: 724, col: 28, offset: 16775},
 								expr: &actionExpr{
-									pos: position{line: 717, col: 30, offset: 16643},
+									pos: position{line: 724, col: 30, offset: 16777},
 									run: (*parser).callonSQLTableExprs7,
 									expr: &seqExpr{
-										pos: position{line: 717, col: 30, offset: 16643},
+										pos: position{line: 724, col: 30, offset: 16777},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 717, col: 30, offset: 16643},
+												pos:  position{line: 724, col: 30, offset: 16777},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 717, col: 33, offset: 16646},
+												pos:        position{line: 724, col: 33, offset: 16780},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 717, col: 37, offset: 16650},
+												pos:  position{line: 724, col: 37, offset: 16784},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 717, col: 40, offset: 16653},
+												pos:   position{line: 724, col: 40, offset: 16787},
 												label: "t",
 												expr: &ruleRefExpr{
-													pos:  position{line: 717, col: 42, offset: 16655},
+													pos:  position{line: 724, col: 42, offset: 16789},
 													name: "JoinedTable",
 												},
 											},
@@ -4546,28 +4571,28 @@ var g = &grammar{
 		},
 		{
 			name: "JoinedTable",
-			pos:  position{line: 721, col: 1, offset: 16762},
+			pos:  position{line: 728, col: 1, offset: 16896},
 			expr: &actionExpr{
-				pos: position{line: 722, col: 5, offset: 16778},
+				pos: position{line: 729, col: 5, offset: 16912},
 				run: (*parser).callonJoinedTable1,
 				expr: &seqExpr{
-					pos: position{line: 722, col: 5, offset: 16778},
+					pos: position{line: 729, col: 5, offset: 16912},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 722, col: 5, offset: 16778},
+							pos:   position{line: 729, col: 5, offset: 16912},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 722, col: 11, offset: 16784},
+								pos:  position{line: 729, col: 11, offset: 16918},
 								name: "SQLTableExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 722, col: 24, offset: 16797},
+							pos:   position{line: 729, col: 24, offset: 16931},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 722, col: 29, offset: 16802},
+								pos: position{line: 729, col: 29, offset: 16936},
 								expr: &ruleRefExpr{
-									pos:  position{line: 722, col: 30, offset: 16803},
+									pos:  position{line: 729, col: 30, offset: 16937},
 									name: "JoinOperation",
 								},
 							},
@@ -4580,40 +4605,40 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTableExpr",
-			pos:  position{line: 740, col: 1, offset: 17247},
+			pos:  position{line: 747, col: 1, offset: 17381},
 			expr: &choiceExpr{
-				pos: position{line: 741, col: 5, offset: 17264},
+				pos: position{line: 748, col: 5, offset: 17398},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 741, col: 5, offset: 17264},
+						pos: position{line: 748, col: 5, offset: 17398},
 						run: (*parser).callonSQLTableExpr2,
 						expr: &seqExpr{
-							pos: position{line: 741, col: 5, offset: 17264},
+							pos: position{line: 748, col: 5, offset: 17398},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 741, col: 5, offset: 17264},
+									pos:        position{line: 748, col: 5, offset: 17398},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 741, col: 9, offset: 17268},
+									pos:  position{line: 748, col: 9, offset: 17402},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 741, col: 12, offset: 17271},
+									pos:   position{line: 748, col: 12, offset: 17405},
 									label: "table",
 									expr: &ruleRefExpr{
-										pos:  position{line: 741, col: 18, offset: 17277},
+										pos:  position{line: 748, col: 18, offset: 17411},
 										name: "JoinedTable",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 741, col: 30, offset: 17289},
+									pos:  position{line: 748, col: 30, offset: 17423},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 741, col: 33, offset: 17292},
+									pos:        position{line: 748, col: 33, offset: 17426},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4622,52 +4647,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 742, col: 5, offset: 17322},
+						pos: position{line: 749, col: 5, offset: 17456},
 						run: (*parser).callonSQLTableExpr10,
 						expr: &seqExpr{
-							pos: position{line: 742, col: 5, offset: 17322},
+							pos: position{line: 749, col: 5, offset: 17456},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 742, col: 5, offset: 17322},
+									pos:        position{line: 749, col: 5, offset: 17456},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 742, col: 9, offset: 17326},
+									pos:  position{line: 749, col: 9, offset: 17460},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 742, col: 12, offset: 17329},
+									pos:   position{line: 749, col: 12, offset: 17463},
 									label: "pipe",
 									expr: &ruleRefExpr{
-										pos:  position{line: 742, col: 17, offset: 17334},
+										pos:  position{line: 749, col: 17, offset: 17468},
 										name: "SQLPipe",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 742, col: 25, offset: 17342},
+									pos:  position{line: 749, col: 25, offset: 17476},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 742, col: 28, offset: 17345},
+									pos:        position{line: 749, col: 28, offset: 17479},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 742, col: 32, offset: 17349},
+									pos:   position{line: 749, col: 32, offset: 17483},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 742, col: 34, offset: 17351},
+										pos:  position{line: 749, col: 34, offset: 17485},
 										name: "OptOrdinality",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 742, col: 48, offset: 17365},
+									pos:   position{line: 749, col: 48, offset: 17499},
 									label: "alias",
 									expr: &ruleRefExpr{
-										pos:  position{line: 742, col: 54, offset: 17371},
+										pos:  position{line: 749, col: 54, offset: 17505},
 										name: "OptAlias",
 									},
 								},
@@ -4675,32 +4700,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 756, col: 5, offset: 17692},
+						pos: position{line: 763, col: 5, offset: 17826},
 						run: (*parser).callonSQLTableExpr22,
 						expr: &seqExpr{
-							pos: position{line: 756, col: 5, offset: 17692},
+							pos: position{line: 763, col: 5, offset: 17826},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 756, col: 5, offset: 17692},
+									pos:   position{line: 763, col: 5, offset: 17826},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 756, col: 7, offset: 17694},
+										pos:  position{line: 763, col: 7, offset: 17828},
 										name: "FromItem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 756, col: 16, offset: 17703},
+									pos:   position{line: 763, col: 16, offset: 17837},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 756, col: 18, offset: 17705},
+										pos:  position{line: 763, col: 18, offset: 17839},
 										name: "OptOrdinality",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 756, col: 32, offset: 17719},
+									pos:   position{line: 763, col: 32, offset: 17853},
 									label: "alias",
 									expr: &ruleRefExpr{
-										pos:  position{line: 756, col: 38, offset: 17725},
+										pos:  position{line: 763, col: 38, offset: 17859},
 										name: "OptAlias",
 									},
 								},
@@ -4714,28 +4739,28 @@ var g = &grammar{
 		},
 		{
 			name: "FromItem",
-			pos:  position{line: 771, col: 1, offset: 18041},
+			pos:  position{line: 778, col: 1, offset: 18175},
 			expr: &actionExpr{
-				pos: position{line: 772, col: 5, offset: 18054},
+				pos: position{line: 779, col: 5, offset: 18188},
 				run: (*parser).callonFromItem1,
 				expr: &seqExpr{
-					pos: position{line: 772, col: 5, offset: 18054},
+					pos: position{line: 779, col: 5, offset: 18188},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 772, col: 5, offset: 18054},
+							pos:   position{line: 779, col: 5, offset: 18188},
 							label: "source",
 							expr: &ruleRefExpr{
-								pos:  position{line: 772, col: 12, offset: 18061},
+								pos:  position{line: 779, col: 12, offset: 18195},
 								name: "FromSource",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 772, col: 23, offset: 18072},
+							pos:   position{line: 779, col: 23, offset: 18206},
 							label: "args",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 772, col: 28, offset: 18077},
+								pos: position{line: 779, col: 28, offset: 18211},
 								expr: &ruleRefExpr{
-									pos:  position{line: 772, col: 28, offset: 18077},
+									pos:  position{line: 779, col: 28, offset: 18211},
 									name: "CommitishOpArgs",
 								},
 							},
@@ -4748,34 +4773,34 @@ var g = &grammar{
 		},
 		{
 			name: "FromSource",
-			pos:  position{line: 780, col: 1, offset: 18246},
+			pos:  position{line: 787, col: 1, offset: 18380},
 			expr: &choiceExpr{
-				pos: position{line: 781, col: 5, offset: 18261},
+				pos: position{line: 788, col: 5, offset: 18395},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 781, col: 5, offset: 18261},
+						pos:  position{line: 788, col: 5, offset: 18395},
 						name: "Regexp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 782, col: 5, offset: 18272},
+						pos:  position{line: 789, col: 5, offset: 18406},
 						name: "Glob",
 					},
 					&actionExpr{
-						pos: position{line: 783, col: 5, offset: 18281},
+						pos: position{line: 790, col: 5, offset: 18415},
 						run: (*parser).callonFromSource4,
 						expr: &seqExpr{
-							pos: position{line: 783, col: 5, offset: 18281},
+							pos: position{line: 790, col: 5, offset: 18415},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 783, col: 5, offset: 18281},
+									pos:        position{line: 790, col: 5, offset: 18415},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&notExpr{
-									pos: position{line: 783, col: 9, offset: 18285},
+									pos: position{line: 790, col: 9, offset: 18419},
 									expr: &ruleRefExpr{
-										pos:  position{line: 783, col: 10, offset: 18286},
+										pos:  position{line: 790, col: 10, offset: 18420},
 										name: "ExprGuard",
 									},
 								},
@@ -4783,43 +4808,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 784, col: 5, offset: 18375},
+						pos: position{line: 791, col: 5, offset: 18509},
 						run: (*parser).callonFromSource9,
 						expr: &seqExpr{
-							pos: position{line: 784, col: 5, offset: 18375},
+							pos: position{line: 791, col: 5, offset: 18509},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 784, col: 5, offset: 18375},
+									pos:  position{line: 791, col: 5, offset: 18509},
 									name: "EVAL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 784, col: 10, offset: 18380},
+									pos:  position{line: 791, col: 10, offset: 18514},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 784, col: 13, offset: 18383},
+									pos:        position{line: 791, col: 13, offset: 18517},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 784, col: 17, offset: 18387},
+									pos:  position{line: 791, col: 17, offset: 18521},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 784, col: 20, offset: 18390},
+									pos:   position{line: 791, col: 20, offset: 18524},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 784, col: 22, offset: 18392},
+										pos:  position{line: 791, col: 22, offset: 18526},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 784, col: 27, offset: 18397},
+									pos:  position{line: 791, col: 27, offset: 18531},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 784, col: 30, offset: 18400},
+									pos:        position{line: 791, col: 30, offset: 18534},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4828,19 +4853,19 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 791, col: 5, offset: 18532},
+						pos: position{line: 798, col: 5, offset: 18666},
 						run: (*parser).callonFromSource19,
 						expr: &labeledExpr{
-							pos:   position{line: 791, col: 5, offset: 18532},
+							pos:   position{line: 798, col: 5, offset: 18666},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 791, col: 10, offset: 18537},
+								pos:  position{line: 798, col: 10, offset: 18671},
 								name: "ColonName",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 798, col: 5, offset: 18675},
+						pos:  position{line: 805, col: 5, offset: 18809},
 						name: "Text",
 					},
 				},
@@ -4850,34 +4875,34 @@ var g = &grammar{
 		},
 		{
 			name: "Text",
-			pos:  position{line: 800, col: 1, offset: 18681},
+			pos:  position{line: 807, col: 1, offset: 18815},
 			expr: &actionExpr{
-				pos: position{line: 801, col: 4, offset: 18689},
+				pos: position{line: 808, col: 4, offset: 18823},
 				run: (*parser).callonText1,
 				expr: &labeledExpr{
-					pos:   position{line: 801, col: 4, offset: 18689},
+					pos:   position{line: 808, col: 4, offset: 18823},
 					label: "s",
 					expr: &choiceExpr{
-						pos: position{line: 801, col: 7, offset: 18692},
+						pos: position{line: 808, col: 7, offset: 18826},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 801, col: 7, offset: 18692},
+								pos:  position{line: 808, col: 7, offset: 18826},
 								name: "SimpleURL",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 801, col: 19, offset: 18704},
+								pos:  position{line: 808, col: 19, offset: 18838},
 								name: "TextChars",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 801, col: 31, offset: 18716},
+								pos:  position{line: 808, col: 31, offset: 18850},
 								name: "DoubleQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 801, col: 52, offset: 18737},
+								pos:  position{line: 808, col: 52, offset: 18871},
 								name: "SingleQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 801, col: 73, offset: 18758},
+								pos:  position{line: 808, col: 73, offset: 18892},
 								name: "RString",
 							},
 						},
@@ -4889,38 +4914,38 @@ var g = &grammar{
 		},
 		{
 			name: "SimpleURL",
-			pos:  position{line: 805, col: 1, offset: 18847},
+			pos:  position{line: 812, col: 1, offset: 18981},
 			expr: &actionExpr{
-				pos: position{line: 806, col: 3, offset: 18861},
+				pos: position{line: 813, col: 3, offset: 18995},
 				run: (*parser).callonSimpleURL1,
 				expr: &seqExpr{
-					pos: position{line: 806, col: 3, offset: 18861},
+					pos: position{line: 813, col: 3, offset: 18995},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 806, col: 3, offset: 18861},
+							pos:        position{line: 813, col: 3, offset: 18995},
 							val:        "http",
 							ignoreCase: false,
 							want:       "\"http\"",
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 806, col: 10, offset: 18868},
+							pos: position{line: 813, col: 10, offset: 19002},
 							expr: &litMatcher{
-								pos:        position{line: 806, col: 10, offset: 18868},
+								pos:        position{line: 813, col: 10, offset: 19002},
 								val:        "s",
 								ignoreCase: false,
 								want:       "\"s\"",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 806, col: 15, offset: 18873},
+							pos:        position{line: 813, col: 15, offset: 19007},
 							val:        "://",
 							ignoreCase: false,
 							want:       "\"://\"",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 807, col: 4, offset: 18882},
+							pos: position{line: 814, col: 4, offset: 19016},
 							expr: &charClassMatcher{
-								pos:        position{line: 807, col: 4, offset: 18882},
+								pos:        position{line: 814, col: 4, offset: 19016},
 								val:        "[a-zA-Z0-9_-]",
 								chars:      []rune{'_', '-'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -4929,20 +4954,20 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 807, col: 20, offset: 18898},
+							pos: position{line: 814, col: 20, offset: 19032},
 							expr: &seqExpr{
-								pos: position{line: 807, col: 22, offset: 18900},
+								pos: position{line: 814, col: 22, offset: 19034},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 807, col: 22, offset: 18900},
+										pos:        position{line: 814, col: 22, offset: 19034},
 										val:        ".",
 										ignoreCase: false,
 										want:       "\".\"",
 									},
 									&oneOrMoreExpr{
-										pos: position{line: 807, col: 26, offset: 18904},
+										pos: position{line: 814, col: 26, offset: 19038},
 										expr: &charClassMatcher{
-											pos:        position{line: 807, col: 26, offset: 18904},
+											pos:        position{line: 814, col: 26, offset: 19038},
 											val:        "[a-zA-Z0-9_-]",
 											chars:      []rune{'_', '-'},
 											ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -4954,20 +4979,20 @@ var g = &grammar{
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 808, col: 3, offset: 18923},
+							pos: position{line: 815, col: 3, offset: 19057},
 							expr: &seqExpr{
-								pos: position{line: 808, col: 4, offset: 18924},
+								pos: position{line: 815, col: 4, offset: 19058},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 808, col: 4, offset: 18924},
+										pos:        position{line: 815, col: 4, offset: 19058},
 										val:        "/",
 										ignoreCase: false,
 										want:       "\"/\"",
 									},
 									&zeroOrOneExpr{
-										pos: position{line: 808, col: 8, offset: 18928},
+										pos: position{line: 815, col: 8, offset: 19062},
 										expr: &ruleRefExpr{
-											pos:  position{line: 808, col: 8, offset: 18928},
+											pos:  position{line: 815, col: 8, offset: 19062},
 											name: "TextChars",
 										},
 									},
@@ -4982,27 +5007,27 @@ var g = &grammar{
 		},
 		{
 			name: "TextChars",
-			pos:  position{line: 810, col: 1, offset: 18973},
+			pos:  position{line: 817, col: 1, offset: 19107},
 			expr: &actionExpr{
-				pos: position{line: 811, col: 5, offset: 18987},
+				pos: position{line: 818, col: 5, offset: 19121},
 				run: (*parser).callonTextChars1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 811, col: 5, offset: 18987},
+					pos: position{line: 818, col: 5, offset: 19121},
 					expr: &choiceExpr{
-						pos: position{line: 811, col: 6, offset: 18988},
+						pos: position{line: 818, col: 6, offset: 19122},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 811, col: 6, offset: 18988},
+								pos:  position{line: 818, col: 6, offset: 19122},
 								name: "IdentifierRest",
 							},
 							&litMatcher{
-								pos:        position{line: 811, col: 23, offset: 19005},
+								pos:        position{line: 818, col: 23, offset: 19139},
 								val:        ".",
 								ignoreCase: false,
 								want:       "\".\"",
 							},
 							&litMatcher{
-								pos:        position{line: 811, col: 29, offset: 19011},
+								pos:        position{line: 818, col: 29, offset: 19145},
 								val:        "/",
 								ignoreCase: false,
 								want:       "\"/\"",
@@ -5016,40 +5041,40 @@ var g = &grammar{
 		},
 		{
 			name: "CommitishOpArgs",
-			pos:  position{line: 813, col: 1, offset: 19049},
+			pos:  position{line: 820, col: 1, offset: 19183},
 			expr: &choiceExpr{
-				pos: position{line: 814, col: 5, offset: 19069},
+				pos: position{line: 821, col: 5, offset: 19203},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 814, col: 5, offset: 19069},
+						pos: position{line: 821, col: 5, offset: 19203},
 						run: (*parser).callonCommitishOpArgs2,
 						expr: &seqExpr{
-							pos: position{line: 814, col: 5, offset: 19069},
+							pos: position{line: 821, col: 5, offset: 19203},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 814, col: 5, offset: 19069},
+									pos:  position{line: 821, col: 5, offset: 19203},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 814, col: 8, offset: 19072},
+									pos:   position{line: 821, col: 8, offset: 19206},
 									label: "commit",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 814, col: 15, offset: 19079},
+										pos: position{line: 821, col: 15, offset: 19213},
 										expr: &ruleRefExpr{
-											pos:  position{line: 814, col: 15, offset: 19079},
+											pos:  position{line: 821, col: 15, offset: 19213},
 											name: "MetaCommitish",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 814, col: 30, offset: 19094},
+									pos:  position{line: 821, col: 30, offset: 19228},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 814, col: 33, offset: 19097},
+									pos:   position{line: 821, col: 33, offset: 19231},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 814, col: 38, offset: 19102},
+										pos:  position{line: 821, col: 38, offset: 19236},
 										name: "OpArgs",
 									},
 								},
@@ -5057,20 +5082,20 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 820, col: 5, offset: 19232},
+						pos: position{line: 827, col: 5, offset: 19366},
 						run: (*parser).callonCommitishOpArgs11,
 						expr: &seqExpr{
-							pos: position{line: 820, col: 5, offset: 19232},
+							pos: position{line: 827, col: 5, offset: 19366},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 820, col: 5, offset: 19232},
+									pos:  position{line: 827, col: 5, offset: 19366},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 820, col: 8, offset: 19235},
+									pos:   position{line: 827, col: 8, offset: 19369},
 									label: "commit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 820, col: 15, offset: 19242},
+										pos:  position{line: 827, col: 15, offset: 19376},
 										name: "MetaCommitish",
 									},
 								},
@@ -5084,31 +5109,31 @@ var g = &grammar{
 		},
 		{
 			name: "MetaCommitish",
-			pos:  position{line: 822, col: 1, offset: 19280},
+			pos:  position{line: 829, col: 1, offset: 19414},
 			expr: &choiceExpr{
-				pos: position{line: 823, col: 5, offset: 19298},
+				pos: position{line: 830, col: 5, offset: 19432},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 823, col: 5, offset: 19298},
+						pos: position{line: 830, col: 5, offset: 19432},
 						run: (*parser).callonMetaCommitish2,
 						expr: &seqExpr{
-							pos: position{line: 823, col: 5, offset: 19298},
+							pos: position{line: 830, col: 5, offset: 19432},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 823, col: 5, offset: 19298},
+									pos:   position{line: 830, col: 5, offset: 19432},
 									label: "commit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 823, col: 12, offset: 19305},
+										pos:  position{line: 830, col: 12, offset: 19439},
 										name: "Commitish",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 823, col: 22, offset: 19315},
+									pos:   position{line: 830, col: 22, offset: 19449},
 									label: "meta",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 823, col: 27, offset: 19320},
+										pos: position{line: 830, col: 27, offset: 19454},
 										expr: &ruleRefExpr{
-											pos:  position{line: 823, col: 27, offset: 19320},
+											pos:  position{line: 830, col: 27, offset: 19454},
 											name: "ColonName",
 										},
 									},
@@ -5117,13 +5142,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 830, col: 5, offset: 19544},
+						pos: position{line: 837, col: 5, offset: 19678},
 						run: (*parser).callonMetaCommitish9,
 						expr: &labeledExpr{
-							pos:   position{line: 830, col: 5, offset: 19544},
+							pos:   position{line: 837, col: 5, offset: 19678},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 830, col: 10, offset: 19549},
+								pos:  position{line: 837, col: 10, offset: 19683},
 								name: "ColonName",
 							},
 						},
@@ -5135,24 +5160,24 @@ var g = &grammar{
 		},
 		{
 			name: "Commitish",
-			pos:  position{line: 834, col: 1, offset: 19673},
+			pos:  position{line: 841, col: 1, offset: 19807},
 			expr: &actionExpr{
-				pos: position{line: 835, col: 5, offset: 19687},
+				pos: position{line: 842, col: 5, offset: 19821},
 				run: (*parser).callonCommitish1,
 				expr: &seqExpr{
-					pos: position{line: 835, col: 5, offset: 19687},
+					pos: position{line: 842, col: 5, offset: 19821},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 835, col: 5, offset: 19687},
+							pos:        position{line: 842, col: 5, offset: 19821},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 835, col: 9, offset: 19691},
+							pos:   position{line: 842, col: 9, offset: 19825},
 							label: "text",
 							expr: &ruleRefExpr{
-								pos:  position{line: 835, col: 14, offset: 19696},
+								pos:  position{line: 842, col: 14, offset: 19830},
 								name: "CommitText",
 							},
 						},
@@ -5164,19 +5189,19 @@ var g = &grammar{
 		},
 		{
 			name: "CommitText",
-			pos:  position{line: 839, col: 1, offset: 19831},
+			pos:  position{line: 846, col: 1, offset: 19965},
 			expr: &choiceExpr{
-				pos: position{line: 840, col: 5, offset: 19846},
+				pos: position{line: 847, col: 5, offset: 19980},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 840, col: 5, offset: 19846},
+						pos:  position{line: 847, col: 5, offset: 19980},
 						name: "Name",
 					},
 					&actionExpr{
-						pos: position{line: 841, col: 5, offset: 19855},
+						pos: position{line: 848, col: 5, offset: 19989},
 						run: (*parser).callonCommitText3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 841, col: 5, offset: 19855},
+							pos:  position{line: 848, col: 5, offset: 19989},
 							name: "KSUID",
 						},
 					},
@@ -5187,11 +5212,11 @@ var g = &grammar{
 		},
 		{
 			name: "KSUID",
-			pos:  position{line: 843, col: 1, offset: 19933},
+			pos:  position{line: 850, col: 1, offset: 20067},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 843, col: 9, offset: 19941},
+				pos: position{line: 850, col: 9, offset: 20075},
 				expr: &charClassMatcher{
-					pos:        position{line: 843, col: 9, offset: 19941},
+					pos:        position{line: 850, col: 9, offset: 20075},
 					val:        "[0-9a-zA-Z]",
 					ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
 					ignoreCase: false,
@@ -5203,40 +5228,40 @@ var g = &grammar{
 		},
 		{
 			name: "OpArg",
-			pos:  position{line: 845, col: 1, offset: 19955},
+			pos:  position{line: 852, col: 1, offset: 20089},
 			expr: &choiceExpr{
-				pos: position{line: 846, col: 5, offset: 19965},
+				pos: position{line: 853, col: 5, offset: 20099},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 846, col: 5, offset: 19965},
+						pos: position{line: 853, col: 5, offset: 20099},
 						run: (*parser).callonOpArg2,
 						expr: &seqExpr{
-							pos: position{line: 846, col: 5, offset: 19965},
+							pos: position{line: 853, col: 5, offset: 20099},
 							exprs: []any{
 								&andExpr{
-									pos: position{line: 846, col: 5, offset: 19965},
+									pos: position{line: 853, col: 5, offset: 20099},
 									expr: &ruleRefExpr{
-										pos:  position{line: 846, col: 6, offset: 19966},
+										pos:  position{line: 853, col: 6, offset: 20100},
 										name: "ArgNameExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 846, col: 18, offset: 19978},
+									pos:   position{line: 853, col: 18, offset: 20112},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 846, col: 22, offset: 19982},
+										pos:  position{line: 853, col: 22, offset: 20116},
 										name: "ArgName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 846, col: 30, offset: 19990},
+									pos:  position{line: 853, col: 30, offset: 20124},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 846, col: 32, offset: 19992},
+									pos:   position{line: 853, col: 32, offset: 20126},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 846, col: 34, offset: 19994},
+										pos:  position{line: 853, col: 34, offset: 20128},
 										name: "Expr",
 									},
 								},
@@ -5244,28 +5269,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 847, col: 5, offset: 20101},
+						pos: position{line: 854, col: 5, offset: 20235},
 						run: (*parser).callonOpArg11,
 						expr: &seqExpr{
-							pos: position{line: 847, col: 5, offset: 20101},
+							pos: position{line: 854, col: 5, offset: 20235},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 847, col: 5, offset: 20101},
+									pos:   position{line: 854, col: 5, offset: 20235},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 847, col: 9, offset: 20105},
+										pos:  position{line: 854, col: 9, offset: 20239},
 										name: "ArgName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 847, col: 17, offset: 20113},
+									pos:  position{line: 854, col: 17, offset: 20247},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 847, col: 19, offset: 20115},
+									pos:   position{line: 854, col: 19, offset: 20249},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 847, col: 21, offset: 20117},
+										pos:  position{line: 854, col: 21, offset: 20251},
 										name: "Text",
 									},
 								},
@@ -5279,51 +5304,51 @@ var g = &grammar{
 		},
 		{
 			name: "OpArgs",
-			pos:  position{line: 849, col: 1, offset: 20222},
+			pos:  position{line: 856, col: 1, offset: 20356},
 			expr: &actionExpr{
-				pos: position{line: 850, col: 5, offset: 20233},
+				pos: position{line: 857, col: 5, offset: 20367},
 				run: (*parser).callonOpArgs1,
 				expr: &seqExpr{
-					pos: position{line: 850, col: 5, offset: 20233},
+					pos: position{line: 857, col: 5, offset: 20367},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 850, col: 5, offset: 20233},
+							pos:        position{line: 857, col: 5, offset: 20367},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 850, col: 9, offset: 20237},
+							pos:  position{line: 857, col: 9, offset: 20371},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 850, col: 12, offset: 20240},
+							pos:   position{line: 857, col: 12, offset: 20374},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 850, col: 18, offset: 20246},
+								pos:  position{line: 857, col: 18, offset: 20380},
 								name: "OpArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 850, col: 24, offset: 20252},
+							pos:   position{line: 857, col: 24, offset: 20386},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 850, col: 29, offset: 20257},
+								pos: position{line: 857, col: 29, offset: 20391},
 								expr: &actionExpr{
-									pos: position{line: 850, col: 30, offset: 20258},
+									pos: position{line: 857, col: 30, offset: 20392},
 									run: (*parser).callonOpArgs9,
 									expr: &seqExpr{
-										pos: position{line: 850, col: 30, offset: 20258},
+										pos: position{line: 857, col: 30, offset: 20392},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 850, col: 30, offset: 20258},
+												pos:  position{line: 857, col: 30, offset: 20392},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 850, col: 32, offset: 20260},
+												pos:   position{line: 857, col: 32, offset: 20394},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 850, col: 34, offset: 20262},
+													pos:  position{line: 857, col: 34, offset: 20396},
 													name: "OpArg",
 												},
 											},
@@ -5333,11 +5358,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 850, col: 60, offset: 20288},
+							pos:  position{line: 857, col: 60, offset: 20422},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 850, col: 63, offset: 20291},
+							pos:        position{line: 857, col: 63, offset: 20425},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -5350,14 +5375,14 @@ var g = &grammar{
 		},
 		{
 			name: "ArgName",
-			pos:  position{line: 854, col: 1, offset: 20343},
+			pos:  position{line: 861, col: 1, offset: 20477},
 			expr: &actionExpr{
-				pos: position{line: 854, col: 11, offset: 20353},
+				pos: position{line: 861, col: 11, offset: 20487},
 				run: (*parser).callonArgName1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 854, col: 11, offset: 20353},
+					pos: position{line: 861, col: 11, offset: 20487},
 					expr: &ruleRefExpr{
-						pos:  position{line: 854, col: 11, offset: 20353},
+						pos:  position{line: 861, col: 11, offset: 20487},
 						name: "UnicodeLetter",
 					},
 				},
@@ -5367,20 +5392,20 @@ var g = &grammar{
 		},
 		{
 			name: "ArgNameExpr",
-			pos:  position{line: 856, col: 1, offset: 20400},
+			pos:  position{line: 863, col: 1, offset: 20534},
 			expr: &seqExpr{
-				pos: position{line: 857, col: 5, offset: 20416},
+				pos: position{line: 864, col: 5, offset: 20550},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 857, col: 5, offset: 20416},
+						pos:        position{line: 864, col: 5, offset: 20550},
 						val:        "headers",
 						ignoreCase: true,
 						want:       "\"headers\"i",
 					},
 					&notExpr{
-						pos: position{line: 857, col: 16, offset: 20427},
+						pos: position{line: 864, col: 16, offset: 20561},
 						expr: &ruleRefExpr{
-							pos:  position{line: 857, col: 17, offset: 20428},
+							pos:  position{line: 864, col: 17, offset: 20562},
 							name: "UnicodeLetter",
 						},
 					},
@@ -5391,24 +5416,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonName",
-			pos:  position{line: 859, col: 1, offset: 20443},
+			pos:  position{line: 866, col: 1, offset: 20577},
 			expr: &actionExpr{
-				pos: position{line: 860, col: 5, offset: 20457},
+				pos: position{line: 867, col: 5, offset: 20591},
 				run: (*parser).callonColonName1,
 				expr: &seqExpr{
-					pos: position{line: 860, col: 5, offset: 20457},
+					pos: position{line: 867, col: 5, offset: 20591},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 860, col: 5, offset: 20457},
+							pos:        position{line: 867, col: 5, offset: 20591},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 860, col: 9, offset: 20461},
+							pos:   position{line: 867, col: 9, offset: 20595},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 860, col: 11, offset: 20463},
+								pos:  position{line: 867, col: 11, offset: 20597},
 								name: "Name",
 							},
 						},
@@ -5420,21 +5445,21 @@ var g = &grammar{
 		},
 		{
 			name: "PassOp",
-			pos:  position{line: 862, col: 1, offset: 20487},
+			pos:  position{line: 869, col: 1, offset: 20621},
 			expr: &actionExpr{
-				pos: position{line: 863, col: 5, offset: 20498},
+				pos: position{line: 870, col: 5, offset: 20632},
 				run: (*parser).callonPassOp1,
 				expr: &seqExpr{
-					pos: position{line: 863, col: 5, offset: 20498},
+					pos: position{line: 870, col: 5, offset: 20632},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 863, col: 5, offset: 20498},
+							pos:  position{line: 870, col: 5, offset: 20632},
 							name: "PASS",
 						},
 						&andExpr{
-							pos: position{line: 863, col: 10, offset: 20503},
+							pos: position{line: 870, col: 10, offset: 20637},
 							expr: &ruleRefExpr{
-								pos:  position{line: 863, col: 11, offset: 20504},
+								pos:  position{line: 870, col: 11, offset: 20638},
 								name: "EndOfOp",
 							},
 						},
@@ -5446,44 +5471,44 @@ var g = &grammar{
 		},
 		{
 			name: "ExplodeOp",
-			pos:  position{line: 869, col: 1, offset: 20702},
+			pos:  position{line: 876, col: 1, offset: 20836},
 			expr: &actionExpr{
-				pos: position{line: 870, col: 5, offset: 20716},
+				pos: position{line: 877, col: 5, offset: 20850},
 				run: (*parser).callonExplodeOp1,
 				expr: &seqExpr{
-					pos: position{line: 870, col: 5, offset: 20716},
+					pos: position{line: 877, col: 5, offset: 20850},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 870, col: 5, offset: 20716},
+							pos:  position{line: 877, col: 5, offset: 20850},
 							name: "EXPLODE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 870, col: 13, offset: 20724},
+							pos:  position{line: 877, col: 13, offset: 20858},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 870, col: 15, offset: 20726},
+							pos:   position{line: 877, col: 15, offset: 20860},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 870, col: 20, offset: 20731},
+								pos:  position{line: 877, col: 20, offset: 20865},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 870, col: 26, offset: 20737},
+							pos:   position{line: 877, col: 26, offset: 20871},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 870, col: 30, offset: 20741},
+								pos:  position{line: 877, col: 30, offset: 20875},
 								name: "TypeArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 870, col: 38, offset: 20749},
+							pos:   position{line: 877, col: 38, offset: 20883},
 							label: "as",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 870, col: 41, offset: 20752},
+								pos: position{line: 877, col: 41, offset: 20886},
 								expr: &ruleRefExpr{
-									pos:  position{line: 870, col: 41, offset: 20752},
+									pos:  position{line: 877, col: 41, offset: 20886},
 									name: "AsArg",
 								},
 							},
@@ -5496,26 +5521,26 @@ var g = &grammar{
 		},
 		{
 			name: "MergeOp",
-			pos:  position{line: 883, col: 1, offset: 20998},
+			pos:  position{line: 890, col: 1, offset: 21132},
 			expr: &actionExpr{
-				pos: position{line: 884, col: 5, offset: 21010},
+				pos: position{line: 891, col: 5, offset: 21144},
 				run: (*parser).callonMergeOp1,
 				expr: &seqExpr{
-					pos: position{line: 884, col: 5, offset: 21010},
+					pos: position{line: 891, col: 5, offset: 21144},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 884, col: 5, offset: 21010},
+							pos:  position{line: 891, col: 5, offset: 21144},
 							name: "MERGE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 884, col: 11, offset: 21016},
+							pos:  position{line: 891, col: 11, offset: 21150},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 884, col: 13, offset: 21018},
+							pos:   position{line: 891, col: 13, offset: 21152},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 884, col: 19, offset: 21024},
+								pos:  position{line: 891, col: 19, offset: 21158},
 								name: "OrderByList",
 							},
 						},
@@ -5527,59 +5552,59 @@ var g = &grammar{
 		},
 		{
 			name: "UnnestOp",
-			pos:  position{line: 892, col: 1, offset: 21170},
+			pos:  position{line: 899, col: 1, offset: 21304},
 			expr: &actionExpr{
-				pos: position{line: 893, col: 6, offset: 21184},
+				pos: position{line: 900, col: 6, offset: 21318},
 				run: (*parser).callonUnnestOp1,
 				expr: &seqExpr{
-					pos: position{line: 893, col: 6, offset: 21184},
+					pos: position{line: 900, col: 6, offset: 21318},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 893, col: 6, offset: 21184},
+							pos:  position{line: 900, col: 6, offset: 21318},
 							name: "UNNEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 893, col: 13, offset: 21191},
+							pos:  position{line: 900, col: 13, offset: 21325},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 893, col: 15, offset: 21193},
+							pos:   position{line: 900, col: 15, offset: 21327},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 893, col: 17, offset: 21195},
+								pos:  position{line: 900, col: 17, offset: 21329},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 893, col: 22, offset: 21200},
+							pos:   position{line: 900, col: 22, offset: 21334},
 							label: "body",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 893, col: 27, offset: 21205},
+								pos: position{line: 900, col: 27, offset: 21339},
 								expr: &actionExpr{
-									pos: position{line: 893, col: 28, offset: 21206},
+									pos: position{line: 900, col: 28, offset: 21340},
 									run: (*parser).callonUnnestOp9,
 									expr: &seqExpr{
-										pos: position{line: 893, col: 28, offset: 21206},
+										pos: position{line: 900, col: 28, offset: 21340},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 893, col: 28, offset: 21206},
+												pos:  position{line: 900, col: 28, offset: 21340},
 												name: "_",
 											},
 											&litMatcher{
-												pos:        position{line: 893, col: 30, offset: 21208},
+												pos:        position{line: 900, col: 30, offset: 21342},
 												val:        "into",
 												ignoreCase: true,
 												want:       "\"into\"i",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 893, col: 38, offset: 21216},
+												pos:  position{line: 900, col: 38, offset: 21350},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 893, col: 40, offset: 21218},
+												pos:   position{line: 900, col: 40, offset: 21352},
 												label: "body",
 												expr: &ruleRefExpr{
-													pos:  position{line: 893, col: 45, offset: 21223},
+													pos:  position{line: 900, col: 45, offset: 21357},
 													name: "ScopeBody",
 												},
 											},
@@ -5596,30 +5621,30 @@ var g = &grammar{
 		},
 		{
 			name: "TypeArg",
-			pos:  position{line: 905, col: 1, offset: 21464},
+			pos:  position{line: 912, col: 1, offset: 21598},
 			expr: &actionExpr{
-				pos: position{line: 906, col: 5, offset: 21476},
+				pos: position{line: 913, col: 5, offset: 21610},
 				run: (*parser).callonTypeArg1,
 				expr: &seqExpr{
-					pos: position{line: 906, col: 5, offset: 21476},
+					pos: position{line: 913, col: 5, offset: 21610},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 906, col: 5, offset: 21476},
+							pos:  position{line: 913, col: 5, offset: 21610},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 906, col: 7, offset: 21478},
+							pos:  position{line: 913, col: 7, offset: 21612},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 906, col: 10, offset: 21481},
+							pos:  position{line: 913, col: 10, offset: 21615},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 906, col: 12, offset: 21483},
+							pos:   position{line: 913, col: 12, offset: 21617},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 906, col: 16, offset: 21487},
+								pos:  position{line: 913, col: 16, offset: 21621},
 								name: "Type",
 							},
 						},
@@ -5631,30 +5656,30 @@ var g = &grammar{
 		},
 		{
 			name: "AsArg",
-			pos:  position{line: 908, col: 1, offset: 21513},
+			pos:  position{line: 915, col: 1, offset: 21647},
 			expr: &actionExpr{
-				pos: position{line: 909, col: 5, offset: 21523},
+				pos: position{line: 916, col: 5, offset: 21657},
 				run: (*parser).callonAsArg1,
 				expr: &seqExpr{
-					pos: position{line: 909, col: 5, offset: 21523},
+					pos: position{line: 916, col: 5, offset: 21657},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 909, col: 5, offset: 21523},
+							pos:  position{line: 916, col: 5, offset: 21657},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 909, col: 7, offset: 21525},
+							pos:  position{line: 916, col: 7, offset: 21659},
 							name: "AS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 909, col: 10, offset: 21528},
+							pos:  position{line: 916, col: 10, offset: 21662},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 909, col: 12, offset: 21530},
+							pos:   position{line: 916, col: 12, offset: 21664},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 909, col: 16, offset: 21534},
+								pos:  position{line: 916, col: 16, offset: 21668},
 								name: "Lval",
 							},
 						},
@@ -5666,9 +5691,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 913, col: 1, offset: 21585},
+			pos:  position{line: 920, col: 1, offset: 21719},
 			expr: &ruleRefExpr{
-				pos:  position{line: 913, col: 8, offset: 21592},
+				pos:  position{line: 920, col: 8, offset: 21726},
 				name: "DerefExpr",
 			},
 			leader:        false,
@@ -5676,51 +5701,51 @@ var g = &grammar{
 		},
 		{
 			name: "Lvals",
-			pos:  position{line: 915, col: 1, offset: 21603},
+			pos:  position{line: 922, col: 1, offset: 21737},
 			expr: &actionExpr{
-				pos: position{line: 916, col: 5, offset: 21613},
+				pos: position{line: 923, col: 5, offset: 21747},
 				run: (*parser).callonLvals1,
 				expr: &seqExpr{
-					pos: position{line: 916, col: 5, offset: 21613},
+					pos: position{line: 923, col: 5, offset: 21747},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 916, col: 5, offset: 21613},
+							pos:   position{line: 923, col: 5, offset: 21747},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 916, col: 11, offset: 21619},
+								pos:  position{line: 923, col: 11, offset: 21753},
 								name: "Lval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 916, col: 16, offset: 21624},
+							pos:   position{line: 923, col: 16, offset: 21758},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 916, col: 21, offset: 21629},
+								pos: position{line: 923, col: 21, offset: 21763},
 								expr: &actionExpr{
-									pos: position{line: 916, col: 22, offset: 21630},
+									pos: position{line: 923, col: 22, offset: 21764},
 									run: (*parser).callonLvals7,
 									expr: &seqExpr{
-										pos: position{line: 916, col: 22, offset: 21630},
+										pos: position{line: 923, col: 22, offset: 21764},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 916, col: 22, offset: 21630},
+												pos:  position{line: 923, col: 22, offset: 21764},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 916, col: 25, offset: 21633},
+												pos:        position{line: 923, col: 25, offset: 21767},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 916, col: 29, offset: 21637},
+												pos:  position{line: 923, col: 29, offset: 21771},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 916, col: 32, offset: 21640},
+												pos:   position{line: 923, col: 32, offset: 21774},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 916, col: 37, offset: 21645},
+													pos:  position{line: 923, col: 37, offset: 21779},
 													name: "Lval",
 												},
 											},
@@ -5737,51 +5762,51 @@ var g = &grammar{
 		},
 		{
 			name: "Assignments",
-			pos:  position{line: 920, col: 1, offset: 21721},
+			pos:  position{line: 927, col: 1, offset: 21855},
 			expr: &actionExpr{
-				pos: position{line: 921, col: 5, offset: 21737},
+				pos: position{line: 928, col: 5, offset: 21871},
 				run: (*parser).callonAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 921, col: 5, offset: 21737},
+					pos: position{line: 928, col: 5, offset: 21871},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 921, col: 5, offset: 21737},
+							pos:   position{line: 928, col: 5, offset: 21871},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 921, col: 11, offset: 21743},
+								pos:  position{line: 928, col: 11, offset: 21877},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 921, col: 22, offset: 21754},
+							pos:   position{line: 928, col: 22, offset: 21888},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 921, col: 27, offset: 21759},
+								pos: position{line: 928, col: 27, offset: 21893},
 								expr: &actionExpr{
-									pos: position{line: 921, col: 28, offset: 21760},
+									pos: position{line: 928, col: 28, offset: 21894},
 									run: (*parser).callonAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 921, col: 28, offset: 21760},
+										pos: position{line: 928, col: 28, offset: 21894},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 921, col: 28, offset: 21760},
+												pos:  position{line: 928, col: 28, offset: 21894},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 921, col: 31, offset: 21763},
+												pos:        position{line: 928, col: 31, offset: 21897},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 921, col: 35, offset: 21767},
+												pos:  position{line: 928, col: 35, offset: 21901},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 921, col: 38, offset: 21770},
+												pos:   position{line: 928, col: 38, offset: 21904},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 921, col: 40, offset: 21772},
+													pos:  position{line: 928, col: 40, offset: 21906},
 													name: "Assignment",
 												},
 											},
@@ -5798,38 +5823,38 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 925, col: 1, offset: 21847},
+			pos:  position{line: 932, col: 1, offset: 21981},
 			expr: &actionExpr{
-				pos: position{line: 926, col: 5, offset: 21862},
+				pos: position{line: 933, col: 5, offset: 21996},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 926, col: 5, offset: 21862},
+					pos: position{line: 933, col: 5, offset: 21996},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 926, col: 5, offset: 21862},
+							pos:   position{line: 933, col: 5, offset: 21996},
 							label: "lhs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 926, col: 9, offset: 21866},
+								pos: position{line: 933, col: 9, offset: 22000},
 								expr: &actionExpr{
-									pos: position{line: 926, col: 10, offset: 21867},
+									pos: position{line: 933, col: 10, offset: 22001},
 									run: (*parser).callonAssignment5,
 									expr: &seqExpr{
-										pos: position{line: 926, col: 10, offset: 21867},
+										pos: position{line: 933, col: 10, offset: 22001},
 										exprs: []any{
 											&labeledExpr{
-												pos:   position{line: 926, col: 10, offset: 21867},
+												pos:   position{line: 933, col: 10, offset: 22001},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 926, col: 15, offset: 21872},
+													pos:  position{line: 933, col: 15, offset: 22006},
 													name: "Lval",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 926, col: 20, offset: 21877},
+												pos:  position{line: 933, col: 20, offset: 22011},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 926, col: 23, offset: 21880},
+												pos:        position{line: 933, col: 23, offset: 22014},
 												val:        ":=",
 												ignoreCase: false,
 												want:       "\":=\"",
@@ -5840,14 +5865,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 926, col: 51, offset: 21908},
+							pos:  position{line: 933, col: 51, offset: 22042},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 926, col: 54, offset: 21911},
+							pos:   position{line: 933, col: 54, offset: 22045},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 926, col: 58, offset: 21915},
+								pos:  position{line: 933, col: 58, offset: 22049},
 								name: "Expr",
 							},
 						},
@@ -5859,9 +5884,9 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 937, col: 1, offset: 22099},
+			pos:  position{line: 944, col: 1, offset: 22233},
 			expr: &ruleRefExpr{
-				pos:  position{line: 937, col: 8, offset: 22106},
+				pos:  position{line: 944, col: 8, offset: 22240},
 				name: "CondExpr",
 			},
 			leader:        false,
@@ -5869,63 +5894,63 @@ var g = &grammar{
 		},
 		{
 			name: "CondExpr",
-			pos:  position{line: 939, col: 1, offset: 22116},
+			pos:  position{line: 946, col: 1, offset: 22250},
 			expr: &actionExpr{
-				pos: position{line: 940, col: 5, offset: 22129},
+				pos: position{line: 947, col: 5, offset: 22263},
 				run: (*parser).callonCondExpr1,
 				expr: &seqExpr{
-					pos: position{line: 940, col: 5, offset: 22129},
+					pos: position{line: 947, col: 5, offset: 22263},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 940, col: 5, offset: 22129},
+							pos:   position{line: 947, col: 5, offset: 22263},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 940, col: 10, offset: 22134},
+								pos:  position{line: 947, col: 10, offset: 22268},
 								name: "LogicalOrExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 940, col: 24, offset: 22148},
+							pos:   position{line: 947, col: 24, offset: 22282},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 940, col: 28, offset: 22152},
+								pos: position{line: 947, col: 28, offset: 22286},
 								expr: &seqExpr{
-									pos: position{line: 940, col: 29, offset: 22153},
+									pos: position{line: 947, col: 29, offset: 22287},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 940, col: 29, offset: 22153},
+											pos:  position{line: 947, col: 29, offset: 22287},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 940, col: 32, offset: 22156},
+											pos:        position{line: 947, col: 32, offset: 22290},
 											val:        "?",
 											ignoreCase: false,
 											want:       "\"?\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 940, col: 36, offset: 22160},
+											pos:  position{line: 947, col: 36, offset: 22294},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 940, col: 39, offset: 22163},
+											pos:  position{line: 947, col: 39, offset: 22297},
 											name: "Expr",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 940, col: 44, offset: 22168},
+											pos:  position{line: 947, col: 44, offset: 22302},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 940, col: 47, offset: 22171},
+											pos:        position{line: 947, col: 47, offset: 22305},
 											val:        ":",
 											ignoreCase: false,
 											want:       "\":\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 940, col: 51, offset: 22175},
+											pos:  position{line: 947, col: 51, offset: 22309},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 940, col: 54, offset: 22178},
+											pos:  position{line: 947, col: 54, offset: 22312},
 											name: "Expr",
 										},
 									},
@@ -5940,53 +5965,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 954, col: 1, offset: 22493},
+			pos:  position{line: 961, col: 1, offset: 22627},
 			expr: &actionExpr{
-				pos: position{line: 955, col: 5, offset: 22511},
+				pos: position{line: 962, col: 5, offset: 22645},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 955, col: 5, offset: 22511},
+					pos: position{line: 962, col: 5, offset: 22645},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 955, col: 5, offset: 22511},
+							pos:   position{line: 962, col: 5, offset: 22645},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 955, col: 11, offset: 22517},
+								pos:  position{line: 962, col: 11, offset: 22651},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 956, col: 5, offset: 22536},
+							pos:   position{line: 963, col: 5, offset: 22670},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 956, col: 10, offset: 22541},
+								pos: position{line: 963, col: 10, offset: 22675},
 								expr: &actionExpr{
-									pos: position{line: 956, col: 11, offset: 22542},
+									pos: position{line: 963, col: 11, offset: 22676},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 956, col: 11, offset: 22542},
+										pos: position{line: 963, col: 11, offset: 22676},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 956, col: 11, offset: 22542},
+												pos:  position{line: 963, col: 11, offset: 22676},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 956, col: 14, offset: 22545},
+												pos:   position{line: 963, col: 14, offset: 22679},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 956, col: 17, offset: 22548},
+													pos:  position{line: 963, col: 17, offset: 22682},
 													name: "OR",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 956, col: 20, offset: 22551},
+												pos:  position{line: 963, col: 20, offset: 22685},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 956, col: 23, offset: 22554},
+												pos:   position{line: 963, col: 23, offset: 22688},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 956, col: 28, offset: 22559},
+													pos:  position{line: 963, col: 28, offset: 22693},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -6003,53 +6028,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 960, col: 1, offset: 22673},
+			pos:  position{line: 967, col: 1, offset: 22807},
 			expr: &actionExpr{
-				pos: position{line: 961, col: 5, offset: 22692},
+				pos: position{line: 968, col: 5, offset: 22826},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 961, col: 5, offset: 22692},
+					pos: position{line: 968, col: 5, offset: 22826},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 961, col: 5, offset: 22692},
+							pos:   position{line: 968, col: 5, offset: 22826},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 961, col: 11, offset: 22698},
+								pos:  position{line: 968, col: 11, offset: 22832},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 962, col: 5, offset: 22710},
+							pos:   position{line: 969, col: 5, offset: 22844},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 962, col: 10, offset: 22715},
+								pos: position{line: 969, col: 10, offset: 22849},
 								expr: &actionExpr{
-									pos: position{line: 962, col: 11, offset: 22716},
+									pos: position{line: 969, col: 11, offset: 22850},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 962, col: 11, offset: 22716},
+										pos: position{line: 969, col: 11, offset: 22850},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 962, col: 11, offset: 22716},
+												pos:  position{line: 969, col: 11, offset: 22850},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 962, col: 14, offset: 22719},
+												pos:   position{line: 969, col: 14, offset: 22853},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 962, col: 17, offset: 22722},
+													pos:  position{line: 969, col: 17, offset: 22856},
 													name: "AND",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 962, col: 21, offset: 22726},
+												pos:  position{line: 969, col: 21, offset: 22860},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 962, col: 24, offset: 22729},
+												pos:   position{line: 969, col: 24, offset: 22863},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 962, col: 29, offset: 22734},
+													pos:  position{line: 969, col: 29, offset: 22868},
 													name: "NotExpr",
 												},
 											},
@@ -6066,43 +6091,43 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 966, col: 1, offset: 22841},
+			pos:  position{line: 973, col: 1, offset: 22975},
 			expr: &choiceExpr{
-				pos: position{line: 967, col: 5, offset: 22853},
+				pos: position{line: 974, col: 5, offset: 22987},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 967, col: 5, offset: 22853},
+						pos: position{line: 974, col: 5, offset: 22987},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 967, col: 5, offset: 22853},
+							pos: position{line: 974, col: 5, offset: 22987},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 967, col: 6, offset: 22854},
+									pos: position{line: 974, col: 6, offset: 22988},
 									alternatives: []any{
 										&seqExpr{
-											pos: position{line: 967, col: 6, offset: 22854},
+											pos: position{line: 974, col: 6, offset: 22988},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 967, col: 6, offset: 22854},
+													pos:  position{line: 974, col: 6, offset: 22988},
 													name: "NOT",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 967, col: 10, offset: 22858},
+													pos:  position{line: 974, col: 10, offset: 22992},
 													name: "__",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 967, col: 15, offset: 22863},
+											pos: position{line: 974, col: 15, offset: 22997},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 967, col: 15, offset: 22863},
+													pos:        position{line: 974, col: 15, offset: 22997},
 													val:        "!",
 													ignoreCase: false,
 													want:       "\"!\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 967, col: 19, offset: 22867},
+													pos:  position{line: 974, col: 19, offset: 23001},
 													name: "__",
 												},
 											},
@@ -6110,10 +6135,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 967, col: 23, offset: 22871},
+									pos:   position{line: 974, col: 23, offset: 23005},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 967, col: 25, offset: 22873},
+										pos:  position{line: 974, col: 25, offset: 23007},
 										name: "NotExpr",
 									},
 								},
@@ -6121,7 +6146,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 975, col: 5, offset: 23039},
+						pos:  position{line: 982, col: 5, offset: 23173},
 						name: "BetweenExpr",
 					},
 				},
@@ -6131,42 +6156,42 @@ var g = &grammar{
 		},
 		{
 			name: "BetweenExpr",
-			pos:  position{line: 977, col: 1, offset: 23052},
+			pos:  position{line: 984, col: 1, offset: 23186},
 			expr: &choiceExpr{
-				pos: position{line: 978, col: 5, offset: 23068},
+				pos: position{line: 985, col: 5, offset: 23202},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 978, col: 5, offset: 23068},
+						pos: position{line: 985, col: 5, offset: 23202},
 						run: (*parser).callonBetweenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 978, col: 5, offset: 23068},
+							pos: position{line: 985, col: 5, offset: 23202},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 978, col: 5, offset: 23068},
+									pos:   position{line: 985, col: 5, offset: 23202},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 978, col: 10, offset: 23073},
+										pos:  position{line: 985, col: 10, offset: 23207},
 										name: "ComparisonExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 978, col: 25, offset: 23088},
+									pos:  position{line: 985, col: 25, offset: 23222},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 978, col: 27, offset: 23090},
+									pos:   position{line: 985, col: 27, offset: 23224},
 									label: "not",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 978, col: 31, offset: 23094},
+										pos: position{line: 985, col: 31, offset: 23228},
 										expr: &seqExpr{
-											pos: position{line: 978, col: 32, offset: 23095},
+											pos: position{line: 985, col: 32, offset: 23229},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 978, col: 32, offset: 23095},
+													pos:  position{line: 985, col: 32, offset: 23229},
 													name: "NOT",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 978, col: 36, offset: 23099},
+													pos:  position{line: 985, col: 36, offset: 23233},
 													name: "_",
 												},
 											},
@@ -6174,38 +6199,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 978, col: 40, offset: 23103},
+									pos:  position{line: 985, col: 40, offset: 23237},
 									name: "BETWEEN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 978, col: 48, offset: 23111},
+									pos:  position{line: 985, col: 48, offset: 23245},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 978, col: 50, offset: 23113},
+									pos:   position{line: 985, col: 50, offset: 23247},
 									label: "lower",
 									expr: &ruleRefExpr{
-										pos:  position{line: 978, col: 56, offset: 23119},
+										pos:  position{line: 985, col: 56, offset: 23253},
 										name: "BetweenExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 978, col: 68, offset: 23131},
+									pos:  position{line: 985, col: 68, offset: 23265},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 978, col: 70, offset: 23133},
+									pos:  position{line: 985, col: 70, offset: 23267},
 									name: "AND",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 978, col: 74, offset: 23137},
+									pos:  position{line: 985, col: 74, offset: 23271},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 978, col: 76, offset: 23139},
+									pos:   position{line: 985, col: 76, offset: 23273},
 									label: "upper",
 									expr: &ruleRefExpr{
-										pos:  position{line: 978, col: 82, offset: 23145},
+										pos:  position{line: 985, col: 82, offset: 23279},
 										name: "BetweenExpr",
 									},
 								},
@@ -6213,7 +6238,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 988, col: 5, offset: 23385},
+						pos:  position{line: 995, col: 5, offset: 23519},
 						name: "ComparisonExpr",
 					},
 				},
@@ -6223,46 +6248,46 @@ var g = &grammar{
 		},
 		{
 			name: "ComparisonExpr",
-			pos:  position{line: 990, col: 1, offset: 23401},
+			pos:  position{line: 997, col: 1, offset: 23535},
 			expr: &choiceExpr{
-				pos: position{line: 991, col: 5, offset: 23420},
+				pos: position{line: 998, col: 5, offset: 23554},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 991, col: 5, offset: 23420},
+						pos: position{line: 998, col: 5, offset: 23554},
 						run: (*parser).callonComparisonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 991, col: 5, offset: 23420},
+							pos: position{line: 998, col: 5, offset: 23554},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 991, col: 5, offset: 23420},
+									pos:   position{line: 998, col: 5, offset: 23554},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 991, col: 10, offset: 23425},
+										pos:  position{line: 998, col: 10, offset: 23559},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 991, col: 23, offset: 23438},
+									pos:  position{line: 998, col: 23, offset: 23572},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 991, col: 25, offset: 23440},
+									pos:  position{line: 998, col: 25, offset: 23574},
 									name: "IS",
 								},
 								&labeledExpr{
-									pos:   position{line: 991, col: 28, offset: 23443},
+									pos:   position{line: 998, col: 28, offset: 23577},
 									label: "not",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 991, col: 32, offset: 23447},
+										pos: position{line: 998, col: 32, offset: 23581},
 										expr: &seqExpr{
-											pos: position{line: 991, col: 33, offset: 23448},
+											pos: position{line: 998, col: 33, offset: 23582},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 991, col: 33, offset: 23448},
+													pos:  position{line: 998, col: 33, offset: 23582},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 991, col: 35, offset: 23450},
+													pos:  position{line: 998, col: 35, offset: 23584},
 													name: "NOT",
 												},
 											},
@@ -6270,82 +6295,82 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 991, col: 41, offset: 23456},
+									pos:  position{line: 998, col: 41, offset: 23590},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 991, col: 43, offset: 23458},
+									pos:  position{line: 998, col: 43, offset: 23592},
 									name: "NULL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 999, col: 5, offset: 23623},
+						pos: position{line: 1006, col: 5, offset: 23757},
 						run: (*parser).callonComparisonExpr15,
 						expr: &seqExpr{
-							pos: position{line: 999, col: 5, offset: 23623},
+							pos: position{line: 1006, col: 5, offset: 23757},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 999, col: 5, offset: 23623},
+									pos:   position{line: 1006, col: 5, offset: 23757},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 999, col: 9, offset: 23627},
+										pos:  position{line: 1006, col: 9, offset: 23761},
 										name: "AdditiveExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 999, col: 22, offset: 23640},
+									pos:   position{line: 1006, col: 22, offset: 23774},
 									label: "opAndRHS",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 999, col: 31, offset: 23649},
+										pos: position{line: 1006, col: 31, offset: 23783},
 										expr: &choiceExpr{
-											pos: position{line: 999, col: 32, offset: 23650},
+											pos: position{line: 1006, col: 32, offset: 23784},
 											alternatives: []any{
 												&seqExpr{
-													pos: position{line: 999, col: 32, offset: 23650},
+													pos: position{line: 1006, col: 32, offset: 23784},
 													exprs: []any{
 														&ruleRefExpr{
-															pos:  position{line: 999, col: 32, offset: 23650},
+															pos:  position{line: 1006, col: 32, offset: 23784},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 999, col: 35, offset: 23653},
+															pos:  position{line: 1006, col: 35, offset: 23787},
 															name: "Comparator",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 999, col: 46, offset: 23664},
+															pos:  position{line: 1006, col: 46, offset: 23798},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 999, col: 49, offset: 23667},
+															pos:  position{line: 1006, col: 49, offset: 23801},
 															name: "AdditiveExpr",
 														},
 													},
 												},
 												&seqExpr{
-													pos: position{line: 999, col: 64, offset: 23682},
+													pos: position{line: 1006, col: 64, offset: 23816},
 													exprs: []any{
 														&ruleRefExpr{
-															pos:  position{line: 999, col: 64, offset: 23682},
+															pos:  position{line: 1006, col: 64, offset: 23816},
 															name: "__",
 														},
 														&actionExpr{
-															pos: position{line: 999, col: 68, offset: 23686},
+															pos: position{line: 1006, col: 68, offset: 23820},
 															run: (*parser).callonComparisonExpr29,
 															expr: &litMatcher{
-																pos:        position{line: 999, col: 68, offset: 23686},
+																pos:        position{line: 1006, col: 68, offset: 23820},
 																val:        "~",
 																ignoreCase: false,
 																want:       "\"~\"",
 															},
 														},
 														&ruleRefExpr{
-															pos:  position{line: 999, col: 104, offset: 23722},
+															pos:  position{line: 1006, col: 104, offset: 23856},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 999, col: 107, offset: 23725},
+															pos:  position{line: 1006, col: 107, offset: 23859},
 															name: "AdditiveExpr",
 														},
 													},
@@ -6364,53 +6389,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 1012, col: 1, offset: 24016},
+			pos:  position{line: 1019, col: 1, offset: 24150},
 			expr: &actionExpr{
-				pos: position{line: 1013, col: 5, offset: 24033},
+				pos: position{line: 1020, col: 5, offset: 24167},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1013, col: 5, offset: 24033},
+					pos: position{line: 1020, col: 5, offset: 24167},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1013, col: 5, offset: 24033},
+							pos:   position{line: 1020, col: 5, offset: 24167},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1013, col: 11, offset: 24039},
+								pos:  position{line: 1020, col: 11, offset: 24173},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1014, col: 5, offset: 24062},
+							pos:   position{line: 1021, col: 5, offset: 24196},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1014, col: 10, offset: 24067},
+								pos: position{line: 1021, col: 10, offset: 24201},
 								expr: &actionExpr{
-									pos: position{line: 1014, col: 11, offset: 24068},
+									pos: position{line: 1021, col: 11, offset: 24202},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 1014, col: 11, offset: 24068},
+										pos: position{line: 1021, col: 11, offset: 24202},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1014, col: 11, offset: 24068},
+												pos:  position{line: 1021, col: 11, offset: 24202},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1014, col: 14, offset: 24071},
+												pos:   position{line: 1021, col: 14, offset: 24205},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1014, col: 17, offset: 24074},
+													pos:  position{line: 1021, col: 17, offset: 24208},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1014, col: 34, offset: 24091},
+												pos:  position{line: 1021, col: 34, offset: 24225},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1014, col: 37, offset: 24094},
+												pos:   position{line: 1021, col: 37, offset: 24228},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1014, col: 42, offset: 24099},
+													pos:  position{line: 1021, col: 42, offset: 24233},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -6427,21 +6452,21 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 1018, col: 1, offset: 24217},
+			pos:  position{line: 1025, col: 1, offset: 24351},
 			expr: &actionExpr{
-				pos: position{line: 1018, col: 20, offset: 24236},
+				pos: position{line: 1025, col: 20, offset: 24370},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 1018, col: 21, offset: 24237},
+					pos: position{line: 1025, col: 21, offset: 24371},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1018, col: 21, offset: 24237},
+							pos:        position{line: 1025, col: 21, offset: 24371},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1018, col: 27, offset: 24243},
+							pos:        position{line: 1025, col: 27, offset: 24377},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
@@ -6454,53 +6479,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 1020, col: 1, offset: 24280},
+			pos:  position{line: 1027, col: 1, offset: 24414},
 			expr: &actionExpr{
-				pos: position{line: 1021, col: 5, offset: 24303},
+				pos: position{line: 1028, col: 5, offset: 24437},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1021, col: 5, offset: 24303},
+					pos: position{line: 1028, col: 5, offset: 24437},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1021, col: 5, offset: 24303},
+							pos:   position{line: 1028, col: 5, offset: 24437},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1021, col: 11, offset: 24309},
+								pos:  position{line: 1028, col: 11, offset: 24443},
 								name: "ConcatExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1022, col: 5, offset: 24324},
+							pos:   position{line: 1029, col: 5, offset: 24458},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1022, col: 10, offset: 24329},
+								pos: position{line: 1029, col: 10, offset: 24463},
 								expr: &actionExpr{
-									pos: position{line: 1022, col: 11, offset: 24330},
+									pos: position{line: 1029, col: 11, offset: 24464},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 1022, col: 11, offset: 24330},
+										pos: position{line: 1029, col: 11, offset: 24464},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1022, col: 11, offset: 24330},
+												pos:  position{line: 1029, col: 11, offset: 24464},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1022, col: 14, offset: 24333},
+												pos:   position{line: 1029, col: 14, offset: 24467},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1022, col: 17, offset: 24336},
+													pos:  position{line: 1029, col: 17, offset: 24470},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1022, col: 40, offset: 24359},
+												pos:  position{line: 1029, col: 40, offset: 24493},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1022, col: 43, offset: 24362},
+												pos:   position{line: 1029, col: 43, offset: 24496},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1022, col: 48, offset: 24367},
+													pos:  position{line: 1029, col: 48, offset: 24501},
 													name: "ConcatExpr",
 												},
 											},
@@ -6517,27 +6542,27 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 1026, col: 1, offset: 24477},
+			pos:  position{line: 1033, col: 1, offset: 24611},
 			expr: &actionExpr{
-				pos: position{line: 1026, col: 26, offset: 24502},
+				pos: position{line: 1033, col: 26, offset: 24636},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 1026, col: 27, offset: 24503},
+					pos: position{line: 1033, col: 27, offset: 24637},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1026, col: 27, offset: 24503},
+							pos:        position{line: 1033, col: 27, offset: 24637},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1026, col: 33, offset: 24509},
+							pos:        position{line: 1033, col: 33, offset: 24643},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1026, col: 39, offset: 24515},
+							pos:        position{line: 1033, col: 39, offset: 24649},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
@@ -6550,51 +6575,51 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatExpr",
-			pos:  position{line: 1028, col: 1, offset: 24552},
+			pos:  position{line: 1035, col: 1, offset: 24686},
 			expr: &actionExpr{
-				pos: position{line: 1029, col: 5, offset: 24567},
+				pos: position{line: 1036, col: 5, offset: 24701},
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1029, col: 5, offset: 24567},
+					pos: position{line: 1036, col: 5, offset: 24701},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1029, col: 5, offset: 24567},
+							pos:   position{line: 1036, col: 5, offset: 24701},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1029, col: 11, offset: 24573},
+								pos:  position{line: 1036, col: 11, offset: 24707},
 								name: "UnaryPlusOrMinus",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1030, col: 5, offset: 24594},
+							pos:   position{line: 1037, col: 5, offset: 24728},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1030, col: 10, offset: 24599},
+								pos: position{line: 1037, col: 10, offset: 24733},
 								expr: &actionExpr{
-									pos: position{line: 1030, col: 11, offset: 24600},
+									pos: position{line: 1037, col: 11, offset: 24734},
 									run: (*parser).callonConcatExpr7,
 									expr: &seqExpr{
-										pos: position{line: 1030, col: 11, offset: 24600},
+										pos: position{line: 1037, col: 11, offset: 24734},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1030, col: 11, offset: 24600},
+												pos:  position{line: 1037, col: 11, offset: 24734},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1030, col: 14, offset: 24603},
+												pos:        position{line: 1037, col: 14, offset: 24737},
 												val:        "||",
 												ignoreCase: false,
 												want:       "\"||\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1030, col: 19, offset: 24608},
+												pos:  position{line: 1037, col: 19, offset: 24742},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1030, col: 22, offset: 24611},
+												pos:   position{line: 1037, col: 22, offset: 24745},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1030, col: 27, offset: 24616},
+													pos:  position{line: 1037, col: 27, offset: 24750},
 													name: "UnaryPlusOrMinus",
 												},
 											},
@@ -6611,40 +6636,40 @@ var g = &grammar{
 		},
 		{
 			name: "UnaryPlusOrMinus",
-			pos:  position{line: 1034, col: 1, offset: 24734},
+			pos:  position{line: 1041, col: 1, offset: 24868},
 			expr: &choiceExpr{
-				pos: position{line: 1035, col: 5, offset: 24755},
+				pos: position{line: 1042, col: 5, offset: 24889},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1035, col: 5, offset: 24755},
+						pos: position{line: 1042, col: 5, offset: 24889},
 						run: (*parser).callonUnaryPlusOrMinus2,
 						expr: &seqExpr{
-							pos: position{line: 1035, col: 5, offset: 24755},
+							pos: position{line: 1042, col: 5, offset: 24889},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1035, col: 5, offset: 24755},
+									pos: position{line: 1042, col: 5, offset: 24889},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1035, col: 6, offset: 24756},
+										pos:  position{line: 1042, col: 6, offset: 24890},
 										name: "Literal",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1035, col: 14, offset: 24764},
+									pos:   position{line: 1042, col: 14, offset: 24898},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1035, col: 17, offset: 24767},
+										pos:  position{line: 1042, col: 17, offset: 24901},
 										name: "PlusOrMinusOp",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1035, col: 31, offset: 24781},
+									pos:  position{line: 1042, col: 31, offset: 24915},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1035, col: 34, offset: 24784},
+									pos:   position{line: 1042, col: 34, offset: 24918},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1035, col: 36, offset: 24786},
+										pos:  position{line: 1042, col: 36, offset: 24920},
 										name: "UnaryPlusOrMinus",
 									},
 								},
@@ -6652,7 +6677,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1044, col: 5, offset: 24970},
+						pos:  position{line: 1051, col: 5, offset: 25104},
 						name: "ColonCast",
 					},
 				},
@@ -6662,21 +6687,21 @@ var g = &grammar{
 		},
 		{
 			name: "PlusOrMinusOp",
-			pos:  position{line: 1046, col: 1, offset: 24981},
+			pos:  position{line: 1053, col: 1, offset: 25115},
 			expr: &actionExpr{
-				pos: position{line: 1046, col: 17, offset: 24997},
+				pos: position{line: 1053, col: 17, offset: 25131},
 				run: (*parser).callonPlusOrMinusOp1,
 				expr: &choiceExpr{
-					pos: position{line: 1046, col: 18, offset: 24998},
+					pos: position{line: 1053, col: 18, offset: 25132},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1046, col: 18, offset: 24998},
+							pos:        position{line: 1053, col: 18, offset: 25132},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1046, col: 24, offset: 25004},
+							pos:        position{line: 1053, col: 24, offset: 25138},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
@@ -6689,58 +6714,58 @@ var g = &grammar{
 		},
 		{
 			name: "ColonCast",
-			pos:  position{line: 1048, col: 1, offset: 25041},
+			pos:  position{line: 1055, col: 1, offset: 25175},
 			expr: &actionExpr{
-				pos: position{line: 1049, col: 5, offset: 25055},
+				pos: position{line: 1056, col: 5, offset: 25189},
 				run: (*parser).callonColonCast1,
 				expr: &seqExpr{
-					pos: position{line: 1049, col: 5, offset: 25055},
+					pos: position{line: 1056, col: 5, offset: 25189},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1049, col: 5, offset: 25055},
+							pos:   position{line: 1056, col: 5, offset: 25189},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1049, col: 11, offset: 25061},
+								pos:  position{line: 1056, col: 11, offset: 25195},
 								name: "DerefExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1050, col: 5, offset: 25075},
+							pos:   position{line: 1057, col: 5, offset: 25209},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1050, col: 10, offset: 25080},
+								pos: position{line: 1057, col: 10, offset: 25214},
 								expr: &actionExpr{
-									pos: position{line: 1050, col: 11, offset: 25081},
+									pos: position{line: 1057, col: 11, offset: 25215},
 									run: (*parser).callonColonCast7,
 									expr: &seqExpr{
-										pos: position{line: 1050, col: 11, offset: 25081},
+										pos: position{line: 1057, col: 11, offset: 25215},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1050, col: 11, offset: 25081},
+												pos:  position{line: 1057, col: 11, offset: 25215},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1050, col: 14, offset: 25084},
+												pos:        position{line: 1057, col: 14, offset: 25218},
 												val:        "::",
 												ignoreCase: false,
 												want:       "\"::\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1050, col: 19, offset: 25089},
+												pos:  position{line: 1057, col: 19, offset: 25223},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1050, col: 22, offset: 25092},
+												pos:   position{line: 1057, col: 22, offset: 25226},
 												label: "expr",
 												expr: &choiceExpr{
-													pos: position{line: 1050, col: 28, offset: 25098},
+													pos: position{line: 1057, col: 28, offset: 25232},
 													alternatives: []any{
 														&ruleRefExpr{
-															pos:  position{line: 1050, col: 28, offset: 25098},
+															pos:  position{line: 1057, col: 28, offset: 25232},
 															name: "TypeAsValue",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 1050, col: 42, offset: 25112},
+															pos:  position{line: 1057, col: 42, offset: 25246},
 															name: "IDExpr",
 														},
 													},
@@ -6759,15 +6784,15 @@ var g = &grammar{
 		},
 		{
 			name: "IDExpr",
-			pos:  position{line: 1054, col: 1, offset: 25219},
+			pos:  position{line: 1061, col: 1, offset: 25353},
 			expr: &actionExpr{
-				pos: position{line: 1054, col: 10, offset: 25228},
+				pos: position{line: 1061, col: 10, offset: 25362},
 				run: (*parser).callonIDExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 1054, col: 10, offset: 25228},
+					pos:   position{line: 1061, col: 10, offset: 25362},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1054, col: 13, offset: 25231},
+						pos:  position{line: 1061, col: 13, offset: 25365},
 						name: "Identifier",
 					},
 				},
@@ -6777,73 +6802,73 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 1056, col: 1, offset: 25308},
+			pos:  position{line: 1063, col: 1, offset: 25442},
 			expr: &choiceExpr{
-				pos: position{line: 1057, col: 5, offset: 25322},
+				pos: position{line: 1064, col: 5, offset: 25456},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1057, col: 5, offset: 25322},
+						pos: position{line: 1064, col: 5, offset: 25456},
 						run: (*parser).callonDerefExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1057, col: 5, offset: 25322},
+							pos: position{line: 1064, col: 5, offset: 25456},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1057, col: 5, offset: 25322},
+									pos:   position{line: 1064, col: 5, offset: 25456},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1057, col: 10, offset: 25327},
+										pos:  position{line: 1064, col: 10, offset: 25461},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1057, col: 20, offset: 25337},
+									pos:        position{line: 1064, col: 20, offset: 25471},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1057, col: 24, offset: 25341},
+									pos:  position{line: 1064, col: 24, offset: 25475},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1057, col: 27, offset: 25344},
+									pos:   position{line: 1064, col: 27, offset: 25478},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1057, col: 32, offset: 25349},
+										pos:  position{line: 1064, col: 32, offset: 25483},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1057, col: 45, offset: 25362},
+									pos:  position{line: 1064, col: 45, offset: 25496},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1057, col: 48, offset: 25365},
+									pos:        position{line: 1064, col: 48, offset: 25499},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1057, col: 52, offset: 25369},
+									pos:  position{line: 1064, col: 52, offset: 25503},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1057, col: 55, offset: 25372},
+									pos:   position{line: 1064, col: 55, offset: 25506},
 									label: "to",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1057, col: 58, offset: 25375},
+										pos: position{line: 1064, col: 58, offset: 25509},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1057, col: 58, offset: 25375},
+											pos:  position{line: 1064, col: 58, offset: 25509},
 											name: "AdditiveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1057, col: 72, offset: 25389},
+									pos:  position{line: 1064, col: 72, offset: 25523},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1057, col: 75, offset: 25392},
+									pos:        position{line: 1064, col: 75, offset: 25526},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6852,49 +6877,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1069, col: 5, offset: 25631},
+						pos: position{line: 1076, col: 5, offset: 25765},
 						run: (*parser).callonDerefExpr18,
 						expr: &seqExpr{
-							pos: position{line: 1069, col: 5, offset: 25631},
+							pos: position{line: 1076, col: 5, offset: 25765},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1069, col: 5, offset: 25631},
+									pos:   position{line: 1076, col: 5, offset: 25765},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1069, col: 10, offset: 25636},
+										pos:  position{line: 1076, col: 10, offset: 25770},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1069, col: 20, offset: 25646},
+									pos:        position{line: 1076, col: 20, offset: 25780},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1069, col: 24, offset: 25650},
+									pos:  position{line: 1076, col: 24, offset: 25784},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1069, col: 27, offset: 25653},
+									pos:        position{line: 1076, col: 27, offset: 25787},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1069, col: 31, offset: 25657},
+									pos:  position{line: 1076, col: 31, offset: 25791},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1069, col: 34, offset: 25660},
+									pos:   position{line: 1076, col: 34, offset: 25794},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1069, col: 37, offset: 25663},
+										pos:  position{line: 1076, col: 37, offset: 25797},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1069, col: 50, offset: 25676},
+									pos:        position{line: 1076, col: 50, offset: 25810},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6903,35 +6928,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1077, col: 5, offset: 25840},
+						pos: position{line: 1084, col: 5, offset: 25974},
 						run: (*parser).callonDerefExpr29,
 						expr: &seqExpr{
-							pos: position{line: 1077, col: 5, offset: 25840},
+							pos: position{line: 1084, col: 5, offset: 25974},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1077, col: 5, offset: 25840},
+									pos:   position{line: 1084, col: 5, offset: 25974},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1077, col: 10, offset: 25845},
+										pos:  position{line: 1084, col: 10, offset: 25979},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1077, col: 20, offset: 25855},
+									pos:        position{line: 1084, col: 20, offset: 25989},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1077, col: 24, offset: 25859},
+									pos:   position{line: 1084, col: 24, offset: 25993},
 									label: "index",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1077, col: 30, offset: 25865},
+										pos:  position{line: 1084, col: 30, offset: 25999},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1077, col: 35, offset: 25870},
+									pos:        position{line: 1084, col: 35, offset: 26004},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6940,30 +6965,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1085, col: 5, offset: 26040},
+						pos: position{line: 1092, col: 5, offset: 26174},
 						run: (*parser).callonDerefExpr37,
 						expr: &seqExpr{
-							pos: position{line: 1085, col: 5, offset: 26040},
+							pos: position{line: 1092, col: 5, offset: 26174},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1085, col: 5, offset: 26040},
+									pos:   position{line: 1092, col: 5, offset: 26174},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1085, col: 10, offset: 26045},
+										pos:  position{line: 1092, col: 10, offset: 26179},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1085, col: 20, offset: 26055},
+									pos:        position{line: 1092, col: 20, offset: 26189},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1085, col: 24, offset: 26059},
+									pos:   position{line: 1092, col: 24, offset: 26193},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1085, col: 27, offset: 26062},
+										pos:  position{line: 1092, col: 27, offset: 26196},
 										name: "DerefKey",
 									},
 								},
@@ -6971,11 +6996,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1094, col: 5, offset: 26250},
+						pos:  position{line: 1101, col: 5, offset: 26384},
 						name: "Function",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1095, col: 5, offset: 26263},
+						pos:  position{line: 1102, col: 5, offset: 26397},
 						name: "Primary",
 					},
 				},
@@ -6985,42 +7010,42 @@ var g = &grammar{
 		},
 		{
 			name: "DerefKey",
-			pos:  position{line: 1097, col: 1, offset: 26272},
+			pos:  position{line: 1104, col: 1, offset: 26406},
 			expr: &choiceExpr{
-				pos: position{line: 1098, col: 5, offset: 26285},
+				pos: position{line: 1105, col: 5, offset: 26419},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1098, col: 5, offset: 26285},
+						pos: position{line: 1105, col: 5, offset: 26419},
 						run: (*parser).callonDerefKey2,
 						expr: &labeledExpr{
-							pos:   position{line: 1098, col: 5, offset: 26285},
+							pos:   position{line: 1105, col: 5, offset: 26419},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1098, col: 8, offset: 26288},
+								pos:  position{line: 1105, col: 8, offset: 26422},
 								name: "Identifier",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1099, col: 5, offset: 26379},
+						pos: position{line: 1106, col: 5, offset: 26513},
 						run: (*parser).callonDerefKey5,
 						expr: &labeledExpr{
-							pos:   position{line: 1099, col: 5, offset: 26379},
+							pos:   position{line: 1106, col: 5, offset: 26513},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1099, col: 7, offset: 26381},
+								pos:  position{line: 1106, col: 7, offset: 26515},
 								name: "DoubleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1100, col: 5, offset: 26493},
+						pos: position{line: 1107, col: 5, offset: 26627},
 						run: (*parser).callonDerefKey8,
 						expr: &labeledExpr{
-							pos:   position{line: 1100, col: 5, offset: 26493},
+							pos:   position{line: 1107, col: 5, offset: 26627},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1100, col: 7, offset: 26495},
+								pos:  position{line: 1107, col: 7, offset: 26629},
 								name: "BacktickString",
 							},
 						},
@@ -7032,79 +7057,79 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 1102, col: 1, offset: 26604},
+			pos:  position{line: 1109, col: 1, offset: 26738},
 			expr: &choiceExpr{
-				pos: position{line: 1103, col: 5, offset: 26617},
+				pos: position{line: 1110, col: 5, offset: 26751},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1103, col: 5, offset: 26617},
+						pos: position{line: 1110, col: 5, offset: 26751},
 						run: (*parser).callonFunction2,
 						expr: &seqExpr{
-							pos: position{line: 1103, col: 5, offset: 26617},
+							pos: position{line: 1110, col: 5, offset: 26751},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1103, col: 5, offset: 26617},
+									pos:  position{line: 1110, col: 5, offset: 26751},
 									name: "EXTRACT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1103, col: 13, offset: 26625},
+									pos:  position{line: 1110, col: 13, offset: 26759},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1103, col: 16, offset: 26628},
+									pos:        position{line: 1110, col: 16, offset: 26762},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1103, col: 20, offset: 26632},
+									pos:  position{line: 1110, col: 20, offset: 26766},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1103, col: 23, offset: 26635},
+									pos:   position{line: 1110, col: 23, offset: 26769},
 									label: "part",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1103, col: 28, offset: 26640},
+										pos:  position{line: 1110, col: 28, offset: 26774},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1103, col: 33, offset: 26645},
+									pos:  position{line: 1110, col: 33, offset: 26779},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1103, col: 35, offset: 26647},
+									pos:  position{line: 1110, col: 35, offset: 26781},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1103, col: 40, offset: 26652},
+									pos:  position{line: 1110, col: 40, offset: 26786},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1103, col: 42, offset: 26654},
+									pos:   position{line: 1110, col: 42, offset: 26788},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1103, col: 44, offset: 26656},
+										pos:  position{line: 1110, col: 44, offset: 26790},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1103, col: 49, offset: 26661},
+									pos:  position{line: 1110, col: 49, offset: 26795},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1103, col: 52, offset: 26664},
+									pos:        position{line: 1110, col: 52, offset: 26798},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1103, col: 56, offset: 26668},
+									pos:   position{line: 1110, col: 56, offset: 26802},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1103, col: 62, offset: 26674},
+										pos: position{line: 1110, col: 62, offset: 26808},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1103, col: 62, offset: 26674},
+											pos:  position{line: 1110, col: 62, offset: 26808},
 											name: "WhereClause",
 										},
 									},
@@ -7113,43 +7138,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1111, col: 5, offset: 26852},
+						pos: position{line: 1118, col: 5, offset: 26986},
 						run: (*parser).callonFunction20,
 						expr: &seqExpr{
-							pos: position{line: 1111, col: 5, offset: 26852},
+							pos: position{line: 1118, col: 5, offset: 26986},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1111, col: 5, offset: 26852},
+									pos:  position{line: 1118, col: 5, offset: 26986},
 									name: "EXISTS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1111, col: 12, offset: 26859},
+									pos:  position{line: 1118, col: 12, offset: 26993},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1111, col: 15, offset: 26862},
+									pos:        position{line: 1118, col: 15, offset: 26996},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1111, col: 19, offset: 26866},
+									pos:  position{line: 1118, col: 19, offset: 27000},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1111, col: 22, offset: 26869},
+									pos:   position{line: 1118, col: 22, offset: 27003},
 									label: "body",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1111, col: 27, offset: 26874},
+										pos:  position{line: 1118, col: 27, offset: 27008},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1111, col: 31, offset: 26878},
+									pos:  position{line: 1118, col: 31, offset: 27012},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1111, col: 34, offset: 26881},
+									pos:        position{line: 1118, col: 34, offset: 27015},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7158,72 +7183,72 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1118, col: 5, offset: 27026},
+						pos: position{line: 1125, col: 5, offset: 27160},
 						run: (*parser).callonFunction30,
 						expr: &seqExpr{
-							pos: position{line: 1118, col: 5, offset: 27026},
+							pos: position{line: 1125, col: 5, offset: 27160},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1118, col: 5, offset: 27026},
+									pos:  position{line: 1125, col: 5, offset: 27160},
 									name: "CAST",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1118, col: 10, offset: 27031},
+									pos:  position{line: 1125, col: 10, offset: 27165},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1118, col: 13, offset: 27034},
+									pos:        position{line: 1125, col: 13, offset: 27168},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1118, col: 17, offset: 27038},
+									pos:  position{line: 1125, col: 17, offset: 27172},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1118, col: 20, offset: 27041},
+									pos:   position{line: 1125, col: 20, offset: 27175},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1118, col: 22, offset: 27043},
+										pos:  position{line: 1125, col: 22, offset: 27177},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1118, col: 27, offset: 27048},
+									pos:  position{line: 1125, col: 27, offset: 27182},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1118, col: 29, offset: 27050},
+									pos:  position{line: 1125, col: 29, offset: 27184},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1118, col: 32, offset: 27053},
+									pos:  position{line: 1125, col: 32, offset: 27187},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1118, col: 34, offset: 27055},
+									pos:   position{line: 1125, col: 34, offset: 27189},
 									label: "typ",
 									expr: &choiceExpr{
-										pos: position{line: 1118, col: 39, offset: 27060},
+										pos: position{line: 1125, col: 39, offset: 27194},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1118, col: 39, offset: 27060},
+												pos:  position{line: 1125, col: 39, offset: 27194},
 												name: "DateTypeHack",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1118, col: 54, offset: 27075},
+												pos:  position{line: 1125, col: 54, offset: 27209},
 												name: "Type",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1118, col: 60, offset: 27081},
+									pos:  position{line: 1125, col: 60, offset: 27215},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1118, col: 63, offset: 27084},
+									pos:        position{line: 1125, col: 63, offset: 27218},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7232,65 +7257,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1126, col: 5, offset: 27246},
+						pos: position{line: 1133, col: 5, offset: 27380},
 						run: (*parser).callonFunction47,
 						expr: &seqExpr{
-							pos: position{line: 1126, col: 5, offset: 27246},
+							pos: position{line: 1133, col: 5, offset: 27380},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1126, col: 5, offset: 27246},
+									pos:  position{line: 1133, col: 5, offset: 27380},
 									name: "SUBSTRING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1126, col: 15, offset: 27256},
+									pos:  position{line: 1133, col: 15, offset: 27390},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1126, col: 18, offset: 27259},
+									pos:        position{line: 1133, col: 18, offset: 27393},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1126, col: 22, offset: 27263},
+									pos:  position{line: 1133, col: 22, offset: 27397},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1126, col: 25, offset: 27266},
+									pos:   position{line: 1133, col: 25, offset: 27400},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1126, col: 30, offset: 27271},
+										pos:  position{line: 1133, col: 30, offset: 27405},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1126, col: 35, offset: 27276},
+									pos:   position{line: 1133, col: 35, offset: 27410},
 									label: "from",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1126, col: 40, offset: 27281},
+										pos: position{line: 1133, col: 40, offset: 27415},
 										expr: &actionExpr{
-											pos: position{line: 1126, col: 41, offset: 27282},
+											pos: position{line: 1133, col: 41, offset: 27416},
 											run: (*parser).callonFunction57,
 											expr: &seqExpr{
-												pos: position{line: 1126, col: 41, offset: 27282},
+												pos: position{line: 1133, col: 41, offset: 27416},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1126, col: 41, offset: 27282},
+														pos:  position{line: 1133, col: 41, offset: 27416},
 														name: "_",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1126, col: 43, offset: 27284},
+														pos:  position{line: 1133, col: 43, offset: 27418},
 														name: "FROM",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1126, col: 48, offset: 27289},
+														pos:  position{line: 1133, col: 48, offset: 27423},
 														name: "_",
 													},
 													&labeledExpr{
-														pos:   position{line: 1126, col: 50, offset: 27291},
+														pos:   position{line: 1133, col: 50, offset: 27425},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1126, col: 52, offset: 27293},
+															pos:  position{line: 1133, col: 52, offset: 27427},
 															name: "Expr",
 														},
 													},
@@ -7300,33 +7325,33 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1126, col: 77, offset: 27318},
+									pos:   position{line: 1133, col: 77, offset: 27452},
 									label: "for_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1126, col: 82, offset: 27323},
+										pos: position{line: 1133, col: 82, offset: 27457},
 										expr: &actionExpr{
-											pos: position{line: 1126, col: 83, offset: 27324},
+											pos: position{line: 1133, col: 83, offset: 27458},
 											run: (*parser).callonFunction66,
 											expr: &seqExpr{
-												pos: position{line: 1126, col: 83, offset: 27324},
+												pos: position{line: 1133, col: 83, offset: 27458},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1126, col: 83, offset: 27324},
+														pos:  position{line: 1133, col: 83, offset: 27458},
 														name: "_",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1126, col: 85, offset: 27326},
+														pos:  position{line: 1133, col: 85, offset: 27460},
 														name: "FOR",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1126, col: 89, offset: 27330},
+														pos:  position{line: 1133, col: 89, offset: 27464},
 														name: "_",
 													},
 													&labeledExpr{
-														pos:   position{line: 1126, col: 91, offset: 27332},
+														pos:   position{line: 1133, col: 91, offset: 27466},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1126, col: 93, offset: 27334},
+															pos:  position{line: 1133, col: 93, offset: 27468},
 															name: "Expr",
 														},
 													},
@@ -7336,7 +7361,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1126, col: 118, offset: 27359},
+									pos:        position{line: 1133, col: 118, offset: 27493},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7345,58 +7370,58 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1140, col: 5, offset: 27644},
+						pos: position{line: 1147, col: 5, offset: 27778},
 						run: (*parser).callonFunction74,
 						expr: &seqExpr{
-							pos: position{line: 1140, col: 5, offset: 27644},
+							pos: position{line: 1147, col: 5, offset: 27778},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1140, col: 5, offset: 27644},
+									pos:   position{line: 1147, col: 5, offset: 27778},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1140, col: 7, offset: 27646},
+										pos:  position{line: 1147, col: 7, offset: 27780},
 										name: "Callable",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1140, col: 16, offset: 27655},
+									pos:  position{line: 1147, col: 16, offset: 27789},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1140, col: 19, offset: 27658},
+									pos:        position{line: 1147, col: 19, offset: 27792},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1140, col: 23, offset: 27662},
+									pos:  position{line: 1147, col: 23, offset: 27796},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1140, col: 26, offset: 27665},
+									pos:   position{line: 1147, col: 26, offset: 27799},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1140, col: 31, offset: 27670},
+										pos:  position{line: 1147, col: 31, offset: 27804},
 										name: "FunctionArgs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1140, col: 44, offset: 27683},
+									pos:  position{line: 1147, col: 44, offset: 27817},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1140, col: 47, offset: 27686},
+									pos:        position{line: 1147, col: 47, offset: 27820},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1140, col: 51, offset: 27690},
+									pos:   position{line: 1147, col: 51, offset: 27824},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1140, col: 57, offset: 27696},
+										pos: position{line: 1147, col: 57, offset: 27830},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1140, col: 57, offset: 27696},
+											pos:  position{line: 1147, col: 57, offset: 27830},
 											name: "WhereClause",
 										},
 									},
@@ -7405,7 +7430,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1143, col: 5, offset: 27766},
+						pos:  position{line: 1150, col: 5, offset: 27900},
 						name: "CountStar",
 					},
 				},
@@ -7415,22 +7440,22 @@ var g = &grammar{
 		},
 		{
 			name: "Callable",
-			pos:  position{line: 1145, col: 1, offset: 27777},
+			pos:  position{line: 1152, col: 1, offset: 27911},
 			expr: &choiceExpr{
-				pos: position{line: 1146, col: 5, offset: 27790},
+				pos: position{line: 1153, col: 5, offset: 27924},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1146, col: 5, offset: 27790},
+						pos:  position{line: 1153, col: 5, offset: 27924},
 						name: "LambdaExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1147, col: 5, offset: 27805},
+						pos: position{line: 1154, col: 5, offset: 27939},
 						run: (*parser).callonCallable3,
 						expr: &labeledExpr{
-							pos:   position{line: 1147, col: 5, offset: 27805},
+							pos:   position{line: 1154, col: 5, offset: 27939},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1147, col: 8, offset: 27808},
+								pos:  position{line: 1154, col: 8, offset: 27942},
 								name: "IdentifierName",
 							},
 						},
@@ -7442,27 +7467,27 @@ var g = &grammar{
 		},
 		{
 			name: "FuncValue",
-			pos:  position{line: 1155, col: 1, offset: 27955},
+			pos:  position{line: 1162, col: 1, offset: 28089},
 			expr: &choiceExpr{
-				pos: position{line: 1156, col: 5, offset: 27969},
+				pos: position{line: 1163, col: 5, offset: 28103},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1156, col: 5, offset: 27969},
+						pos: position{line: 1163, col: 5, offset: 28103},
 						run: (*parser).callonFuncValue2,
 						expr: &seqExpr{
-							pos: position{line: 1156, col: 5, offset: 27969},
+							pos: position{line: 1163, col: 5, offset: 28103},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1156, col: 5, offset: 27969},
+									pos:        position{line: 1163, col: 5, offset: 28103},
 									val:        "&",
 									ignoreCase: false,
 									want:       "\"&\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1156, col: 9, offset: 27973},
+									pos:   position{line: 1163, col: 9, offset: 28107},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1156, col: 12, offset: 27976},
+										pos:  position{line: 1163, col: 12, offset: 28110},
 										name: "IdentifierName",
 									},
 								},
@@ -7470,7 +7495,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1163, col: 5, offset: 28126},
+						pos:  position{line: 1170, col: 5, offset: 28260},
 						name: "LambdaExpr",
 					},
 				},
@@ -7480,12 +7505,12 @@ var g = &grammar{
 		},
 		{
 			name: "DateTypeHack",
-			pos:  position{line: 1165, col: 1, offset: 28138},
+			pos:  position{line: 1172, col: 1, offset: 28272},
 			expr: &actionExpr{
-				pos: position{line: 1166, col: 5, offset: 28155},
+				pos: position{line: 1173, col: 5, offset: 28289},
 				run: (*parser).callonDateTypeHack1,
 				expr: &litMatcher{
-					pos:        position{line: 1166, col: 5, offset: 28155},
+					pos:        position{line: 1173, col: 5, offset: 28289},
 					val:        "date",
 					ignoreCase: true,
 					want:       "\"date\"i",
@@ -7496,19 +7521,19 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionArgs",
-			pos:  position{line: 1173, col: 1, offset: 28267},
+			pos:  position{line: 1180, col: 1, offset: 28401},
 			expr: &choiceExpr{
-				pos: position{line: 1174, col: 5, offset: 28284},
+				pos: position{line: 1181, col: 5, offset: 28418},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1174, col: 5, offset: 28284},
+						pos:  position{line: 1181, col: 5, offset: 28418},
 						name: "FuncOrExprs",
 					},
 					&actionExpr{
-						pos: position{line: 1175, col: 5, offset: 28300},
+						pos: position{line: 1182, col: 5, offset: 28434},
 						run: (*parser).callonFunctionArgs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1175, col: 5, offset: 28300},
+							pos:  position{line: 1182, col: 5, offset: 28434},
 							name: "__",
 						},
 					},
@@ -7519,51 +7544,51 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 1177, col: 1, offset: 28328},
+			pos:  position{line: 1184, col: 1, offset: 28462},
 			expr: &actionExpr{
-				pos: position{line: 1178, col: 5, offset: 28338},
+				pos: position{line: 1185, col: 5, offset: 28472},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 1178, col: 5, offset: 28338},
+					pos: position{line: 1185, col: 5, offset: 28472},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1178, col: 5, offset: 28338},
+							pos:   position{line: 1185, col: 5, offset: 28472},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1178, col: 11, offset: 28344},
+								pos:  position{line: 1185, col: 11, offset: 28478},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1178, col: 16, offset: 28349},
+							pos:   position{line: 1185, col: 16, offset: 28483},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1178, col: 21, offset: 28354},
+								pos: position{line: 1185, col: 21, offset: 28488},
 								expr: &actionExpr{
-									pos: position{line: 1178, col: 22, offset: 28355},
+									pos: position{line: 1185, col: 22, offset: 28489},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 1178, col: 22, offset: 28355},
+										pos: position{line: 1185, col: 22, offset: 28489},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1178, col: 22, offset: 28355},
+												pos:  position{line: 1185, col: 22, offset: 28489},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1178, col: 25, offset: 28358},
+												pos:        position{line: 1185, col: 25, offset: 28492},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1178, col: 29, offset: 28362},
+												pos:  position{line: 1185, col: 29, offset: 28496},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1178, col: 32, offset: 28365},
+												pos:   position{line: 1185, col: 32, offset: 28499},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1178, col: 34, offset: 28367},
+													pos:  position{line: 1185, col: 34, offset: 28501},
 													name: "Expr",
 												},
 											},
@@ -7580,84 +7605,84 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 1182, col: 1, offset: 28440},
+			pos:  position{line: 1189, col: 1, offset: 28574},
 			expr: &choiceExpr{
-				pos: position{line: 1183, col: 5, offset: 28452},
+				pos: position{line: 1190, col: 5, offset: 28586},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1183, col: 5, offset: 28452},
+						pos:  position{line: 1190, col: 5, offset: 28586},
 						name: "CaseExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1184, col: 5, offset: 28465},
+						pos:  position{line: 1191, col: 5, offset: 28599},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1185, col: 5, offset: 28476},
+						pos:  position{line: 1192, col: 5, offset: 28610},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1186, col: 5, offset: 28486},
+						pos:  position{line: 1193, col: 5, offset: 28620},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1187, col: 5, offset: 28494},
+						pos:  position{line: 1194, col: 5, offset: 28628},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1188, col: 5, offset: 28502},
+						pos:  position{line: 1195, col: 5, offset: 28636},
 						name: "SQLTimeExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1189, col: 5, offset: 28518},
+						pos:  position{line: 1196, col: 5, offset: 28652},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 1190, col: 5, offset: 28530},
+						pos: position{line: 1197, col: 5, offset: 28664},
 						run: (*parser).callonPrimary9,
 						expr: &labeledExpr{
-							pos:   position{line: 1190, col: 5, offset: 28530},
+							pos:   position{line: 1197, col: 5, offset: 28664},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1190, col: 8, offset: 28533},
+								pos:  position{line: 1197, col: 8, offset: 28667},
 								name: "Identifier",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1191, col: 5, offset: 28626},
+						pos:  position{line: 1198, col: 5, offset: 28760},
 						name: "Tuple",
 					},
 					&actionExpr{
-						pos: position{line: 1192, col: 5, offset: 28636},
+						pos: position{line: 1199, col: 5, offset: 28770},
 						run: (*parser).callonPrimary13,
 						expr: &seqExpr{
-							pos: position{line: 1192, col: 5, offset: 28636},
+							pos: position{line: 1199, col: 5, offset: 28770},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1192, col: 5, offset: 28636},
+									pos:        position{line: 1199, col: 5, offset: 28770},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1192, col: 9, offset: 28640},
+									pos:  position{line: 1199, col: 9, offset: 28774},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1192, col: 12, offset: 28643},
+									pos:   position{line: 1199, col: 12, offset: 28777},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1192, col: 17, offset: 28648},
+										pos:  position{line: 1199, col: 17, offset: 28782},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1192, col: 22, offset: 28653},
+									pos:  position{line: 1199, col: 22, offset: 28787},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1192, col: 25, offset: 28656},
+									pos:        position{line: 1199, col: 25, offset: 28790},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7666,35 +7691,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1193, col: 5, offset: 28685},
+						pos: position{line: 1200, col: 5, offset: 28819},
 						run: (*parser).callonPrimary21,
 						expr: &seqExpr{
-							pos: position{line: 1193, col: 5, offset: 28685},
+							pos: position{line: 1200, col: 5, offset: 28819},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1193, col: 5, offset: 28685},
+									pos:        position{line: 1200, col: 5, offset: 28819},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1193, col: 9, offset: 28689},
+									pos:  position{line: 1200, col: 9, offset: 28823},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1193, col: 12, offset: 28692},
+									pos:   position{line: 1200, col: 12, offset: 28826},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1193, col: 17, offset: 28697},
+										pos:  position{line: 1200, col: 17, offset: 28831},
 										name: "SubqueryExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1193, col: 30, offset: 28710},
+									pos:  position{line: 1200, col: 30, offset: 28844},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1193, col: 33, offset: 28713},
+									pos:        position{line: 1200, col: 33, offset: 28847},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7703,35 +7728,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1194, col: 5, offset: 28742},
+						pos: position{line: 1201, col: 5, offset: 28876},
 						run: (*parser).callonPrimary29,
 						expr: &seqExpr{
-							pos: position{line: 1194, col: 5, offset: 28742},
+							pos: position{line: 1201, col: 5, offset: 28876},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1194, col: 5, offset: 28742},
+									pos:        position{line: 1201, col: 5, offset: 28876},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1194, col: 9, offset: 28746},
+									pos:  position{line: 1201, col: 9, offset: 28880},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1194, col: 12, offset: 28749},
+									pos:   position{line: 1201, col: 12, offset: 28883},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1194, col: 17, offset: 28754},
+										pos:  position{line: 1201, col: 17, offset: 28888},
 										name: "SubqueryExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1194, col: 30, offset: 28767},
+									pos:  position{line: 1201, col: 30, offset: 28901},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1194, col: 33, offset: 28770},
+									pos:        position{line: 1201, col: 33, offset: 28904},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -7746,53 +7771,53 @@ var g = &grammar{
 		},
 		{
 			name: "CaseExpr",
-			pos:  position{line: 1199, col: 1, offset: 28852},
+			pos:  position{line: 1206, col: 1, offset: 28986},
 			expr: &choiceExpr{
-				pos: position{line: 1200, col: 5, offset: 28865},
+				pos: position{line: 1207, col: 5, offset: 28999},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1200, col: 5, offset: 28865},
+						pos: position{line: 1207, col: 5, offset: 28999},
 						run: (*parser).callonCaseExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1200, col: 5, offset: 28865},
+							pos: position{line: 1207, col: 5, offset: 28999},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1200, col: 5, offset: 28865},
+									pos:  position{line: 1207, col: 5, offset: 28999},
 									name: "CASE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1200, col: 10, offset: 28870},
+									pos:   position{line: 1207, col: 10, offset: 29004},
 									label: "whens",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1200, col: 16, offset: 28876},
+										pos: position{line: 1207, col: 16, offset: 29010},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1200, col: 16, offset: 28876},
+											pos:  position{line: 1207, col: 16, offset: 29010},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1200, col: 22, offset: 28882},
+									pos:   position{line: 1207, col: 22, offset: 29016},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1200, col: 28, offset: 28888},
+										pos: position{line: 1207, col: 28, offset: 29022},
 										expr: &seqExpr{
-											pos: position{line: 1200, col: 29, offset: 28889},
+											pos: position{line: 1207, col: 29, offset: 29023},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1200, col: 29, offset: 28889},
+													pos:  position{line: 1207, col: 29, offset: 29023},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1200, col: 31, offset: 28891},
+													pos:  position{line: 1207, col: 31, offset: 29025},
 													name: "ELSE",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1200, col: 36, offset: 28896},
+													pos:  position{line: 1207, col: 36, offset: 29030},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1200, col: 38, offset: 28898},
+													pos:  position{line: 1207, col: 38, offset: 29032},
 													name: "Expr",
 												},
 											},
@@ -7800,24 +7825,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1200, col: 45, offset: 28905},
+									pos:  position{line: 1207, col: 45, offset: 29039},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1200, col: 47, offset: 28907},
+									pos:  position{line: 1207, col: 47, offset: 29041},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1200, col: 51, offset: 28911},
+									pos: position{line: 1207, col: 51, offset: 29045},
 									expr: &seqExpr{
-										pos: position{line: 1200, col: 52, offset: 28912},
+										pos: position{line: 1207, col: 52, offset: 29046},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1200, col: 52, offset: 28912},
+												pos:  position{line: 1207, col: 52, offset: 29046},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1200, col: 54, offset: 28914},
+												pos:  position{line: 1207, col: 54, offset: 29048},
 												name: "CASE",
 											},
 										},
@@ -7827,60 +7852,60 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1211, col: 5, offset: 29187},
+						pos: position{line: 1218, col: 5, offset: 29321},
 						run: (*parser).callonCaseExpr21,
 						expr: &seqExpr{
-							pos: position{line: 1211, col: 5, offset: 29187},
+							pos: position{line: 1218, col: 5, offset: 29321},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1211, col: 5, offset: 29187},
+									pos:  position{line: 1218, col: 5, offset: 29321},
 									name: "CASE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1211, col: 10, offset: 29192},
+									pos:  position{line: 1218, col: 10, offset: 29326},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1211, col: 12, offset: 29194},
+									pos:   position{line: 1218, col: 12, offset: 29328},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1211, col: 17, offset: 29199},
+										pos:  position{line: 1218, col: 17, offset: 29333},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1211, col: 22, offset: 29204},
+									pos:   position{line: 1218, col: 22, offset: 29338},
 									label: "whens",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1211, col: 28, offset: 29210},
+										pos: position{line: 1218, col: 28, offset: 29344},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1211, col: 28, offset: 29210},
+											pos:  position{line: 1218, col: 28, offset: 29344},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1211, col: 34, offset: 29216},
+									pos:   position{line: 1218, col: 34, offset: 29350},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1211, col: 40, offset: 29222},
+										pos: position{line: 1218, col: 40, offset: 29356},
 										expr: &seqExpr{
-											pos: position{line: 1211, col: 41, offset: 29223},
+											pos: position{line: 1218, col: 41, offset: 29357},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1211, col: 41, offset: 29223},
+													pos:  position{line: 1218, col: 41, offset: 29357},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1211, col: 43, offset: 29225},
+													pos:  position{line: 1218, col: 43, offset: 29359},
 													name: "ELSE",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1211, col: 48, offset: 29230},
+													pos:  position{line: 1218, col: 48, offset: 29364},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1211, col: 50, offset: 29232},
+													pos:  position{line: 1218, col: 50, offset: 29366},
 													name: "Expr",
 												},
 											},
@@ -7888,24 +7913,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1211, col: 57, offset: 29239},
+									pos:  position{line: 1218, col: 57, offset: 29373},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1211, col: 59, offset: 29241},
+									pos:  position{line: 1218, col: 59, offset: 29375},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1211, col: 63, offset: 29245},
+									pos: position{line: 1218, col: 63, offset: 29379},
 									expr: &seqExpr{
-										pos: position{line: 1211, col: 64, offset: 29246},
+										pos: position{line: 1218, col: 64, offset: 29380},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1211, col: 64, offset: 29246},
+												pos:  position{line: 1218, col: 64, offset: 29380},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1211, col: 66, offset: 29248},
+												pos:  position{line: 1218, col: 66, offset: 29382},
 												name: "CASE",
 											},
 										},
@@ -7921,50 +7946,50 @@ var g = &grammar{
 		},
 		{
 			name: "When",
-			pos:  position{line: 1224, col: 1, offset: 29554},
+			pos:  position{line: 1231, col: 1, offset: 29688},
 			expr: &actionExpr{
-				pos: position{line: 1225, col: 5, offset: 29563},
+				pos: position{line: 1232, col: 5, offset: 29697},
 				run: (*parser).callonWhen1,
 				expr: &seqExpr{
-					pos: position{line: 1225, col: 5, offset: 29563},
+					pos: position{line: 1232, col: 5, offset: 29697},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1225, col: 5, offset: 29563},
+							pos:  position{line: 1232, col: 5, offset: 29697},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1225, col: 7, offset: 29565},
+							pos:  position{line: 1232, col: 7, offset: 29699},
 							name: "WHEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1225, col: 12, offset: 29570},
+							pos:  position{line: 1232, col: 12, offset: 29704},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1225, col: 14, offset: 29572},
+							pos:   position{line: 1232, col: 14, offset: 29706},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1225, col: 19, offset: 29577},
+								pos:  position{line: 1232, col: 19, offset: 29711},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1225, col: 24, offset: 29582},
+							pos:  position{line: 1232, col: 24, offset: 29716},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1225, col: 26, offset: 29584},
+							pos:  position{line: 1232, col: 26, offset: 29718},
 							name: "THEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1225, col: 31, offset: 29589},
+							pos:  position{line: 1232, col: 31, offset: 29723},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1225, col: 33, offset: 29591},
+							pos:   position{line: 1232, col: 33, offset: 29725},
 							label: "then",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1225, col: 38, offset: 29596},
+								pos:  position{line: 1232, col: 38, offset: 29730},
 								name: "Expr",
 							},
 						},
@@ -7976,15 +8001,15 @@ var g = &grammar{
 		},
 		{
 			name: "SubqueryExpr",
-			pos:  position{line: 1233, col: 1, offset: 29729},
+			pos:  position{line: 1240, col: 1, offset: 29863},
 			expr: &actionExpr{
-				pos: position{line: 1234, col: 5, offset: 29746},
+				pos: position{line: 1241, col: 5, offset: 29880},
 				run: (*parser).callonSubqueryExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 1234, col: 5, offset: 29746},
+					pos:   position{line: 1241, col: 5, offset: 29880},
 					label: "body",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1234, col: 10, offset: 29751},
+						pos:  position{line: 1241, col: 10, offset: 29885},
 						name: "Query",
 					},
 				},
@@ -7994,37 +8019,37 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 1242, col: 1, offset: 29897},
+			pos:  position{line: 1249, col: 1, offset: 30031},
 			expr: &actionExpr{
-				pos: position{line: 1243, col: 5, offset: 29908},
+				pos: position{line: 1250, col: 5, offset: 30042},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 1243, col: 5, offset: 29908},
+					pos: position{line: 1250, col: 5, offset: 30042},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1243, col: 5, offset: 29908},
+							pos:        position{line: 1250, col: 5, offset: 30042},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1243, col: 9, offset: 29912},
+							pos:  position{line: 1250, col: 9, offset: 30046},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1243, col: 12, offset: 29915},
+							pos:   position{line: 1250, col: 12, offset: 30049},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1243, col: 18, offset: 29921},
+								pos:  position{line: 1250, col: 18, offset: 30055},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1243, col: 30, offset: 29933},
+							pos:  position{line: 1250, col: 30, offset: 30067},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1243, col: 33, offset: 29936},
+							pos:        position{line: 1250, col: 33, offset: 30070},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -8037,31 +8062,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 1251, col: 1, offset: 30094},
+			pos:  position{line: 1258, col: 1, offset: 30228},
 			expr: &choiceExpr{
-				pos: position{line: 1252, col: 5, offset: 30110},
+				pos: position{line: 1259, col: 5, offset: 30244},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1252, col: 5, offset: 30110},
+						pos: position{line: 1259, col: 5, offset: 30244},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 1252, col: 5, offset: 30110},
+							pos: position{line: 1259, col: 5, offset: 30244},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1252, col: 5, offset: 30110},
+									pos:   position{line: 1259, col: 5, offset: 30244},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1252, col: 11, offset: 30116},
+										pos:  position{line: 1259, col: 11, offset: 30250},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1252, col: 22, offset: 30127},
+									pos:   position{line: 1259, col: 22, offset: 30261},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1252, col: 27, offset: 30132},
+										pos: position{line: 1259, col: 27, offset: 30266},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1252, col: 27, offset: 30132},
+											pos:  position{line: 1259, col: 27, offset: 30266},
 											name: "RecordElemTail",
 										},
 									},
@@ -8070,10 +8095,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1255, col: 5, offset: 30195},
+						pos: position{line: 1262, col: 5, offset: 30329},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1255, col: 5, offset: 30195},
+							pos:  position{line: 1262, col: 5, offset: 30329},
 							name: "__",
 						},
 					},
@@ -8084,32 +8109,32 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 1257, col: 1, offset: 30219},
+			pos:  position{line: 1264, col: 1, offset: 30353},
 			expr: &actionExpr{
-				pos: position{line: 1257, col: 18, offset: 30236},
+				pos: position{line: 1264, col: 18, offset: 30370},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 1257, col: 18, offset: 30236},
+					pos: position{line: 1264, col: 18, offset: 30370},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1257, col: 18, offset: 30236},
+							pos:  position{line: 1264, col: 18, offset: 30370},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1257, col: 21, offset: 30239},
+							pos:        position{line: 1264, col: 21, offset: 30373},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1257, col: 25, offset: 30243},
+							pos:  position{line: 1264, col: 25, offset: 30377},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1257, col: 28, offset: 30246},
+							pos:   position{line: 1264, col: 28, offset: 30380},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1257, col: 33, offset: 30251},
+								pos:  position{line: 1264, col: 33, offset: 30385},
 								name: "RecordElem",
 							},
 						},
@@ -8121,20 +8146,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 1259, col: 1, offset: 30284},
+			pos:  position{line: 1266, col: 1, offset: 30418},
 			expr: &choiceExpr{
-				pos: position{line: 1259, col: 14, offset: 30297},
+				pos: position{line: 1266, col: 14, offset: 30431},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1259, col: 14, offset: 30297},
+						pos:  position{line: 1266, col: 14, offset: 30431},
 						name: "SpreadElem",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1259, col: 27, offset: 30310},
+						pos:  position{line: 1266, col: 27, offset: 30444},
 						name: "FieldElem",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1259, col: 39, offset: 30322},
+						pos:  position{line: 1266, col: 39, offset: 30456},
 						name: "ExprElem",
 					},
 				},
@@ -8144,28 +8169,28 @@ var g = &grammar{
 		},
 		{
 			name: "SpreadElem",
-			pos:  position{line: 1261, col: 1, offset: 30332},
+			pos:  position{line: 1268, col: 1, offset: 30466},
 			expr: &actionExpr{
-				pos: position{line: 1262, col: 5, offset: 30347},
+				pos: position{line: 1269, col: 5, offset: 30481},
 				run: (*parser).callonSpreadElem1,
 				expr: &seqExpr{
-					pos: position{line: 1262, col: 5, offset: 30347},
+					pos: position{line: 1269, col: 5, offset: 30481},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1262, col: 5, offset: 30347},
+							pos:        position{line: 1269, col: 5, offset: 30481},
 							val:        "...",
 							ignoreCase: false,
 							want:       "\"...\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1262, col: 11, offset: 30353},
+							pos:  position{line: 1269, col: 11, offset: 30487},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1262, col: 14, offset: 30356},
+							pos:   position{line: 1269, col: 14, offset: 30490},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1262, col: 19, offset: 30361},
+								pos:  position{line: 1269, col: 19, offset: 30495},
 								name: "Expr",
 							},
 						},
@@ -8177,40 +8202,40 @@ var g = &grammar{
 		},
 		{
 			name: "FieldElem",
-			pos:  position{line: 1266, col: 1, offset: 30465},
+			pos:  position{line: 1273, col: 1, offset: 30599},
 			expr: &actionExpr{
-				pos: position{line: 1267, col: 5, offset: 30479},
+				pos: position{line: 1274, col: 5, offset: 30613},
 				run: (*parser).callonFieldElem1,
 				expr: &seqExpr{
-					pos: position{line: 1267, col: 5, offset: 30479},
+					pos: position{line: 1274, col: 5, offset: 30613},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1267, col: 5, offset: 30479},
+							pos:   position{line: 1274, col: 5, offset: 30613},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1267, col: 10, offset: 30484},
+								pos:  position{line: 1274, col: 10, offset: 30618},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1267, col: 15, offset: 30489},
+							pos:  position{line: 1274, col: 15, offset: 30623},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1267, col: 18, offset: 30492},
+							pos:        position{line: 1274, col: 18, offset: 30626},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1267, col: 22, offset: 30496},
+							pos:  position{line: 1274, col: 22, offset: 30630},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1267, col: 25, offset: 30499},
+							pos:   position{line: 1274, col: 25, offset: 30633},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1267, col: 31, offset: 30505},
+								pos:  position{line: 1274, col: 31, offset: 30639},
 								name: "Expr",
 							},
 						},
@@ -8222,15 +8247,15 @@ var g = &grammar{
 		},
 		{
 			name: "ExprElem",
-			pos:  position{line: 1276, col: 1, offset: 30674},
+			pos:  position{line: 1283, col: 1, offset: 30808},
 			expr: &actionExpr{
-				pos: position{line: 1277, col: 5, offset: 30687},
+				pos: position{line: 1284, col: 5, offset: 30821},
 				run: (*parser).callonExprElem1,
 				expr: &labeledExpr{
-					pos:   position{line: 1277, col: 5, offset: 30687},
+					pos:   position{line: 1284, col: 5, offset: 30821},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1277, col: 10, offset: 30692},
+						pos:  position{line: 1284, col: 10, offset: 30826},
 						name: "Expr",
 					},
 				},
@@ -8240,37 +8265,37 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 1281, col: 1, offset: 30792},
+			pos:  position{line: 1288, col: 1, offset: 30926},
 			expr: &actionExpr{
-				pos: position{line: 1282, col: 5, offset: 30802},
+				pos: position{line: 1289, col: 5, offset: 30936},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 1282, col: 5, offset: 30802},
+					pos: position{line: 1289, col: 5, offset: 30936},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1282, col: 5, offset: 30802},
+							pos:        position{line: 1289, col: 5, offset: 30936},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1282, col: 9, offset: 30806},
+							pos:  position{line: 1289, col: 9, offset: 30940},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1282, col: 12, offset: 30809},
+							pos:   position{line: 1289, col: 12, offset: 30943},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1282, col: 18, offset: 30815},
+								pos:  position{line: 1289, col: 18, offset: 30949},
 								name: "ArrayElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1282, col: 29, offset: 30826},
+							pos:  position{line: 1289, col: 29, offset: 30960},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1282, col: 32, offset: 30829},
+							pos:        position{line: 1289, col: 32, offset: 30963},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -8283,37 +8308,37 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 1290, col: 1, offset: 30984},
+			pos:  position{line: 1297, col: 1, offset: 31118},
 			expr: &actionExpr{
-				pos: position{line: 1291, col: 5, offset: 30992},
+				pos: position{line: 1298, col: 5, offset: 31126},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 1291, col: 5, offset: 30992},
+					pos: position{line: 1298, col: 5, offset: 31126},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1291, col: 5, offset: 30992},
+							pos:        position{line: 1298, col: 5, offset: 31126},
 							val:        "|[",
 							ignoreCase: false,
 							want:       "\"|[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1291, col: 10, offset: 30997},
+							pos:  position{line: 1298, col: 10, offset: 31131},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1291, col: 13, offset: 31000},
+							pos:   position{line: 1298, col: 13, offset: 31134},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1291, col: 19, offset: 31006},
+								pos:  position{line: 1298, col: 19, offset: 31140},
 								name: "ArrayElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1291, col: 30, offset: 31017},
+							pos:  position{line: 1298, col: 30, offset: 31151},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1291, col: 33, offset: 31020},
+							pos:        position{line: 1298, col: 33, offset: 31154},
 							val:        "]|",
 							ignoreCase: false,
 							want:       "\"]|\"",
@@ -8326,54 +8351,54 @@ var g = &grammar{
 		},
 		{
 			name: "ArrayElems",
-			pos:  position{line: 1299, col: 1, offset: 31172},
+			pos:  position{line: 1306, col: 1, offset: 31306},
 			expr: &choiceExpr{
-				pos: position{line: 1300, col: 5, offset: 31187},
+				pos: position{line: 1307, col: 5, offset: 31321},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1300, col: 5, offset: 31187},
+						pos: position{line: 1307, col: 5, offset: 31321},
 						run: (*parser).callonArrayElems2,
 						expr: &seqExpr{
-							pos: position{line: 1300, col: 5, offset: 31187},
+							pos: position{line: 1307, col: 5, offset: 31321},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1300, col: 5, offset: 31187},
+									pos:   position{line: 1307, col: 5, offset: 31321},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1300, col: 11, offset: 31193},
+										pos:  position{line: 1307, col: 11, offset: 31327},
 										name: "ArrayElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1300, col: 21, offset: 31203},
+									pos:   position{line: 1307, col: 21, offset: 31337},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1300, col: 26, offset: 31208},
+										pos: position{line: 1307, col: 26, offset: 31342},
 										expr: &actionExpr{
-											pos: position{line: 1300, col: 27, offset: 31209},
+											pos: position{line: 1307, col: 27, offset: 31343},
 											run: (*parser).callonArrayElems8,
 											expr: &seqExpr{
-												pos: position{line: 1300, col: 27, offset: 31209},
+												pos: position{line: 1307, col: 27, offset: 31343},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1300, col: 27, offset: 31209},
+														pos:  position{line: 1307, col: 27, offset: 31343},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 1300, col: 30, offset: 31212},
+														pos:        position{line: 1307, col: 30, offset: 31346},
 														val:        ",",
 														ignoreCase: false,
 														want:       "\",\"",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1300, col: 34, offset: 31216},
+														pos:  position{line: 1307, col: 34, offset: 31350},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 1300, col: 37, offset: 31219},
+														pos:   position{line: 1307, col: 37, offset: 31353},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1300, col: 39, offset: 31221},
+															pos:  position{line: 1307, col: 39, offset: 31355},
 															name: "ArrayElem",
 														},
 													},
@@ -8386,10 +8411,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1303, col: 5, offset: 31302},
+						pos: position{line: 1310, col: 5, offset: 31436},
 						run: (*parser).callonArrayElems15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1303, col: 5, offset: 31302},
+							pos:  position{line: 1310, col: 5, offset: 31436},
 							name: "__",
 						},
 					},
@@ -8400,16 +8425,16 @@ var g = &grammar{
 		},
 		{
 			name: "ArrayElem",
-			pos:  position{line: 1305, col: 1, offset: 31326},
+			pos:  position{line: 1312, col: 1, offset: 31460},
 			expr: &choiceExpr{
-				pos: position{line: 1305, col: 13, offset: 31338},
+				pos: position{line: 1312, col: 13, offset: 31472},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1305, col: 13, offset: 31338},
+						pos:  position{line: 1312, col: 13, offset: 31472},
 						name: "SpreadElem",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1305, col: 26, offset: 31351},
+						pos:  position{line: 1312, col: 26, offset: 31485},
 						name: "ExprElem",
 					},
 				},
@@ -8419,37 +8444,37 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 1307, col: 1, offset: 31361},
+			pos:  position{line: 1314, col: 1, offset: 31495},
 			expr: &actionExpr{
-				pos: position{line: 1308, col: 5, offset: 31369},
+				pos: position{line: 1315, col: 5, offset: 31503},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 1308, col: 5, offset: 31369},
+					pos: position{line: 1315, col: 5, offset: 31503},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1308, col: 5, offset: 31369},
+							pos:        position{line: 1315, col: 5, offset: 31503},
 							val:        "|{",
 							ignoreCase: false,
 							want:       "\"|{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1308, col: 10, offset: 31374},
+							pos:  position{line: 1315, col: 10, offset: 31508},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1308, col: 13, offset: 31377},
+							pos:   position{line: 1315, col: 13, offset: 31511},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1308, col: 19, offset: 31383},
+								pos:  position{line: 1315, col: 19, offset: 31517},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1308, col: 27, offset: 31391},
+							pos:  position{line: 1315, col: 27, offset: 31525},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1308, col: 30, offset: 31394},
+							pos:        position{line: 1315, col: 30, offset: 31528},
 							val:        "}|",
 							ignoreCase: false,
 							want:       "\"}|\"",
@@ -8462,31 +8487,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 1316, col: 1, offset: 31547},
+			pos:  position{line: 1323, col: 1, offset: 31681},
 			expr: &choiceExpr{
-				pos: position{line: 1317, col: 5, offset: 31559},
+				pos: position{line: 1324, col: 5, offset: 31693},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1317, col: 5, offset: 31559},
+						pos: position{line: 1324, col: 5, offset: 31693},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 1317, col: 5, offset: 31559},
+							pos: position{line: 1324, col: 5, offset: 31693},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1317, col: 5, offset: 31559},
+									pos:   position{line: 1324, col: 5, offset: 31693},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1317, col: 11, offset: 31565},
+										pos:  position{line: 1324, col: 11, offset: 31699},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1317, col: 17, offset: 31571},
+									pos:   position{line: 1324, col: 17, offset: 31705},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1317, col: 22, offset: 31576},
+										pos: position{line: 1324, col: 22, offset: 31710},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1317, col: 22, offset: 31576},
+											pos:  position{line: 1324, col: 22, offset: 31710},
 											name: "EntryTail",
 										},
 									},
@@ -8495,10 +8520,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1320, col: 5, offset: 31634},
+						pos: position{line: 1327, col: 5, offset: 31768},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1320, col: 5, offset: 31634},
+							pos:  position{line: 1327, col: 5, offset: 31768},
 							name: "__",
 						},
 					},
@@ -8509,32 +8534,32 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 1323, col: 1, offset: 31659},
+			pos:  position{line: 1330, col: 1, offset: 31793},
 			expr: &actionExpr{
-				pos: position{line: 1323, col: 13, offset: 31671},
+				pos: position{line: 1330, col: 13, offset: 31805},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 1323, col: 13, offset: 31671},
+					pos: position{line: 1330, col: 13, offset: 31805},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1323, col: 13, offset: 31671},
+							pos:  position{line: 1330, col: 13, offset: 31805},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1323, col: 16, offset: 31674},
+							pos:        position{line: 1330, col: 16, offset: 31808},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1323, col: 20, offset: 31678},
+							pos:  position{line: 1330, col: 20, offset: 31812},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1323, col: 23, offset: 31681},
+							pos:   position{line: 1330, col: 23, offset: 31815},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1323, col: 25, offset: 31683},
+								pos:  position{line: 1330, col: 25, offset: 31817},
 								name: "Entry",
 							},
 						},
@@ -8546,40 +8571,40 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 1325, col: 1, offset: 31708},
+			pos:  position{line: 1332, col: 1, offset: 31842},
 			expr: &actionExpr{
-				pos: position{line: 1326, col: 5, offset: 31718},
+				pos: position{line: 1333, col: 5, offset: 31852},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 1326, col: 5, offset: 31718},
+					pos: position{line: 1333, col: 5, offset: 31852},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1326, col: 5, offset: 31718},
+							pos:   position{line: 1333, col: 5, offset: 31852},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1326, col: 9, offset: 31722},
+								pos:  position{line: 1333, col: 9, offset: 31856},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1326, col: 14, offset: 31727},
+							pos:  position{line: 1333, col: 14, offset: 31861},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1326, col: 17, offset: 31730},
+							pos:        position{line: 1333, col: 17, offset: 31864},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1326, col: 21, offset: 31734},
+							pos:  position{line: 1333, col: 21, offset: 31868},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1326, col: 24, offset: 31737},
+							pos:   position{line: 1333, col: 24, offset: 31871},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1326, col: 30, offset: 31743},
+								pos:  position{line: 1333, col: 30, offset: 31877},
 								name: "Expr",
 							},
 						},
@@ -8591,61 +8616,61 @@ var g = &grammar{
 		},
 		{
 			name: "Tuple",
-			pos:  position{line: 1330, col: 1, offset: 31845},
+			pos:  position{line: 1337, col: 1, offset: 31979},
 			expr: &actionExpr{
-				pos: position{line: 1331, col: 5, offset: 31855},
+				pos: position{line: 1338, col: 5, offset: 31989},
 				run: (*parser).callonTuple1,
 				expr: &seqExpr{
-					pos: position{line: 1331, col: 5, offset: 31855},
+					pos: position{line: 1338, col: 5, offset: 31989},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1331, col: 5, offset: 31855},
+							pos:        position{line: 1338, col: 5, offset: 31989},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1331, col: 9, offset: 31859},
+							pos:  position{line: 1338, col: 9, offset: 31993},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1331, col: 12, offset: 31862},
+							pos:   position{line: 1338, col: 12, offset: 31996},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1331, col: 18, offset: 31868},
+								pos:  position{line: 1338, col: 18, offset: 32002},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1331, col: 23, offset: 31873},
+							pos:   position{line: 1338, col: 23, offset: 32007},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1331, col: 28, offset: 31878},
+								pos: position{line: 1338, col: 28, offset: 32012},
 								expr: &actionExpr{
-									pos: position{line: 1331, col: 29, offset: 31879},
+									pos: position{line: 1338, col: 29, offset: 32013},
 									run: (*parser).callonTuple9,
 									expr: &seqExpr{
-										pos: position{line: 1331, col: 29, offset: 31879},
+										pos: position{line: 1338, col: 29, offset: 32013},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1331, col: 29, offset: 31879},
+												pos:  position{line: 1338, col: 29, offset: 32013},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1331, col: 32, offset: 31882},
+												pos:        position{line: 1338, col: 32, offset: 32016},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1331, col: 36, offset: 31886},
+												pos:  position{line: 1338, col: 36, offset: 32020},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1331, col: 39, offset: 31889},
+												pos:   position{line: 1338, col: 39, offset: 32023},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1331, col: 41, offset: 31891},
+													pos:  position{line: 1338, col: 41, offset: 32025},
 													name: "Expr",
 												},
 											},
@@ -8655,11 +8680,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1331, col: 66, offset: 31916},
+							pos:  position{line: 1338, col: 66, offset: 32050},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1331, col: 69, offset: 31919},
+							pos:        position{line: 1338, col: 69, offset: 32053},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -8672,39 +8697,39 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTimeExpr",
-			pos:  position{line: 1339, col: 1, offset: 32078},
+			pos:  position{line: 1346, col: 1, offset: 32212},
 			expr: &actionExpr{
-				pos: position{line: 1340, col: 5, offset: 32094},
+				pos: position{line: 1347, col: 5, offset: 32228},
 				run: (*parser).callonSQLTimeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1340, col: 5, offset: 32094},
+					pos: position{line: 1347, col: 5, offset: 32228},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1340, col: 5, offset: 32094},
+							pos:   position{line: 1347, col: 5, offset: 32228},
 							label: "typ",
 							expr: &choiceExpr{
-								pos: position{line: 1340, col: 10, offset: 32099},
+								pos: position{line: 1347, col: 10, offset: 32233},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1340, col: 10, offset: 32099},
+										pos:  position{line: 1347, col: 10, offset: 32233},
 										name: "DATE",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1340, col: 17, offset: 32106},
+										pos:  position{line: 1347, col: 17, offset: 32240},
 										name: "TIMESTAMP",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1340, col: 28, offset: 32117},
+							pos:  position{line: 1347, col: 28, offset: 32251},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1340, col: 30, offset: 32119},
+							pos:   position{line: 1347, col: 30, offset: 32253},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1340, col: 32, offset: 32121},
+								pos:  position{line: 1347, col: 32, offset: 32255},
 								name: "StringLiteral",
 							},
 						},
@@ -8716,56 +8741,56 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 1351, col: 1, offset: 32336},
+			pos:  position{line: 1358, col: 1, offset: 32470},
 			expr: &choiceExpr{
-				pos: position{line: 1352, col: 5, offset: 32348},
+				pos: position{line: 1359, col: 5, offset: 32482},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1352, col: 5, offset: 32348},
+						pos:  position{line: 1359, col: 5, offset: 32482},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1353, col: 5, offset: 32364},
+						pos:  position{line: 1360, col: 5, offset: 32498},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1354, col: 5, offset: 32382},
+						pos:  position{line: 1361, col: 5, offset: 32516},
 						name: "FString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1355, col: 5, offset: 32394},
+						pos:  position{line: 1362, col: 5, offset: 32528},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1356, col: 5, offset: 32412},
+						pos:  position{line: 1363, col: 5, offset: 32546},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1357, col: 5, offset: 32431},
+						pos:  position{line: 1364, col: 5, offset: 32565},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1358, col: 5, offset: 32448},
+						pos:  position{line: 1365, col: 5, offset: 32582},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1359, col: 5, offset: 32461},
+						pos:  position{line: 1366, col: 5, offset: 32595},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1360, col: 5, offset: 32470},
+						pos:  position{line: 1367, col: 5, offset: 32604},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1361, col: 5, offset: 32487},
+						pos:  position{line: 1368, col: 5, offset: 32621},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1362, col: 5, offset: 32506},
+						pos:  position{line: 1369, col: 5, offset: 32640},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1363, col: 5, offset: 32525},
+						pos:  position{line: 1370, col: 5, offset: 32659},
 						name: "NullLiteral",
 					},
 				},
@@ -8775,28 +8800,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1365, col: 1, offset: 32538},
+			pos:  position{line: 1372, col: 1, offset: 32672},
 			expr: &choiceExpr{
-				pos: position{line: 1366, col: 5, offset: 32556},
+				pos: position{line: 1373, col: 5, offset: 32690},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1366, col: 5, offset: 32556},
+						pos: position{line: 1373, col: 5, offset: 32690},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1366, col: 5, offset: 32556},
+							pos: position{line: 1373, col: 5, offset: 32690},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1366, col: 5, offset: 32556},
+									pos:   position{line: 1373, col: 5, offset: 32690},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1366, col: 7, offset: 32558},
+										pos:  position{line: 1373, col: 7, offset: 32692},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1366, col: 14, offset: 32565},
+									pos: position{line: 1373, col: 14, offset: 32699},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1366, col: 15, offset: 32566},
+										pos:  position{line: 1373, col: 15, offset: 32700},
 										name: "IdentifierRest",
 									},
 								},
@@ -8804,13 +8829,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1369, col: 5, offset: 32646},
+						pos: position{line: 1376, col: 5, offset: 32780},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1369, col: 5, offset: 32646},
+							pos:   position{line: 1376, col: 5, offset: 32780},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1369, col: 7, offset: 32648},
+								pos:  position{line: 1376, col: 7, offset: 32782},
 								name: "IP4Net",
 							},
 						},
@@ -8822,35 +8847,35 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1373, col: 1, offset: 32717},
+			pos:  position{line: 1380, col: 1, offset: 32851},
 			expr: &choiceExpr{
-				pos: position{line: 1374, col: 5, offset: 32736},
+				pos: position{line: 1381, col: 5, offset: 32870},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1374, col: 5, offset: 32736},
+						pos: position{line: 1381, col: 5, offset: 32870},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1374, col: 5, offset: 32736},
+							pos: position{line: 1381, col: 5, offset: 32870},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1374, col: 5, offset: 32736},
+									pos:   position{line: 1381, col: 5, offset: 32870},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1374, col: 7, offset: 32738},
+										pos:  position{line: 1381, col: 7, offset: 32872},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1374, col: 11, offset: 32742},
+									pos: position{line: 1381, col: 11, offset: 32876},
 									expr: &choiceExpr{
-										pos: position{line: 1374, col: 13, offset: 32744},
+										pos: position{line: 1381, col: 13, offset: 32878},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1374, col: 13, offset: 32744},
+												pos:  position{line: 1381, col: 13, offset: 32878},
 												name: "IdentifierRest",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1374, col: 30, offset: 32761},
+												pos:  position{line: 1381, col: 30, offset: 32895},
 												name: "TypeLiteral",
 											},
 										},
@@ -8860,13 +8885,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1377, col: 5, offset: 32838},
+						pos: position{line: 1384, col: 5, offset: 32972},
 						run: (*parser).callonAddressLiteral10,
 						expr: &labeledExpr{
-							pos:   position{line: 1377, col: 5, offset: 32838},
+							pos:   position{line: 1384, col: 5, offset: 32972},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1377, col: 7, offset: 32840},
+								pos:  position{line: 1384, col: 7, offset: 32974},
 								name: "IP",
 							},
 						},
@@ -8878,15 +8903,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1381, col: 1, offset: 32904},
+			pos:  position{line: 1388, col: 1, offset: 33038},
 			expr: &actionExpr{
-				pos: position{line: 1382, col: 5, offset: 32921},
+				pos: position{line: 1389, col: 5, offset: 33055},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1382, col: 5, offset: 32921},
+					pos:   position{line: 1389, col: 5, offset: 33055},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1382, col: 7, offset: 32923},
+						pos:  position{line: 1389, col: 7, offset: 33057},
 						name: "FloatString",
 					},
 				},
@@ -8896,15 +8921,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1386, col: 1, offset: 33001},
+			pos:  position{line: 1393, col: 1, offset: 33135},
 			expr: &actionExpr{
-				pos: position{line: 1387, col: 5, offset: 33020},
+				pos: position{line: 1394, col: 5, offset: 33154},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1387, col: 5, offset: 33020},
+					pos:   position{line: 1394, col: 5, offset: 33154},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1387, col: 7, offset: 33022},
+						pos:  position{line: 1394, col: 7, offset: 33156},
 						name: "IntString",
 					},
 				},
@@ -8914,23 +8939,23 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1391, col: 1, offset: 33096},
+			pos:  position{line: 1398, col: 1, offset: 33230},
 			expr: &choiceExpr{
-				pos: position{line: 1392, col: 5, offset: 33115},
+				pos: position{line: 1399, col: 5, offset: 33249},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1392, col: 5, offset: 33115},
+						pos: position{line: 1399, col: 5, offset: 33249},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1392, col: 5, offset: 33115},
+							pos:  position{line: 1399, col: 5, offset: 33249},
 							name: "TRUE",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1393, col: 5, offset: 33173},
+						pos: position{line: 1400, col: 5, offset: 33307},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1393, col: 5, offset: 33173},
+							pos:  position{line: 1400, col: 5, offset: 33307},
 							name: "FALSE",
 						},
 					},
@@ -8941,12 +8966,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1395, col: 1, offset: 33229},
+			pos:  position{line: 1402, col: 1, offset: 33363},
 			expr: &actionExpr{
-				pos: position{line: 1396, col: 5, offset: 33245},
+				pos: position{line: 1403, col: 5, offset: 33379},
 				run: (*parser).callonNullLiteral1,
 				expr: &ruleRefExpr{
-					pos:  position{line: 1396, col: 5, offset: 33245},
+					pos:  position{line: 1403, col: 5, offset: 33379},
 					name: "NULL",
 				},
 			},
@@ -8955,23 +8980,23 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 1398, col: 1, offset: 33295},
+			pos:  position{line: 1405, col: 1, offset: 33429},
 			expr: &actionExpr{
-				pos: position{line: 1399, col: 5, offset: 33312},
+				pos: position{line: 1406, col: 5, offset: 33446},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1399, col: 5, offset: 33312},
+					pos: position{line: 1406, col: 5, offset: 33446},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1399, col: 5, offset: 33312},
+							pos:        position{line: 1406, col: 5, offset: 33446},
 							val:        "0x",
 							ignoreCase: false,
 							want:       "\"0x\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1399, col: 10, offset: 33317},
+							pos: position{line: 1406, col: 10, offset: 33451},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1399, col: 10, offset: 33317},
+								pos:  position{line: 1406, col: 10, offset: 33451},
 								name: "HexDigit",
 							},
 						},
@@ -8983,29 +9008,29 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1403, col: 1, offset: 33391},
+			pos:  position{line: 1410, col: 1, offset: 33525},
 			expr: &actionExpr{
-				pos: position{line: 1404, col: 5, offset: 33407},
+				pos: position{line: 1411, col: 5, offset: 33541},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1404, col: 5, offset: 33407},
+					pos: position{line: 1411, col: 5, offset: 33541},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1404, col: 5, offset: 33407},
+							pos:        position{line: 1411, col: 5, offset: 33541},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1404, col: 9, offset: 33411},
+							pos:   position{line: 1411, col: 9, offset: 33545},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1404, col: 13, offset: 33415},
+								pos:  position{line: 1411, col: 13, offset: 33549},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1404, col: 18, offset: 33420},
+							pos:        position{line: 1411, col: 18, offset: 33554},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
@@ -9018,27 +9043,27 @@ var g = &grammar{
 		},
 		{
 			name: "TypeAsValue",
-			pos:  position{line: 1412, col: 1, offset: 33553},
+			pos:  position{line: 1419, col: 1, offset: 33687},
 			expr: &choiceExpr{
-				pos: position{line: 1413, col: 5, offset: 33569},
+				pos: position{line: 1420, col: 5, offset: 33703},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1413, col: 5, offset: 33569},
+						pos: position{line: 1420, col: 5, offset: 33703},
 						run: (*parser).callonTypeAsValue2,
 						expr: &seqExpr{
-							pos: position{line: 1413, col: 5, offset: 33569},
+							pos: position{line: 1420, col: 5, offset: 33703},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1413, col: 5, offset: 33569},
+									pos:        position{line: 1420, col: 5, offset: 33703},
 									val:        "=",
 									ignoreCase: false,
 									want:       "\"=\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1413, col: 9, offset: 33573},
+									pos:   position{line: 1420, col: 9, offset: 33707},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1413, col: 14, offset: 33578},
+										pos:  position{line: 1420, col: 14, offset: 33712},
 										name: "Name",
 									},
 								},
@@ -9046,13 +9071,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1414, col: 5, offset: 33652},
+						pos: position{line: 1421, col: 5, offset: 33786},
 						run: (*parser).callonTypeAsValue7,
 						expr: &labeledExpr{
-							pos:   position{line: 1414, col: 5, offset: 33652},
+							pos:   position{line: 1421, col: 5, offset: 33786},
 							label: "t",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1414, col: 7, offset: 33654},
+								pos:  position{line: 1421, col: 7, offset: 33788},
 								name: "EasyType",
 							},
 						},
@@ -9064,16 +9089,16 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1422, col: 1, offset: 33790},
+			pos:  position{line: 1429, col: 1, offset: 33924},
 			expr: &choiceExpr{
-				pos: position{line: 1423, col: 5, offset: 33799},
+				pos: position{line: 1430, col: 5, offset: 33933},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1423, col: 5, offset: 33799},
+						pos:  position{line: 1430, col: 5, offset: 33933},
 						name: "TypeUnion",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1424, col: 5, offset: 33813},
+						pos:  position{line: 1431, col: 5, offset: 33947},
 						name: "ComponentType",
 					},
 				},
@@ -9083,52 +9108,52 @@ var g = &grammar{
 		},
 		{
 			name: "ComponentType",
-			pos:  position{line: 1426, col: 1, offset: 33828},
+			pos:  position{line: 1433, col: 1, offset: 33962},
 			expr: &choiceExpr{
-				pos: position{line: 1427, col: 5, offset: 33846},
+				pos: position{line: 1434, col: 5, offset: 33980},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1427, col: 5, offset: 33846},
+						pos:  position{line: 1434, col: 5, offset: 33980},
 						name: "EasyType",
 					},
 					&actionExpr{
-						pos: position{line: 1428, col: 5, offset: 33859},
+						pos: position{line: 1435, col: 5, offset: 33993},
 						run: (*parser).callonComponentType3,
 						expr: &seqExpr{
-							pos: position{line: 1428, col: 5, offset: 33859},
+							pos: position{line: 1435, col: 5, offset: 33993},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1428, col: 5, offset: 33859},
+									pos:   position{line: 1435, col: 5, offset: 33993},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1428, col: 10, offset: 33864},
+										pos:  position{line: 1435, col: 10, offset: 33998},
 										name: "Name",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1428, col: 15, offset: 33869},
+									pos:   position{line: 1435, col: 15, offset: 34003},
 									label: "opt",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1428, col: 19, offset: 33873},
+										pos: position{line: 1435, col: 19, offset: 34007},
 										expr: &seqExpr{
-											pos: position{line: 1428, col: 20, offset: 33874},
+											pos: position{line: 1435, col: 20, offset: 34008},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1428, col: 20, offset: 33874},
+													pos:  position{line: 1435, col: 20, offset: 34008},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1428, col: 23, offset: 33877},
+													pos:        position{line: 1435, col: 23, offset: 34011},
 													val:        "=",
 													ignoreCase: false,
 													want:       "\"=\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1428, col: 27, offset: 33881},
+													pos:  position{line: 1435, col: 27, offset: 34015},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1428, col: 30, offset: 33884},
+													pos:  position{line: 1435, col: 30, offset: 34018},
 													name: "Type",
 												},
 											},
@@ -9145,40 +9170,40 @@ var g = &grammar{
 		},
 		{
 			name: "EasyType",
-			pos:  position{line: 1440, col: 1, offset: 34206},
+			pos:  position{line: 1447, col: 1, offset: 34340},
 			expr: &choiceExpr{
-				pos: position{line: 1441, col: 5, offset: 34219},
+				pos: position{line: 1448, col: 5, offset: 34353},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1441, col: 5, offset: 34219},
+						pos: position{line: 1448, col: 5, offset: 34353},
 						run: (*parser).callonEasyType2,
 						expr: &seqExpr{
-							pos: position{line: 1441, col: 5, offset: 34219},
+							pos: position{line: 1448, col: 5, offset: 34353},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1441, col: 5, offset: 34219},
+									pos:        position{line: 1448, col: 5, offset: 34353},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1441, col: 9, offset: 34223},
+									pos:  position{line: 1448, col: 9, offset: 34357},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1441, col: 12, offset: 34226},
+									pos:   position{line: 1448, col: 12, offset: 34360},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1441, col: 16, offset: 34230},
+										pos:  position{line: 1448, col: 16, offset: 34364},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1441, col: 21, offset: 34235},
+									pos:  position{line: 1448, col: 21, offset: 34369},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1441, col: 24, offset: 34238},
+									pos:        position{line: 1448, col: 24, offset: 34372},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9187,23 +9212,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1442, col: 5, offset: 34265},
+						pos: position{line: 1449, col: 5, offset: 34399},
 						run: (*parser).callonEasyType10,
 						expr: &seqExpr{
-							pos: position{line: 1442, col: 5, offset: 34265},
+							pos: position{line: 1449, col: 5, offset: 34399},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1442, col: 5, offset: 34265},
+									pos:   position{line: 1449, col: 5, offset: 34399},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1442, col: 10, offset: 34270},
+										pos:  position{line: 1449, col: 10, offset: 34404},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1442, col: 24, offset: 34284},
+									pos: position{line: 1449, col: 24, offset: 34418},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1442, col: 25, offset: 34285},
+										pos:  position{line: 1449, col: 25, offset: 34419},
 										name: "IdentifierRest",
 									},
 								},
@@ -9211,43 +9236,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1443, col: 5, offset: 34325},
+						pos: position{line: 1450, col: 5, offset: 34459},
 						run: (*parser).callonEasyType16,
 						expr: &seqExpr{
-							pos: position{line: 1443, col: 5, offset: 34325},
+							pos: position{line: 1450, col: 5, offset: 34459},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1443, col: 5, offset: 34325},
+									pos:  position{line: 1450, col: 5, offset: 34459},
 									name: "ERROR",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1443, col: 11, offset: 34331},
+									pos:  position{line: 1450, col: 11, offset: 34465},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1443, col: 14, offset: 34334},
+									pos:        position{line: 1450, col: 14, offset: 34468},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1443, col: 18, offset: 34338},
+									pos:  position{line: 1450, col: 18, offset: 34472},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1443, col: 21, offset: 34341},
+									pos:   position{line: 1450, col: 21, offset: 34475},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1443, col: 23, offset: 34343},
+										pos:  position{line: 1450, col: 23, offset: 34477},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1443, col: 28, offset: 34348},
+									pos:  position{line: 1450, col: 28, offset: 34482},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1443, col: 31, offset: 34351},
+									pos:        position{line: 1450, col: 31, offset: 34485},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9256,43 +9281,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1450, col: 5, offset: 34491},
+						pos: position{line: 1457, col: 5, offset: 34625},
 						run: (*parser).callonEasyType26,
 						expr: &seqExpr{
-							pos: position{line: 1450, col: 5, offset: 34491},
+							pos: position{line: 1457, col: 5, offset: 34625},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1450, col: 5, offset: 34491},
+									pos:  position{line: 1457, col: 5, offset: 34625},
 									name: "ENUM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1450, col: 10, offset: 34496},
+									pos:  position{line: 1457, col: 10, offset: 34630},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1450, col: 13, offset: 34499},
+									pos:        position{line: 1457, col: 13, offset: 34633},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1450, col: 17, offset: 34503},
+									pos:  position{line: 1457, col: 17, offset: 34637},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1450, col: 20, offset: 34506},
+									pos:   position{line: 1457, col: 20, offset: 34640},
 									label: "names",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1450, col: 26, offset: 34512},
+										pos:  position{line: 1457, col: 26, offset: 34646},
 										name: "Names",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1450, col: 32, offset: 34518},
+									pos:  position{line: 1457, col: 32, offset: 34652},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1450, col: 35, offset: 34521},
+									pos:        position{line: 1457, col: 35, offset: 34655},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9301,35 +9326,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1457, col: 5, offset: 34675},
+						pos: position{line: 1464, col: 5, offset: 34809},
 						run: (*parser).callonEasyType36,
 						expr: &seqExpr{
-							pos: position{line: 1457, col: 5, offset: 34675},
+							pos: position{line: 1464, col: 5, offset: 34809},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1457, col: 5, offset: 34675},
+									pos:        position{line: 1464, col: 5, offset: 34809},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1457, col: 9, offset: 34679},
+									pos:  position{line: 1464, col: 9, offset: 34813},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1457, col: 12, offset: 34682},
+									pos:   position{line: 1464, col: 12, offset: 34816},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1457, col: 19, offset: 34689},
+										pos:  position{line: 1464, col: 19, offset: 34823},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1457, col: 33, offset: 34703},
+									pos:  position{line: 1464, col: 33, offset: 34837},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1457, col: 36, offset: 34706},
+									pos:        position{line: 1464, col: 36, offset: 34840},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -9338,35 +9363,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1464, col: 5, offset: 34868},
+						pos: position{line: 1471, col: 5, offset: 35002},
 						run: (*parser).callonEasyType44,
 						expr: &seqExpr{
-							pos: position{line: 1464, col: 5, offset: 34868},
+							pos: position{line: 1471, col: 5, offset: 35002},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1464, col: 5, offset: 34868},
+									pos:        position{line: 1471, col: 5, offset: 35002},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1464, col: 9, offset: 34872},
+									pos:  position{line: 1471, col: 9, offset: 35006},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1464, col: 12, offset: 34875},
+									pos:   position{line: 1471, col: 12, offset: 35009},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1464, col: 16, offset: 34879},
+										pos:  position{line: 1471, col: 16, offset: 35013},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1464, col: 21, offset: 34884},
+									pos:  position{line: 1471, col: 21, offset: 35018},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1464, col: 24, offset: 34887},
+									pos:        position{line: 1471, col: 24, offset: 35021},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -9375,35 +9400,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1471, col: 5, offset: 35029},
+						pos: position{line: 1478, col: 5, offset: 35163},
 						run: (*parser).callonEasyType52,
 						expr: &seqExpr{
-							pos: position{line: 1471, col: 5, offset: 35029},
+							pos: position{line: 1478, col: 5, offset: 35163},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1471, col: 5, offset: 35029},
+									pos:        position{line: 1478, col: 5, offset: 35163},
 									val:        "|[",
 									ignoreCase: false,
 									want:       "\"|[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1471, col: 10, offset: 35034},
+									pos:  position{line: 1478, col: 10, offset: 35168},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1471, col: 13, offset: 35037},
+									pos:   position{line: 1478, col: 13, offset: 35171},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1471, col: 17, offset: 35041},
+										pos:  position{line: 1478, col: 17, offset: 35175},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1471, col: 22, offset: 35046},
+									pos:  position{line: 1478, col: 22, offset: 35180},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1471, col: 25, offset: 35049},
+									pos:        position{line: 1478, col: 25, offset: 35183},
 									val:        "]|",
 									ignoreCase: false,
 									want:       "\"]|\"",
@@ -9412,57 +9437,57 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1478, col: 5, offset: 35188},
+						pos: position{line: 1485, col: 5, offset: 35322},
 						run: (*parser).callonEasyType60,
 						expr: &seqExpr{
-							pos: position{line: 1478, col: 5, offset: 35188},
+							pos: position{line: 1485, col: 5, offset: 35322},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1478, col: 5, offset: 35188},
+									pos:        position{line: 1485, col: 5, offset: 35322},
 									val:        "|{",
 									ignoreCase: false,
 									want:       "\"|{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1478, col: 10, offset: 35193},
+									pos:  position{line: 1485, col: 10, offset: 35327},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1478, col: 13, offset: 35196},
+									pos:   position{line: 1485, col: 13, offset: 35330},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1478, col: 21, offset: 35204},
+										pos:  position{line: 1485, col: 21, offset: 35338},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1478, col: 26, offset: 35209},
+									pos:  position{line: 1485, col: 26, offset: 35343},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1478, col: 29, offset: 35212},
+									pos:        position{line: 1485, col: 29, offset: 35346},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1478, col: 33, offset: 35216},
+									pos:  position{line: 1485, col: 33, offset: 35350},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1478, col: 36, offset: 35219},
+									pos:   position{line: 1485, col: 36, offset: 35353},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1478, col: 44, offset: 35227},
+										pos:  position{line: 1485, col: 44, offset: 35361},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1478, col: 49, offset: 35232},
+									pos:  position{line: 1485, col: 49, offset: 35366},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1478, col: 52, offset: 35235},
+									pos:        position{line: 1485, col: 52, offset: 35369},
 									val:        "}|",
 									ignoreCase: false,
 									want:       "\"}|\"",
@@ -9477,15 +9502,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeUnion",
-			pos:  position{line: 1487, col: 1, offset: 35409},
+			pos:  position{line: 1494, col: 1, offset: 35543},
 			expr: &actionExpr{
-				pos: position{line: 1488, col: 5, offset: 35423},
+				pos: position{line: 1495, col: 5, offset: 35557},
 				run: (*parser).callonTypeUnion1,
 				expr: &labeledExpr{
-					pos:   position{line: 1488, col: 5, offset: 35423},
+					pos:   position{line: 1495, col: 5, offset: 35557},
 					label: "types",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1488, col: 11, offset: 35429},
+						pos:  position{line: 1495, col: 11, offset: 35563},
 						name: "TypeList",
 					},
 				},
@@ -9495,28 +9520,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1496, col: 1, offset: 35566},
+			pos:  position{line: 1503, col: 1, offset: 35700},
 			expr: &actionExpr{
-				pos: position{line: 1497, col: 5, offset: 35579},
+				pos: position{line: 1504, col: 5, offset: 35713},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1497, col: 5, offset: 35579},
+					pos: position{line: 1504, col: 5, offset: 35713},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1497, col: 5, offset: 35579},
+							pos:   position{line: 1504, col: 5, offset: 35713},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1497, col: 11, offset: 35585},
+								pos:  position{line: 1504, col: 11, offset: 35719},
 								name: "ComponentType",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1497, col: 25, offset: 35599},
+							pos:   position{line: 1504, col: 25, offset: 35733},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1497, col: 30, offset: 35604},
+								pos: position{line: 1504, col: 30, offset: 35738},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1497, col: 30, offset: 35604},
+									pos:  position{line: 1504, col: 30, offset: 35738},
 									name: "TypeListTail",
 								},
 							},
@@ -9529,32 +9554,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1501, col: 1, offset: 35662},
+			pos:  position{line: 1508, col: 1, offset: 35796},
 			expr: &actionExpr{
-				pos: position{line: 1501, col: 16, offset: 35677},
+				pos: position{line: 1508, col: 16, offset: 35811},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1501, col: 16, offset: 35677},
+					pos: position{line: 1508, col: 16, offset: 35811},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1501, col: 16, offset: 35677},
+							pos:  position{line: 1508, col: 16, offset: 35811},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1501, col: 19, offset: 35680},
+							pos:        position{line: 1508, col: 19, offset: 35814},
 							val:        "|",
 							ignoreCase: false,
 							want:       "\"|\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1501, col: 23, offset: 35684},
+							pos:  position{line: 1508, col: 23, offset: 35818},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1501, col: 26, offset: 35687},
+							pos:   position{line: 1508, col: 26, offset: 35821},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1501, col: 30, offset: 35691},
+								pos:  position{line: 1508, col: 30, offset: 35825},
 								name: "ComponentType",
 							},
 						},
@@ -9566,42 +9591,42 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 1503, col: 1, offset: 35726},
+			pos:  position{line: 1510, col: 1, offset: 35860},
 			expr: &choiceExpr{
-				pos: position{line: 1504, col: 5, offset: 35744},
+				pos: position{line: 1511, col: 5, offset: 35878},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1504, col: 5, offset: 35744},
+						pos: position{line: 1511, col: 5, offset: 35878},
 						run: (*parser).callonStringLiteral2,
 						expr: &labeledExpr{
-							pos:   position{line: 1504, col: 5, offset: 35744},
+							pos:   position{line: 1511, col: 5, offset: 35878},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1504, col: 7, offset: 35746},
+								pos:  position{line: 1511, col: 7, offset: 35880},
 								name: "DoubleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1505, col: 5, offset: 35861},
+						pos: position{line: 1512, col: 5, offset: 35995},
 						run: (*parser).callonStringLiteral5,
 						expr: &labeledExpr{
-							pos:   position{line: 1505, col: 5, offset: 35861},
+							pos:   position{line: 1512, col: 5, offset: 35995},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1505, col: 7, offset: 35863},
+								pos:  position{line: 1512, col: 7, offset: 35997},
 								name: "SingleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1506, col: 5, offset: 35940},
+						pos: position{line: 1513, col: 5, offset: 36074},
 						run: (*parser).callonStringLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1506, col: 5, offset: 35940},
+							pos:   position{line: 1513, col: 5, offset: 36074},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1506, col: 7, offset: 35942},
+								pos:  position{line: 1513, col: 7, offset: 36076},
 								name: "RString",
 							},
 						},
@@ -9613,35 +9638,35 @@ var g = &grammar{
 		},
 		{
 			name: "FString",
-			pos:  position{line: 1508, col: 1, offset: 36005},
+			pos:  position{line: 1515, col: 1, offset: 36139},
 			expr: &choiceExpr{
-				pos: position{line: 1509, col: 5, offset: 36017},
+				pos: position{line: 1516, col: 5, offset: 36151},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1509, col: 5, offset: 36017},
+						pos: position{line: 1516, col: 5, offset: 36151},
 						run: (*parser).callonFString2,
 						expr: &seqExpr{
-							pos: position{line: 1509, col: 5, offset: 36017},
+							pos: position{line: 1516, col: 5, offset: 36151},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1509, col: 5, offset: 36017},
+									pos:        position{line: 1516, col: 5, offset: 36151},
 									val:        "f\"",
 									ignoreCase: false,
 									want:       "\"f\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1509, col: 11, offset: 36023},
+									pos:   position{line: 1516, col: 11, offset: 36157},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1509, col: 13, offset: 36025},
+										pos: position{line: 1516, col: 13, offset: 36159},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1509, col: 13, offset: 36025},
+											pos:  position{line: 1516, col: 13, offset: 36159},
 											name: "FStringDoubleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1509, col: 38, offset: 36050},
+									pos:        position{line: 1516, col: 38, offset: 36184},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -9650,30 +9675,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1516, col: 5, offset: 36204},
+						pos: position{line: 1523, col: 5, offset: 36338},
 						run: (*parser).callonFString9,
 						expr: &seqExpr{
-							pos: position{line: 1516, col: 5, offset: 36204},
+							pos: position{line: 1523, col: 5, offset: 36338},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1516, col: 5, offset: 36204},
+									pos:        position{line: 1523, col: 5, offset: 36338},
 									val:        "f'",
 									ignoreCase: false,
 									want:       "\"f'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1516, col: 10, offset: 36209},
+									pos:   position{line: 1523, col: 10, offset: 36343},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1516, col: 12, offset: 36211},
+										pos: position{line: 1523, col: 12, offset: 36345},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1516, col: 12, offset: 36211},
+											pos:  position{line: 1523, col: 12, offset: 36345},
 											name: "FStringSingleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1516, col: 37, offset: 36236},
+									pos:        position{line: 1523, col: 37, offset: 36370},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -9688,24 +9713,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedElem",
-			pos:  position{line: 1524, col: 1, offset: 36387},
+			pos:  position{line: 1531, col: 1, offset: 36521},
 			expr: &choiceExpr{
-				pos: position{line: 1525, col: 5, offset: 36415},
+				pos: position{line: 1532, col: 5, offset: 36549},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1525, col: 5, offset: 36415},
+						pos:  position{line: 1532, col: 5, offset: 36549},
 						name: "FStringExprElem",
 					},
 					&actionExpr{
-						pos: position{line: 1526, col: 5, offset: 36435},
+						pos: position{line: 1533, col: 5, offset: 36569},
 						run: (*parser).callonFStringDoubleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1526, col: 5, offset: 36435},
+							pos:   position{line: 1533, col: 5, offset: 36569},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1526, col: 7, offset: 36437},
+								pos: position{line: 1533, col: 7, offset: 36571},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1526, col: 7, offset: 36437},
+									pos:  position{line: 1533, col: 7, offset: 36571},
 									name: "FStringDoubleQuotedChar",
 								},
 							},
@@ -9718,27 +9743,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedChar",
-			pos:  position{line: 1530, col: 1, offset: 36568},
+			pos:  position{line: 1537, col: 1, offset: 36702},
 			expr: &choiceExpr{
-				pos: position{line: 1531, col: 5, offset: 36596},
+				pos: position{line: 1538, col: 5, offset: 36730},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1531, col: 5, offset: 36596},
+						pos: position{line: 1538, col: 5, offset: 36730},
 						run: (*parser).callonFStringDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1531, col: 5, offset: 36596},
+							pos: position{line: 1538, col: 5, offset: 36730},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1531, col: 5, offset: 36596},
+									pos:        position{line: 1538, col: 5, offset: 36730},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1531, col: 10, offset: 36601},
+									pos:   position{line: 1538, col: 10, offset: 36735},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1531, col: 12, offset: 36603},
+										pos:        position{line: 1538, col: 12, offset: 36737},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9748,25 +9773,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1532, col: 5, offset: 36629},
+						pos: position{line: 1539, col: 5, offset: 36763},
 						run: (*parser).callonFStringDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1532, col: 5, offset: 36629},
+							pos: position{line: 1539, col: 5, offset: 36763},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1532, col: 5, offset: 36629},
+									pos: position{line: 1539, col: 5, offset: 36763},
 									expr: &litMatcher{
-										pos:        position{line: 1532, col: 7, offset: 36631},
+										pos:        position{line: 1539, col: 7, offset: 36765},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1532, col: 12, offset: 36636},
+									pos:   position{line: 1539, col: 12, offset: 36770},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1532, col: 14, offset: 36638},
+										pos:  position{line: 1539, col: 14, offset: 36772},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -9780,24 +9805,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedElem",
-			pos:  position{line: 1534, col: 1, offset: 36674},
+			pos:  position{line: 1541, col: 1, offset: 36808},
 			expr: &choiceExpr{
-				pos: position{line: 1535, col: 5, offset: 36702},
+				pos: position{line: 1542, col: 5, offset: 36836},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1535, col: 5, offset: 36702},
+						pos:  position{line: 1542, col: 5, offset: 36836},
 						name: "FStringExprElem",
 					},
 					&actionExpr{
-						pos: position{line: 1536, col: 5, offset: 36722},
+						pos: position{line: 1543, col: 5, offset: 36856},
 						run: (*parser).callonFStringSingleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1536, col: 5, offset: 36722},
+							pos:   position{line: 1543, col: 5, offset: 36856},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1536, col: 7, offset: 36724},
+								pos: position{line: 1543, col: 7, offset: 36858},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1536, col: 7, offset: 36724},
+									pos:  position{line: 1543, col: 7, offset: 36858},
 									name: "FStringSingleQuotedChar",
 								},
 							},
@@ -9810,27 +9835,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedChar",
-			pos:  position{line: 1540, col: 1, offset: 36855},
+			pos:  position{line: 1547, col: 1, offset: 36989},
 			expr: &choiceExpr{
-				pos: position{line: 1541, col: 5, offset: 36883},
+				pos: position{line: 1548, col: 5, offset: 37017},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1541, col: 5, offset: 36883},
+						pos: position{line: 1548, col: 5, offset: 37017},
 						run: (*parser).callonFStringSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1541, col: 5, offset: 36883},
+							pos: position{line: 1548, col: 5, offset: 37017},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1541, col: 5, offset: 36883},
+									pos:        position{line: 1548, col: 5, offset: 37017},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1541, col: 10, offset: 36888},
+									pos:   position{line: 1548, col: 10, offset: 37022},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1541, col: 12, offset: 36890},
+										pos:        position{line: 1548, col: 12, offset: 37024},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9840,25 +9865,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1542, col: 5, offset: 36916},
+						pos: position{line: 1549, col: 5, offset: 37050},
 						run: (*parser).callonFStringSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1542, col: 5, offset: 36916},
+							pos: position{line: 1549, col: 5, offset: 37050},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1542, col: 5, offset: 36916},
+									pos: position{line: 1549, col: 5, offset: 37050},
 									expr: &litMatcher{
-										pos:        position{line: 1542, col: 7, offset: 36918},
+										pos:        position{line: 1549, col: 7, offset: 37052},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1542, col: 12, offset: 36923},
+									pos:   position{line: 1549, col: 12, offset: 37057},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1542, col: 14, offset: 36925},
+										pos:  position{line: 1549, col: 14, offset: 37059},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -9872,37 +9897,37 @@ var g = &grammar{
 		},
 		{
 			name: "FStringExprElem",
-			pos:  position{line: 1544, col: 1, offset: 36961},
+			pos:  position{line: 1551, col: 1, offset: 37095},
 			expr: &actionExpr{
-				pos: position{line: 1545, col: 5, offset: 36981},
+				pos: position{line: 1552, col: 5, offset: 37115},
 				run: (*parser).callonFStringExprElem1,
 				expr: &seqExpr{
-					pos: position{line: 1545, col: 5, offset: 36981},
+					pos: position{line: 1552, col: 5, offset: 37115},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1545, col: 5, offset: 36981},
+							pos:        position{line: 1552, col: 5, offset: 37115},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1545, col: 9, offset: 36985},
+							pos:  position{line: 1552, col: 9, offset: 37119},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1545, col: 12, offset: 36988},
+							pos:   position{line: 1552, col: 12, offset: 37122},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1545, col: 14, offset: 36990},
+								pos:  position{line: 1552, col: 14, offset: 37124},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1545, col: 19, offset: 36995},
+							pos:  position{line: 1552, col: 19, offset: 37129},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1545, col: 22, offset: 36998},
+							pos:        position{line: 1552, col: 22, offset: 37132},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -9915,144 +9940,144 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1553, col: 1, offset: 37141},
+			pos:  position{line: 1560, col: 1, offset: 37275},
 			expr: &choiceExpr{
-				pos: position{line: 1554, col: 5, offset: 37159},
+				pos: position{line: 1561, col: 5, offset: 37293},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1554, col: 5, offset: 37159},
+						pos: position{line: 1561, col: 5, offset: 37293},
 						run: (*parser).callonPrimitiveType2,
 						expr: &labeledExpr{
-							pos:   position{line: 1554, col: 5, offset: 37159},
+							pos:   position{line: 1561, col: 5, offset: 37293},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1554, col: 10, offset: 37164},
+								pos:  position{line: 1561, col: 10, offset: 37298},
 								name: "PostgreSQLPrimitiveType",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1561, col: 5, offset: 37339},
+						pos: position{line: 1568, col: 5, offset: 37473},
 						run: (*parser).callonPrimitiveType5,
 						expr: &choiceExpr{
-							pos: position{line: 1561, col: 9, offset: 37343},
+							pos: position{line: 1568, col: 9, offset: 37477},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1561, col: 9, offset: 37343},
+									pos:        position{line: 1568, col: 9, offset: 37477},
 									val:        "uint8",
 									ignoreCase: false,
 									want:       "\"uint8\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1561, col: 19, offset: 37353},
+									pos:        position{line: 1568, col: 19, offset: 37487},
 									val:        "uint16",
 									ignoreCase: false,
 									want:       "\"uint16\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1561, col: 30, offset: 37364},
+									pos:        position{line: 1568, col: 30, offset: 37498},
 									val:        "uint32",
 									ignoreCase: false,
 									want:       "\"uint32\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1561, col: 41, offset: 37375},
+									pos:        position{line: 1568, col: 41, offset: 37509},
 									val:        "uint64",
 									ignoreCase: false,
 									want:       "\"uint64\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1562, col: 9, offset: 37392},
+									pos:        position{line: 1569, col: 9, offset: 37526},
 									val:        "int8",
 									ignoreCase: false,
 									want:       "\"int8\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1562, col: 18, offset: 37401},
+									pos:        position{line: 1569, col: 18, offset: 37535},
 									val:        "int16",
 									ignoreCase: false,
 									want:       "\"int16\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1562, col: 28, offset: 37411},
+									pos:        position{line: 1569, col: 28, offset: 37545},
 									val:        "int32",
 									ignoreCase: false,
 									want:       "\"int32\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1562, col: 38, offset: 37421},
+									pos:        position{line: 1569, col: 38, offset: 37555},
 									val:        "int64",
 									ignoreCase: false,
 									want:       "\"int64\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1563, col: 9, offset: 37437},
+									pos:        position{line: 1570, col: 9, offset: 37571},
 									val:        "float16",
 									ignoreCase: false,
 									want:       "\"float16\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1563, col: 21, offset: 37449},
+									pos:        position{line: 1570, col: 21, offset: 37583},
 									val:        "float32",
 									ignoreCase: false,
 									want:       "\"float32\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1563, col: 33, offset: 37461},
+									pos:        position{line: 1570, col: 33, offset: 37595},
 									val:        "float64",
 									ignoreCase: false,
 									want:       "\"float64\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1564, col: 9, offset: 37479},
+									pos:        position{line: 1571, col: 9, offset: 37613},
 									val:        "bool",
 									ignoreCase: false,
 									want:       "\"bool\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1564, col: 18, offset: 37488},
+									pos:        position{line: 1571, col: 18, offset: 37622},
 									val:        "string",
 									ignoreCase: false,
 									want:       "\"string\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1565, col: 9, offset: 37505},
+									pos:        position{line: 1572, col: 9, offset: 37639},
 									val:        "duration",
 									ignoreCase: false,
 									want:       "\"duration\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1565, col: 22, offset: 37518},
+									pos:        position{line: 1572, col: 22, offset: 37652},
 									val:        "time",
 									ignoreCase: false,
 									want:       "\"time\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1566, col: 9, offset: 37533},
+									pos:        position{line: 1573, col: 9, offset: 37667},
 									val:        "bytes",
 									ignoreCase: false,
 									want:       "\"bytes\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1567, col: 9, offset: 37549},
+									pos:        position{line: 1574, col: 9, offset: 37683},
 									val:        "ip",
 									ignoreCase: false,
 									want:       "\"ip\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1567, col: 16, offset: 37556},
+									pos:        position{line: 1574, col: 16, offset: 37690},
 									val:        "net",
 									ignoreCase: false,
 									want:       "\"net\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1568, col: 9, offset: 37570},
+									pos:        position{line: 1575, col: 9, offset: 37704},
 									val:        "type",
 									ignoreCase: false,
 									want:       "\"type\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1568, col: 18, offset: 37579},
+									pos:        position{line: 1575, col: 18, offset: 37713},
 									val:        "null",
 									ignoreCase: false,
 									want:       "\"null\"",
@@ -10067,56 +10092,56 @@ var g = &grammar{
 		},
 		{
 			name: "PostgreSQLPrimitiveType",
-			pos:  position{line: 1577, col: 1, offset: 37836},
+			pos:  position{line: 1584, col: 1, offset: 37970},
 			expr: &choiceExpr{
-				pos: position{line: 1578, col: 5, offset: 37864},
+				pos: position{line: 1585, col: 5, offset: 37998},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1578, col: 5, offset: 37864},
+						pos: position{line: 1585, col: 5, offset: 37998},
 						run: (*parser).callonPostgreSQLPrimitiveType2,
 						expr: &litMatcher{
-							pos:        position{line: 1578, col: 5, offset: 37864},
+							pos:        position{line: 1585, col: 5, offset: 37998},
 							val:        "bigint",
 							ignoreCase: true,
 							want:       "\"bigint\"i",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1579, col: 5, offset: 37913},
+						pos: position{line: 1586, col: 5, offset: 38047},
 						run: (*parser).callonPostgreSQLPrimitiveType4,
 						expr: &litMatcher{
-							pos:        position{line: 1579, col: 5, offset: 37913},
+							pos:        position{line: 1586, col: 5, offset: 38047},
 							val:        "boolean",
 							ignoreCase: true,
 							want:       "\"boolean\"i",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1580, col: 5, offset: 37961},
+						pos: position{line: 1587, col: 5, offset: 38095},
 						run: (*parser).callonPostgreSQLPrimitiveType6,
 						expr: &litMatcher{
-							pos:        position{line: 1580, col: 5, offset: 37961},
+							pos:        position{line: 1587, col: 5, offset: 38095},
 							val:        "bytea",
 							ignoreCase: true,
 							want:       "\"bytea\"i",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1581, col: 5, offset: 38010},
+						pos: position{line: 1588, col: 5, offset: 38144},
 						run: (*parser).callonPostgreSQLPrimitiveType8,
 						expr: &seqExpr{
-							pos: position{line: 1581, col: 5, offset: 38010},
+							pos: position{line: 1588, col: 5, offset: 38144},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1581, col: 5, offset: 38010},
+									pos:        position{line: 1588, col: 5, offset: 38144},
 									val:        "char",
 									ignoreCase: true,
 									want:       "\"char\"i",
 								},
 								&notExpr{
-									pos: position{line: 1581, col: 13, offset: 38018},
+									pos: position{line: 1588, col: 13, offset: 38152},
 									expr: &litMatcher{
-										pos:        position{line: 1581, col: 14, offset: 38019},
+										pos:        position{line: 1588, col: 14, offset: 38153},
 										val:        "a",
 										ignoreCase: true,
 										want:       "\"a\"i",
@@ -10126,61 +10151,61 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1582, col: 5, offset: 38060},
+						pos: position{line: 1589, col: 5, offset: 38194},
 						run: (*parser).callonPostgreSQLPrimitiveType13,
 						expr: &litMatcher{
-							pos:        position{line: 1582, col: 5, offset: 38060},
+							pos:        position{line: 1589, col: 5, offset: 38194},
 							val:        "character varying",
 							ignoreCase: true,
 							want:       "\"character varying\"i",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1583, col: 5, offset: 38110},
+						pos: position{line: 1590, col: 5, offset: 38244},
 						run: (*parser).callonPostgreSQLPrimitiveType15,
 						expr: &litMatcher{
-							pos:        position{line: 1583, col: 5, offset: 38110},
+							pos:        position{line: 1590, col: 5, offset: 38244},
 							val:        "character",
 							ignoreCase: true,
 							want:       "\"character\"i",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1584, col: 5, offset: 38160},
+						pos: position{line: 1591, col: 5, offset: 38294},
 						run: (*parser).callonPostgreSQLPrimitiveType17,
 						expr: &litMatcher{
-							pos:        position{line: 1584, col: 5, offset: 38160},
+							pos:        position{line: 1591, col: 5, offset: 38294},
 							val:        "cidr",
 							ignoreCase: true,
 							want:       "\"cidr\"i",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1585, col: 5, offset: 38207},
+						pos: position{line: 1592, col: 5, offset: 38341},
 						run: (*parser).callonPostgreSQLPrimitiveType19,
 						expr: &litMatcher{
-							pos:        position{line: 1585, col: 5, offset: 38207},
+							pos:        position{line: 1592, col: 5, offset: 38341},
 							val:        "double precision",
 							ignoreCase: true,
 							want:       "\"double precision\"i",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1586, col: 5, offset: 38258},
+						pos: position{line: 1593, col: 5, offset: 38392},
 						run: (*parser).callonPostgreSQLPrimitiveType21,
 						expr: &seqExpr{
-							pos: position{line: 1586, col: 5, offset: 38258},
+							pos: position{line: 1593, col: 5, offset: 38392},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1586, col: 5, offset: 38258},
+									pos:        position{line: 1593, col: 5, offset: 38392},
 									val:        "float",
 									ignoreCase: true,
 									want:       "\"float\"i",
 								},
 								&notExpr{
-									pos: position{line: 1586, col: 14, offset: 38267},
+									pos: position{line: 1593, col: 14, offset: 38401},
 									expr: &charClassMatcher{
-										pos:        position{line: 1586, col: 15, offset: 38268},
+										pos:        position{line: 1593, col: 15, offset: 38402},
 										val:        "[136]",
 										chars:      []rune{'1', '3', '6'},
 										ignoreCase: false,
@@ -10191,31 +10216,31 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1587, col: 5, offset: 38309},
+						pos: position{line: 1594, col: 5, offset: 38443},
 						run: (*parser).callonPostgreSQLPrimitiveType26,
 						expr: &litMatcher{
-							pos:        position{line: 1587, col: 5, offset: 38309},
+							pos:        position{line: 1594, col: 5, offset: 38443},
 							val:        "inet",
 							ignoreCase: true,
 							want:       "\"inet\"i",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1588, col: 5, offset: 38355},
+						pos: position{line: 1595, col: 5, offset: 38489},
 						run: (*parser).callonPostgreSQLPrimitiveType28,
 						expr: &seqExpr{
-							pos: position{line: 1588, col: 5, offset: 38355},
+							pos: position{line: 1595, col: 5, offset: 38489},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1588, col: 5, offset: 38355},
+									pos:        position{line: 1595, col: 5, offset: 38489},
 									val:        "int",
 									ignoreCase: true,
 									want:       "\"int\"i",
 								},
 								&notExpr{
-									pos: position{line: 1588, col: 12, offset: 38362},
+									pos: position{line: 1595, col: 12, offset: 38496},
 									expr: &charClassMatcher{
-										pos:        position{line: 1588, col: 13, offset: 38363},
+										pos:        position{line: 1595, col: 13, offset: 38497},
 										val:        "[1368e]i",
 										chars:      []rune{'1', '3', '6', '8', 'e'},
 										ignoreCase: true,
@@ -10226,60 +10251,60 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1589, col: 5, offset: 38404},
+						pos: position{line: 1596, col: 5, offset: 38538},
 						run: (*parser).callonPostgreSQLPrimitiveType33,
 						expr: &litMatcher{
-							pos:        position{line: 1589, col: 5, offset: 38404},
+							pos:        position{line: 1596, col: 5, offset: 38538},
 							val:        "integer",
 							ignoreCase: true,
 							want:       "\"integer\"i",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1590, col: 5, offset: 38453},
+						pos: position{line: 1597, col: 5, offset: 38587},
 						run: (*parser).callonPostgreSQLPrimitiveType35,
 						expr: &litMatcher{
-							pos:        position{line: 1590, col: 5, offset: 38453},
+							pos:        position{line: 1597, col: 5, offset: 38587},
 							val:        "interval",
 							ignoreCase: true,
 							want:       "\"interval\"i",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1591, col: 5, offset: 38505},
+						pos: position{line: 1598, col: 5, offset: 38639},
 						run: (*parser).callonPostgreSQLPrimitiveType37,
 						expr: &litMatcher{
-							pos:        position{line: 1591, col: 5, offset: 38505},
+							pos:        position{line: 1598, col: 5, offset: 38639},
 							val:        "real",
 							ignoreCase: true,
 							want:       "\"real\"i",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1592, col: 5, offset: 38556},
+						pos: position{line: 1599, col: 5, offset: 38690},
 						run: (*parser).callonPostgreSQLPrimitiveType39,
 						expr: &litMatcher{
-							pos:        position{line: 1592, col: 5, offset: 38556},
+							pos:        position{line: 1599, col: 5, offset: 38690},
 							val:        "smallint",
 							ignoreCase: true,
 							want:       "\"smallint\"i",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1593, col: 5, offset: 38605},
+						pos: position{line: 1600, col: 5, offset: 38739},
 						run: (*parser).callonPostgreSQLPrimitiveType41,
 						expr: &litMatcher{
-							pos:        position{line: 1593, col: 5, offset: 38605},
+							pos:        position{line: 1600, col: 5, offset: 38739},
 							val:        "text",
 							ignoreCase: true,
 							want:       "\"text\"i",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1594, col: 5, offset: 38655},
+						pos: position{line: 1601, col: 5, offset: 38789},
 						run: (*parser).callonPostgreSQLPrimitiveType43,
 						expr: &litMatcher{
-							pos:        position{line: 1594, col: 5, offset: 38655},
+							pos:        position{line: 1601, col: 5, offset: 38789},
 							val:        "varchar",
 							ignoreCase: true,
 							want:       "\"varchar\"i",
@@ -10292,31 +10317,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1596, col: 1, offset: 38702},
+			pos:  position{line: 1603, col: 1, offset: 38836},
 			expr: &choiceExpr{
-				pos: position{line: 1597, col: 5, offset: 38720},
+				pos: position{line: 1604, col: 5, offset: 38854},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1597, col: 5, offset: 38720},
+						pos: position{line: 1604, col: 5, offset: 38854},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1597, col: 5, offset: 38720},
+							pos: position{line: 1604, col: 5, offset: 38854},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1597, col: 5, offset: 38720},
+									pos:   position{line: 1604, col: 5, offset: 38854},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1597, col: 11, offset: 38726},
+										pos:  position{line: 1604, col: 11, offset: 38860},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1597, col: 21, offset: 38736},
+									pos:   position{line: 1604, col: 21, offset: 38870},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1597, col: 26, offset: 38741},
+										pos: position{line: 1604, col: 26, offset: 38875},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1597, col: 26, offset: 38741},
+											pos:  position{line: 1604, col: 26, offset: 38875},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -10325,10 +10350,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1600, col: 5, offset: 38807},
+						pos: position{line: 1607, col: 5, offset: 38941},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1600, col: 5, offset: 38807},
+							pos:        position{line: 1607, col: 5, offset: 38941},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -10341,32 +10366,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1602, col: 1, offset: 38831},
+			pos:  position{line: 1609, col: 1, offset: 38965},
 			expr: &actionExpr{
-				pos: position{line: 1602, col: 21, offset: 38851},
+				pos: position{line: 1609, col: 21, offset: 38985},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1602, col: 21, offset: 38851},
+					pos: position{line: 1609, col: 21, offset: 38985},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1602, col: 21, offset: 38851},
+							pos:  position{line: 1609, col: 21, offset: 38985},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1602, col: 24, offset: 38854},
+							pos:        position{line: 1609, col: 24, offset: 38988},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1602, col: 28, offset: 38858},
+							pos:  position{line: 1609, col: 28, offset: 38992},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1602, col: 31, offset: 38861},
+							pos:   position{line: 1609, col: 31, offset: 38995},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1602, col: 35, offset: 38865},
+								pos:  position{line: 1609, col: 35, offset: 38999},
 								name: "TypeField",
 							},
 						},
@@ -10378,40 +10403,40 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1604, col: 1, offset: 38896},
+			pos:  position{line: 1611, col: 1, offset: 39030},
 			expr: &actionExpr{
-				pos: position{line: 1605, col: 5, offset: 38910},
+				pos: position{line: 1612, col: 5, offset: 39044},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1605, col: 5, offset: 38910},
+					pos: position{line: 1612, col: 5, offset: 39044},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1605, col: 5, offset: 38910},
+							pos:   position{line: 1612, col: 5, offset: 39044},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1605, col: 10, offset: 38915},
+								pos:  position{line: 1612, col: 10, offset: 39049},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1605, col: 15, offset: 38920},
+							pos:  position{line: 1612, col: 15, offset: 39054},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1605, col: 18, offset: 38923},
+							pos:        position{line: 1612, col: 18, offset: 39057},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1605, col: 22, offset: 38927},
+							pos:  position{line: 1612, col: 22, offset: 39061},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1605, col: 25, offset: 38930},
+							pos:   position{line: 1612, col: 25, offset: 39064},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1605, col: 29, offset: 38934},
+								pos:  position{line: 1612, col: 29, offset: 39068},
 								name: "Type",
 							},
 						},
@@ -10423,26 +10448,26 @@ var g = &grammar{
 		},
 		{
 			name: "Name",
-			pos:  position{line: 1613, col: 1, offset: 39083},
+			pos:  position{line: 1620, col: 1, offset: 39217},
 			expr: &actionExpr{
-				pos: position{line: 1614, col: 4, offset: 39091},
+				pos: position{line: 1621, col: 4, offset: 39225},
 				run: (*parser).callonName1,
 				expr: &labeledExpr{
-					pos:   position{line: 1614, col: 4, offset: 39091},
+					pos:   position{line: 1621, col: 4, offset: 39225},
 					label: "s",
 					expr: &choiceExpr{
-						pos: position{line: 1614, col: 7, offset: 39094},
+						pos: position{line: 1621, col: 7, offset: 39228},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1614, col: 7, offset: 39094},
+								pos:  position{line: 1621, col: 7, offset: 39228},
 								name: "IdentifierName",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1614, col: 24, offset: 39111},
+								pos:  position{line: 1621, col: 24, offset: 39245},
 								name: "DoubleQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1614, col: 45, offset: 39132},
+								pos:  position{line: 1621, col: 45, offset: 39266},
 								name: "SingleQuotedString",
 							},
 						},
@@ -10454,51 +10479,51 @@ var g = &grammar{
 		},
 		{
 			name: "Names",
-			pos:  position{line: 1618, col: 1, offset: 39232},
+			pos:  position{line: 1625, col: 1, offset: 39366},
 			expr: &actionExpr{
-				pos: position{line: 1619, col: 5, offset: 39242},
+				pos: position{line: 1626, col: 5, offset: 39376},
 				run: (*parser).callonNames1,
 				expr: &seqExpr{
-					pos: position{line: 1619, col: 5, offset: 39242},
+					pos: position{line: 1626, col: 5, offset: 39376},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1619, col: 5, offset: 39242},
+							pos:   position{line: 1626, col: 5, offset: 39376},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1619, col: 11, offset: 39248},
+								pos:  position{line: 1626, col: 11, offset: 39382},
 								name: "Name",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1619, col: 16, offset: 39253},
+							pos:   position{line: 1626, col: 16, offset: 39387},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1619, col: 21, offset: 39258},
+								pos: position{line: 1626, col: 21, offset: 39392},
 								expr: &actionExpr{
-									pos: position{line: 1619, col: 22, offset: 39259},
+									pos: position{line: 1626, col: 22, offset: 39393},
 									run: (*parser).callonNames7,
 									expr: &seqExpr{
-										pos: position{line: 1619, col: 22, offset: 39259},
+										pos: position{line: 1626, col: 22, offset: 39393},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1619, col: 22, offset: 39259},
+												pos:  position{line: 1626, col: 22, offset: 39393},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1619, col: 25, offset: 39262},
+												pos:        position{line: 1626, col: 25, offset: 39396},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1619, col: 29, offset: 39266},
+												pos:  position{line: 1626, col: 29, offset: 39400},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1619, col: 32, offset: 39269},
+												pos:   position{line: 1626, col: 32, offset: 39403},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1619, col: 37, offset: 39274},
+													pos:  position{line: 1626, col: 37, offset: 39408},
 													name: "Name",
 												},
 											},
@@ -10515,15 +10540,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1623, col: 1, offset: 39346},
+			pos:  position{line: 1630, col: 1, offset: 39480},
 			expr: &actionExpr{
-				pos: position{line: 1624, col: 5, offset: 39361},
+				pos: position{line: 1631, col: 5, offset: 39495},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1624, col: 5, offset: 39361},
+					pos:   position{line: 1631, col: 5, offset: 39495},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1624, col: 8, offset: 39364},
+						pos:  position{line: 1631, col: 8, offset: 39498},
 						name: "IdentifierName",
 					},
 				},
@@ -10533,51 +10558,51 @@ var g = &grammar{
 		},
 		{
 			name: "Identifiers",
-			pos:  position{line: 1631, col: 1, offset: 39475},
+			pos:  position{line: 1638, col: 1, offset: 39609},
 			expr: &actionExpr{
-				pos: position{line: 1632, col: 5, offset: 39491},
+				pos: position{line: 1639, col: 5, offset: 39625},
 				run: (*parser).callonIdentifiers1,
 				expr: &seqExpr{
-					pos: position{line: 1632, col: 5, offset: 39491},
+					pos: position{line: 1639, col: 5, offset: 39625},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1632, col: 5, offset: 39491},
+							pos:   position{line: 1639, col: 5, offset: 39625},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1632, col: 11, offset: 39497},
+								pos:  position{line: 1639, col: 11, offset: 39631},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1632, col: 22, offset: 39508},
+							pos:   position{line: 1639, col: 22, offset: 39642},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1632, col: 27, offset: 39513},
+								pos: position{line: 1639, col: 27, offset: 39647},
 								expr: &actionExpr{
-									pos: position{line: 1632, col: 28, offset: 39514},
+									pos: position{line: 1639, col: 28, offset: 39648},
 									run: (*parser).callonIdentifiers7,
 									expr: &seqExpr{
-										pos: position{line: 1632, col: 28, offset: 39514},
+										pos: position{line: 1639, col: 28, offset: 39648},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1632, col: 28, offset: 39514},
+												pos:  position{line: 1639, col: 28, offset: 39648},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1632, col: 31, offset: 39517},
+												pos:        position{line: 1639, col: 31, offset: 39651},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1632, col: 35, offset: 39521},
+												pos:  position{line: 1639, col: 35, offset: 39655},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1632, col: 38, offset: 39524},
+												pos:   position{line: 1639, col: 38, offset: 39658},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1632, col: 43, offset: 39529},
+													pos:  position{line: 1639, col: 43, offset: 39663},
 													name: "Identifier",
 												},
 											},
@@ -10594,22 +10619,22 @@ var g = &grammar{
 		},
 		{
 			name: "SQLIdentifier",
-			pos:  position{line: 1636, col: 1, offset: 39607},
+			pos:  position{line: 1643, col: 1, offset: 39741},
 			expr: &choiceExpr{
-				pos: position{line: 1637, col: 5, offset: 39625},
+				pos: position{line: 1644, col: 5, offset: 39759},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1637, col: 5, offset: 39625},
+						pos:  position{line: 1644, col: 5, offset: 39759},
 						name: "Identifier",
 					},
 					&actionExpr{
-						pos: position{line: 1638, col: 5, offset: 39640},
+						pos: position{line: 1645, col: 5, offset: 39774},
 						run: (*parser).callonSQLIdentifier3,
 						expr: &labeledExpr{
-							pos:   position{line: 1638, col: 5, offset: 39640},
+							pos:   position{line: 1645, col: 5, offset: 39774},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1638, col: 7, offset: 39642},
+								pos:  position{line: 1645, col: 7, offset: 39776},
 								name: "DoubleQuotedString",
 							},
 						},
@@ -10621,29 +10646,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1640, col: 1, offset: 39716},
+			pos:  position{line: 1647, col: 1, offset: 39850},
 			expr: &choiceExpr{
-				pos: position{line: 1641, col: 5, offset: 39735},
+				pos: position{line: 1648, col: 5, offset: 39869},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1641, col: 5, offset: 39735},
+						pos: position{line: 1648, col: 5, offset: 39869},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1641, col: 5, offset: 39735},
+							pos: position{line: 1648, col: 5, offset: 39869},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1641, col: 5, offset: 39735},
+									pos: position{line: 1648, col: 5, offset: 39869},
 									expr: &seqExpr{
-										pos: position{line: 1641, col: 7, offset: 39737},
+										pos: position{line: 1648, col: 7, offset: 39871},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1641, col: 7, offset: 39737},
+												pos:  position{line: 1648, col: 7, offset: 39871},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1641, col: 15, offset: 39745},
+												pos: position{line: 1648, col: 15, offset: 39879},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1641, col: 16, offset: 39746},
+													pos:  position{line: 1648, col: 16, offset: 39880},
 													name: "IdentifierRest",
 												},
 											},
@@ -10651,13 +10676,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1641, col: 32, offset: 39762},
+									pos:  position{line: 1648, col: 32, offset: 39896},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1641, col: 48, offset: 39778},
+									pos: position{line: 1648, col: 48, offset: 39912},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1641, col: 48, offset: 39778},
+										pos:  position{line: 1648, col: 48, offset: 39912},
 										name: "IdentifierRest",
 									},
 								},
@@ -10665,7 +10690,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1642, col: 5, offset: 39829},
+						pos:  position{line: 1649, col: 5, offset: 39963},
 						name: "BacktickString",
 					},
 				},
@@ -10675,22 +10700,22 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1644, col: 1, offset: 39845},
+			pos:  position{line: 1651, col: 1, offset: 39979},
 			expr: &choiceExpr{
-				pos: position{line: 1645, col: 5, offset: 39865},
+				pos: position{line: 1652, col: 5, offset: 39999},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1645, col: 5, offset: 39865},
+						pos:  position{line: 1652, col: 5, offset: 39999},
 						name: "UnicodeLetter",
 					},
 					&litMatcher{
-						pos:        position{line: 1646, col: 5, offset: 39883},
+						pos:        position{line: 1653, col: 5, offset: 40017},
 						val:        "$",
 						ignoreCase: false,
 						want:       "\"$\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1647, col: 5, offset: 39891},
+						pos:        position{line: 1654, col: 5, offset: 40025},
 						val:        "_",
 						ignoreCase: false,
 						want:       "\"_\"",
@@ -10702,24 +10727,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1649, col: 1, offset: 39896},
+			pos:  position{line: 1656, col: 1, offset: 40030},
 			expr: &choiceExpr{
-				pos: position{line: 1650, col: 5, offset: 39915},
+				pos: position{line: 1657, col: 5, offset: 40049},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1650, col: 5, offset: 39915},
+						pos:  position{line: 1657, col: 5, offset: 40049},
 						name: "IdentifierStart",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1651, col: 5, offset: 39935},
+						pos:  position{line: 1658, col: 5, offset: 40069},
 						name: "UnicodeCombiningMark",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1652, col: 5, offset: 39960},
+						pos:  position{line: 1659, col: 5, offset: 40094},
 						name: "UnicodeDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1653, col: 5, offset: 39977},
+						pos:  position{line: 1660, col: 5, offset: 40111},
 						name: "UnicodeConnectorPunctuation",
 					},
 				},
@@ -10729,24 +10754,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1655, col: 1, offset: 40006},
+			pos:  position{line: 1662, col: 1, offset: 40140},
 			expr: &choiceExpr{
-				pos: position{line: 1656, col: 5, offset: 40018},
+				pos: position{line: 1663, col: 5, offset: 40152},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1656, col: 5, offset: 40018},
+						pos:  position{line: 1663, col: 5, offset: 40152},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1657, col: 5, offset: 40037},
+						pos:  position{line: 1664, col: 5, offset: 40171},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1658, col: 5, offset: 40053},
+						pos:  position{line: 1665, col: 5, offset: 40187},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1659, col: 5, offset: 40061},
+						pos:  position{line: 1666, col: 5, offset: 40195},
 						name: "Infinity",
 					},
 				},
@@ -10756,25 +10781,25 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1661, col: 1, offset: 40071},
+			pos:  position{line: 1668, col: 1, offset: 40205},
 			expr: &actionExpr{
-				pos: position{line: 1662, col: 5, offset: 40080},
+				pos: position{line: 1669, col: 5, offset: 40214},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1662, col: 5, offset: 40080},
+					pos: position{line: 1669, col: 5, offset: 40214},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1662, col: 5, offset: 40080},
+							pos:  position{line: 1669, col: 5, offset: 40214},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1662, col: 14, offset: 40089},
+							pos:        position{line: 1669, col: 14, offset: 40223},
 							val:        "T",
 							ignoreCase: false,
 							want:       "\"T\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1662, col: 18, offset: 40093},
+							pos:  position{line: 1669, col: 18, offset: 40227},
 							name: "FullTime",
 						},
 					},
@@ -10785,32 +10810,32 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1666, col: 1, offset: 40169},
+			pos:  position{line: 1673, col: 1, offset: 40303},
 			expr: &seqExpr{
-				pos: position{line: 1666, col: 12, offset: 40180},
+				pos: position{line: 1673, col: 12, offset: 40314},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1666, col: 12, offset: 40180},
+						pos:  position{line: 1673, col: 12, offset: 40314},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1666, col: 15, offset: 40183},
+						pos:        position{line: 1673, col: 15, offset: 40317},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1666, col: 19, offset: 40187},
+						pos:  position{line: 1673, col: 19, offset: 40321},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1666, col: 22, offset: 40190},
+						pos:        position{line: 1673, col: 22, offset: 40324},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1666, col: 26, offset: 40194},
+						pos:  position{line: 1673, col: 26, offset: 40328},
 						name: "D2",
 					},
 				},
@@ -10820,33 +10845,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1668, col: 1, offset: 40198},
+			pos:  position{line: 1675, col: 1, offset: 40332},
 			expr: &seqExpr{
-				pos: position{line: 1668, col: 6, offset: 40203},
+				pos: position{line: 1675, col: 6, offset: 40337},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1668, col: 6, offset: 40203},
+						pos:        position{line: 1675, col: 6, offset: 40337},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1668, col: 11, offset: 40208},
+						pos:        position{line: 1675, col: 11, offset: 40342},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1668, col: 16, offset: 40213},
+						pos:        position{line: 1675, col: 16, offset: 40347},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1668, col: 21, offset: 40218},
+						pos:        position{line: 1675, col: 21, offset: 40352},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10859,19 +10884,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1669, col: 1, offset: 40224},
+			pos:  position{line: 1676, col: 1, offset: 40358},
 			expr: &seqExpr{
-				pos: position{line: 1669, col: 6, offset: 40229},
+				pos: position{line: 1676, col: 6, offset: 40363},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1669, col: 6, offset: 40229},
+						pos:        position{line: 1676, col: 6, offset: 40363},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1669, col: 11, offset: 40234},
+						pos:        position{line: 1676, col: 11, offset: 40368},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10884,16 +10909,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1671, col: 1, offset: 40241},
+			pos:  position{line: 1678, col: 1, offset: 40375},
 			expr: &seqExpr{
-				pos: position{line: 1671, col: 12, offset: 40252},
+				pos: position{line: 1678, col: 12, offset: 40386},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1671, col: 12, offset: 40252},
+						pos:  position{line: 1678, col: 12, offset: 40386},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1671, col: 24, offset: 40264},
+						pos:  position{line: 1678, col: 24, offset: 40398},
 						name: "TimeOffset",
 					},
 				},
@@ -10903,49 +10928,49 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1673, col: 1, offset: 40276},
+			pos:  position{line: 1680, col: 1, offset: 40410},
 			expr: &seqExpr{
-				pos: position{line: 1673, col: 15, offset: 40290},
+				pos: position{line: 1680, col: 15, offset: 40424},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1673, col: 15, offset: 40290},
+						pos:  position{line: 1680, col: 15, offset: 40424},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1673, col: 18, offset: 40293},
+						pos:        position{line: 1680, col: 18, offset: 40427},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1673, col: 22, offset: 40297},
+						pos:  position{line: 1680, col: 22, offset: 40431},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1673, col: 25, offset: 40300},
+						pos:        position{line: 1680, col: 25, offset: 40434},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1673, col: 29, offset: 40304},
+						pos:  position{line: 1680, col: 29, offset: 40438},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1673, col: 32, offset: 40307},
+						pos: position{line: 1680, col: 32, offset: 40441},
 						expr: &seqExpr{
-							pos: position{line: 1673, col: 33, offset: 40308},
+							pos: position{line: 1680, col: 33, offset: 40442},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1673, col: 33, offset: 40308},
+									pos:        position{line: 1680, col: 33, offset: 40442},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1673, col: 37, offset: 40312},
+									pos: position{line: 1680, col: 37, offset: 40446},
 									expr: &charClassMatcher{
-										pos:        position{line: 1673, col: 37, offset: 40312},
+										pos:        position{line: 1680, col: 37, offset: 40446},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10962,30 +10987,30 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1675, col: 1, offset: 40322},
+			pos:  position{line: 1682, col: 1, offset: 40456},
 			expr: &choiceExpr{
-				pos: position{line: 1676, col: 5, offset: 40337},
+				pos: position{line: 1683, col: 5, offset: 40471},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1676, col: 5, offset: 40337},
+						pos:        position{line: 1683, col: 5, offset: 40471},
 						val:        "Z",
 						ignoreCase: false,
 						want:       "\"Z\"",
 					},
 					&seqExpr{
-						pos: position{line: 1677, col: 5, offset: 40345},
+						pos: position{line: 1684, col: 5, offset: 40479},
 						exprs: []any{
 							&choiceExpr{
-								pos: position{line: 1677, col: 6, offset: 40346},
+								pos: position{line: 1684, col: 6, offset: 40480},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 1677, col: 6, offset: 40346},
+										pos:        position{line: 1684, col: 6, offset: 40480},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1677, col: 12, offset: 40352},
+										pos:        position{line: 1684, col: 12, offset: 40486},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
@@ -10993,34 +11018,34 @@ var g = &grammar{
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1677, col: 17, offset: 40357},
+								pos:  position{line: 1684, col: 17, offset: 40491},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1677, col: 20, offset: 40360},
+								pos:        position{line: 1684, col: 20, offset: 40494},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1677, col: 24, offset: 40364},
+								pos:  position{line: 1684, col: 24, offset: 40498},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1677, col: 27, offset: 40367},
+								pos: position{line: 1684, col: 27, offset: 40501},
 								expr: &seqExpr{
-									pos: position{line: 1677, col: 28, offset: 40368},
+									pos: position{line: 1684, col: 28, offset: 40502},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 1677, col: 28, offset: 40368},
+											pos:        position{line: 1684, col: 28, offset: 40502},
 											val:        ".",
 											ignoreCase: false,
 											want:       "\".\"",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1677, col: 32, offset: 40372},
+											pos: position{line: 1684, col: 32, offset: 40506},
 											expr: &charClassMatcher{
-												pos:        position{line: 1677, col: 32, offset: 40372},
+												pos:        position{line: 1684, col: 32, offset: 40506},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -11039,33 +11064,33 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1679, col: 1, offset: 40382},
+			pos:  position{line: 1686, col: 1, offset: 40516},
 			expr: &actionExpr{
-				pos: position{line: 1680, col: 5, offset: 40395},
+				pos: position{line: 1687, col: 5, offset: 40529},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1680, col: 5, offset: 40395},
+					pos: position{line: 1687, col: 5, offset: 40529},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 1680, col: 5, offset: 40395},
+							pos: position{line: 1687, col: 5, offset: 40529},
 							expr: &litMatcher{
-								pos:        position{line: 1680, col: 5, offset: 40395},
+								pos:        position{line: 1687, col: 5, offset: 40529},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1680, col: 10, offset: 40400},
+							pos: position{line: 1687, col: 10, offset: 40534},
 							expr: &seqExpr{
-								pos: position{line: 1680, col: 11, offset: 40401},
+								pos: position{line: 1687, col: 11, offset: 40535},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1680, col: 11, offset: 40401},
+										pos:  position{line: 1687, col: 11, offset: 40535},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1680, col: 19, offset: 40409},
+										pos:  position{line: 1687, col: 19, offset: 40543},
 										name: "TimeUnit",
 									},
 								},
@@ -11079,27 +11104,27 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1684, col: 1, offset: 40491},
+			pos:  position{line: 1691, col: 1, offset: 40625},
 			expr: &seqExpr{
-				pos: position{line: 1684, col: 11, offset: 40501},
+				pos: position{line: 1691, col: 11, offset: 40635},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1684, col: 11, offset: 40501},
+						pos:  position{line: 1691, col: 11, offset: 40635},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1684, col: 16, offset: 40506},
+						pos: position{line: 1691, col: 16, offset: 40640},
 						expr: &seqExpr{
-							pos: position{line: 1684, col: 17, offset: 40507},
+							pos: position{line: 1691, col: 17, offset: 40641},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1684, col: 17, offset: 40507},
+									pos:        position{line: 1691, col: 17, offset: 40641},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1684, col: 21, offset: 40511},
+									pos:  position{line: 1691, col: 21, offset: 40645},
 									name: "UInt",
 								},
 							},
@@ -11112,60 +11137,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1686, col: 1, offset: 40519},
+			pos:  position{line: 1693, col: 1, offset: 40653},
 			expr: &choiceExpr{
-				pos: position{line: 1687, col: 5, offset: 40532},
+				pos: position{line: 1694, col: 5, offset: 40666},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1687, col: 5, offset: 40532},
+						pos:        position{line: 1694, col: 5, offset: 40666},
 						val:        "ns",
 						ignoreCase: false,
 						want:       "\"ns\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1688, col: 5, offset: 40541},
+						pos:        position{line: 1695, col: 5, offset: 40675},
 						val:        "us",
 						ignoreCase: false,
 						want:       "\"us\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1689, col: 5, offset: 40550},
+						pos:        position{line: 1696, col: 5, offset: 40684},
 						val:        "ms",
 						ignoreCase: false,
 						want:       "\"ms\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1690, col: 5, offset: 40559},
+						pos:        position{line: 1697, col: 5, offset: 40693},
 						val:        "s",
 						ignoreCase: false,
 						want:       "\"s\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1691, col: 5, offset: 40567},
+						pos:        position{line: 1698, col: 5, offset: 40701},
 						val:        "m",
 						ignoreCase: false,
 						want:       "\"m\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1692, col: 5, offset: 40575},
+						pos:        position{line: 1699, col: 5, offset: 40709},
 						val:        "h",
 						ignoreCase: false,
 						want:       "\"h\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1693, col: 5, offset: 40583},
+						pos:        position{line: 1700, col: 5, offset: 40717},
 						val:        "d",
 						ignoreCase: false,
 						want:       "\"d\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1694, col: 5, offset: 40591},
+						pos:        position{line: 1701, col: 5, offset: 40725},
 						val:        "w",
 						ignoreCase: false,
 						want:       "\"w\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1695, col: 5, offset: 40599},
+						pos:        position{line: 1702, col: 5, offset: 40733},
 						val:        "y",
 						ignoreCase: false,
 						want:       "\"y\"",
@@ -11177,45 +11202,45 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1697, col: 1, offset: 40604},
+			pos:  position{line: 1704, col: 1, offset: 40738},
 			expr: &actionExpr{
-				pos: position{line: 1698, col: 5, offset: 40611},
+				pos: position{line: 1705, col: 5, offset: 40745},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1698, col: 5, offset: 40611},
+					pos: position{line: 1705, col: 5, offset: 40745},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1698, col: 5, offset: 40611},
+							pos:  position{line: 1705, col: 5, offset: 40745},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1698, col: 10, offset: 40616},
+							pos:        position{line: 1705, col: 10, offset: 40750},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1698, col: 14, offset: 40620},
+							pos:  position{line: 1705, col: 14, offset: 40754},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1698, col: 19, offset: 40625},
+							pos:        position{line: 1705, col: 19, offset: 40759},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1698, col: 23, offset: 40629},
+							pos:  position{line: 1705, col: 23, offset: 40763},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1698, col: 28, offset: 40634},
+							pos:        position{line: 1705, col: 28, offset: 40768},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1698, col: 32, offset: 40638},
+							pos:  position{line: 1705, col: 32, offset: 40772},
 							name: "UInt",
 						},
 					},
@@ -11226,43 +11251,43 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1700, col: 1, offset: 40675},
+			pos:  position{line: 1707, col: 1, offset: 40809},
 			expr: &actionExpr{
-				pos: position{line: 1701, col: 5, offset: 40683},
+				pos: position{line: 1708, col: 5, offset: 40817},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1701, col: 5, offset: 40683},
+					pos: position{line: 1708, col: 5, offset: 40817},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1701, col: 5, offset: 40683},
+							pos: position{line: 1708, col: 5, offset: 40817},
 							expr: &seqExpr{
-								pos: position{line: 1701, col: 7, offset: 40685},
+								pos: position{line: 1708, col: 7, offset: 40819},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1701, col: 7, offset: 40685},
+										pos:  position{line: 1708, col: 7, offset: 40819},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1701, col: 11, offset: 40689},
+										pos:        position{line: 1708, col: 11, offset: 40823},
 										val:        ":",
 										ignoreCase: false,
 										want:       "\":\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1701, col: 15, offset: 40693},
+										pos:  position{line: 1708, col: 15, offset: 40827},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1701, col: 19, offset: 40697},
+										pos: position{line: 1708, col: 19, offset: 40831},
 										expr: &choiceExpr{
-											pos: position{line: 1701, col: 21, offset: 40699},
+											pos: position{line: 1708, col: 21, offset: 40833},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1701, col: 21, offset: 40699},
+													pos:  position{line: 1708, col: 21, offset: 40833},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1701, col: 32, offset: 40710},
+													pos:        position{line: 1708, col: 32, offset: 40844},
 													val:        ":",
 													ignoreCase: false,
 													want:       "\":\"",
@@ -11274,10 +11299,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1701, col: 38, offset: 40716},
+							pos:   position{line: 1708, col: 38, offset: 40850},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1701, col: 40, offset: 40718},
+								pos:  position{line: 1708, col: 40, offset: 40852},
 								name: "IP6Variations",
 							},
 						},
@@ -11289,32 +11314,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1705, col: 1, offset: 40882},
+			pos:  position{line: 1712, col: 1, offset: 41016},
 			expr: &choiceExpr{
-				pos: position{line: 1706, col: 5, offset: 40900},
+				pos: position{line: 1713, col: 5, offset: 41034},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1706, col: 5, offset: 40900},
+						pos: position{line: 1713, col: 5, offset: 41034},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1706, col: 5, offset: 40900},
+							pos: position{line: 1713, col: 5, offset: 41034},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1706, col: 5, offset: 40900},
+									pos:   position{line: 1713, col: 5, offset: 41034},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1706, col: 7, offset: 40902},
+										pos: position{line: 1713, col: 7, offset: 41036},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1706, col: 7, offset: 40902},
+											pos:  position{line: 1713, col: 7, offset: 41036},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1706, col: 17, offset: 40912},
+									pos:   position{line: 1713, col: 17, offset: 41046},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1706, col: 19, offset: 40914},
+										pos:  position{line: 1713, col: 19, offset: 41048},
 										name: "IP6Tail",
 									},
 								},
@@ -11322,52 +11347,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1709, col: 5, offset: 40978},
+						pos: position{line: 1716, col: 5, offset: 41112},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1709, col: 5, offset: 40978},
+							pos: position{line: 1716, col: 5, offset: 41112},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1709, col: 5, offset: 40978},
+									pos:   position{line: 1716, col: 5, offset: 41112},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1709, col: 7, offset: 40980},
+										pos:  position{line: 1716, col: 7, offset: 41114},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1709, col: 11, offset: 40984},
+									pos:   position{line: 1716, col: 11, offset: 41118},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1709, col: 13, offset: 40986},
+										pos: position{line: 1716, col: 13, offset: 41120},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1709, col: 13, offset: 40986},
+											pos:  position{line: 1716, col: 13, offset: 41120},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1709, col: 23, offset: 40996},
+									pos:        position{line: 1716, col: 23, offset: 41130},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1709, col: 28, offset: 41001},
+									pos:   position{line: 1716, col: 28, offset: 41135},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1709, col: 30, offset: 41003},
+										pos: position{line: 1716, col: 30, offset: 41137},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1709, col: 30, offset: 41003},
+											pos:  position{line: 1716, col: 30, offset: 41137},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1709, col: 40, offset: 41013},
+									pos:   position{line: 1716, col: 40, offset: 41147},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1709, col: 42, offset: 41015},
+										pos:  position{line: 1716, col: 42, offset: 41149},
 										name: "IP6Tail",
 									},
 								},
@@ -11375,33 +11400,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1712, col: 5, offset: 41114},
+						pos: position{line: 1719, col: 5, offset: 41248},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1712, col: 5, offset: 41114},
+							pos: position{line: 1719, col: 5, offset: 41248},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1712, col: 5, offset: 41114},
+									pos:        position{line: 1719, col: 5, offset: 41248},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1712, col: 10, offset: 41119},
+									pos:   position{line: 1719, col: 10, offset: 41253},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1712, col: 12, offset: 41121},
+										pos: position{line: 1719, col: 12, offset: 41255},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1712, col: 12, offset: 41121},
+											pos:  position{line: 1719, col: 12, offset: 41255},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1712, col: 22, offset: 41131},
+									pos:   position{line: 1719, col: 22, offset: 41265},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1712, col: 24, offset: 41133},
+										pos:  position{line: 1719, col: 24, offset: 41267},
 										name: "IP6Tail",
 									},
 								},
@@ -11409,40 +11434,40 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1715, col: 5, offset: 41204},
+						pos: position{line: 1722, col: 5, offset: 41338},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1715, col: 5, offset: 41204},
+							pos: position{line: 1722, col: 5, offset: 41338},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1715, col: 5, offset: 41204},
+									pos:   position{line: 1722, col: 5, offset: 41338},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1715, col: 7, offset: 41206},
+										pos:  position{line: 1722, col: 7, offset: 41340},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1715, col: 11, offset: 41210},
+									pos:   position{line: 1722, col: 11, offset: 41344},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1715, col: 13, offset: 41212},
+										pos: position{line: 1722, col: 13, offset: 41346},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1715, col: 13, offset: 41212},
+											pos:  position{line: 1722, col: 13, offset: 41346},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1715, col: 23, offset: 41222},
+									pos:        position{line: 1722, col: 23, offset: 41356},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&notExpr{
-									pos: position{line: 1715, col: 28, offset: 41227},
+									pos: position{line: 1722, col: 28, offset: 41361},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1715, col: 29, offset: 41228},
+										pos:  position{line: 1722, col: 29, offset: 41362},
 										name: "TypeAsValue",
 									},
 								},
@@ -11450,10 +11475,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1718, col: 5, offset: 41303},
+						pos: position{line: 1725, col: 5, offset: 41437},
 						run: (*parser).callonIP6Variations40,
 						expr: &litMatcher{
-							pos:        position{line: 1718, col: 5, offset: 41303},
+							pos:        position{line: 1725, col: 5, offset: 41437},
 							val:        "::",
 							ignoreCase: false,
 							want:       "\"::\"",
@@ -11466,16 +11491,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1722, col: 1, offset: 41340},
+			pos:  position{line: 1729, col: 1, offset: 41474},
 			expr: &choiceExpr{
-				pos: position{line: 1723, col: 5, offset: 41352},
+				pos: position{line: 1730, col: 5, offset: 41486},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1723, col: 5, offset: 41352},
+						pos:  position{line: 1730, col: 5, offset: 41486},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1724, col: 5, offset: 41359},
+						pos:  position{line: 1731, col: 5, offset: 41493},
 						name: "Hex",
 					},
 				},
@@ -11485,24 +11510,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1726, col: 1, offset: 41364},
+			pos:  position{line: 1733, col: 1, offset: 41498},
 			expr: &actionExpr{
-				pos: position{line: 1726, col: 12, offset: 41375},
+				pos: position{line: 1733, col: 12, offset: 41509},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1726, col: 12, offset: 41375},
+					pos: position{line: 1733, col: 12, offset: 41509},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1726, col: 12, offset: 41375},
+							pos:        position{line: 1733, col: 12, offset: 41509},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1726, col: 16, offset: 41379},
+							pos:   position{line: 1733, col: 16, offset: 41513},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1726, col: 18, offset: 41381},
+								pos:  position{line: 1733, col: 18, offset: 41515},
 								name: "Hex",
 							},
 						},
@@ -11514,23 +11539,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1728, col: 1, offset: 41419},
+			pos:  position{line: 1735, col: 1, offset: 41553},
 			expr: &actionExpr{
-				pos: position{line: 1728, col: 12, offset: 41430},
+				pos: position{line: 1735, col: 12, offset: 41564},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1728, col: 12, offset: 41430},
+					pos: position{line: 1735, col: 12, offset: 41564},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1728, col: 12, offset: 41430},
+							pos:   position{line: 1735, col: 12, offset: 41564},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1728, col: 14, offset: 41432},
+								pos:  position{line: 1735, col: 14, offset: 41566},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1728, col: 18, offset: 41436},
+							pos:        position{line: 1735, col: 18, offset: 41570},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
@@ -11543,32 +11568,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1730, col: 1, offset: 41474},
+			pos:  position{line: 1737, col: 1, offset: 41608},
 			expr: &actionExpr{
-				pos: position{line: 1731, col: 5, offset: 41485},
+				pos: position{line: 1738, col: 5, offset: 41619},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1731, col: 5, offset: 41485},
+					pos: position{line: 1738, col: 5, offset: 41619},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1731, col: 5, offset: 41485},
+							pos:   position{line: 1738, col: 5, offset: 41619},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1731, col: 7, offset: 41487},
+								pos:  position{line: 1738, col: 7, offset: 41621},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1731, col: 10, offset: 41490},
+							pos:        position{line: 1738, col: 10, offset: 41624},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1731, col: 14, offset: 41494},
+							pos:   position{line: 1738, col: 14, offset: 41628},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1731, col: 16, offset: 41496},
+								pos:  position{line: 1738, col: 16, offset: 41630},
 								name: "UIntString",
 							},
 						},
@@ -11580,32 +11605,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1735, col: 1, offset: 41564},
+			pos:  position{line: 1742, col: 1, offset: 41698},
 			expr: &actionExpr{
-				pos: position{line: 1736, col: 5, offset: 41575},
+				pos: position{line: 1743, col: 5, offset: 41709},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1736, col: 5, offset: 41575},
+					pos: position{line: 1743, col: 5, offset: 41709},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1736, col: 5, offset: 41575},
+							pos:   position{line: 1743, col: 5, offset: 41709},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1736, col: 7, offset: 41577},
+								pos:  position{line: 1743, col: 7, offset: 41711},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1736, col: 11, offset: 41581},
+							pos:        position{line: 1743, col: 11, offset: 41715},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1736, col: 15, offset: 41585},
+							pos:   position{line: 1743, col: 15, offset: 41719},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1736, col: 17, offset: 41587},
+								pos:  position{line: 1743, col: 17, offset: 41721},
 								name: "UIntString",
 							},
 						},
@@ -11617,15 +11642,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1740, col: 1, offset: 41655},
+			pos:  position{line: 1747, col: 1, offset: 41789},
 			expr: &actionExpr{
-				pos: position{line: 1741, col: 4, offset: 41663},
+				pos: position{line: 1748, col: 4, offset: 41797},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1741, col: 4, offset: 41663},
+					pos:   position{line: 1748, col: 4, offset: 41797},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1741, col: 6, offset: 41665},
+						pos:  position{line: 1748, col: 6, offset: 41799},
 						name: "UIntString",
 					},
 				},
@@ -11635,16 +11660,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1743, col: 1, offset: 41705},
+			pos:  position{line: 1750, col: 1, offset: 41839},
 			expr: &choiceExpr{
-				pos: position{line: 1744, col: 5, offset: 41719},
+				pos: position{line: 1751, col: 5, offset: 41853},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1744, col: 5, offset: 41719},
+						pos:  position{line: 1751, col: 5, offset: 41853},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1745, col: 5, offset: 41734},
+						pos:  position{line: 1752, col: 5, offset: 41868},
 						name: "MinusIntString",
 					},
 				},
@@ -11654,14 +11679,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1747, col: 1, offset: 41750},
+			pos:  position{line: 1754, col: 1, offset: 41884},
 			expr: &actionExpr{
-				pos: position{line: 1747, col: 14, offset: 41763},
+				pos: position{line: 1754, col: 14, offset: 41897},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1747, col: 14, offset: 41763},
+					pos: position{line: 1754, col: 14, offset: 41897},
 					expr: &charClassMatcher{
-						pos:        position{line: 1747, col: 14, offset: 41763},
+						pos:        position{line: 1754, col: 14, offset: 41897},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11674,21 +11699,21 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1749, col: 1, offset: 41802},
+			pos:  position{line: 1756, col: 1, offset: 41936},
 			expr: &actionExpr{
-				pos: position{line: 1750, col: 5, offset: 41821},
+				pos: position{line: 1757, col: 5, offset: 41955},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1750, col: 5, offset: 41821},
+					pos: position{line: 1757, col: 5, offset: 41955},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1750, col: 5, offset: 41821},
+							pos:        position{line: 1757, col: 5, offset: 41955},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1750, col: 9, offset: 41825},
+							pos:  position{line: 1757, col: 9, offset: 41959},
 							name: "UIntString",
 						},
 					},
@@ -11699,29 +11724,29 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1752, col: 1, offset: 41868},
+			pos:  position{line: 1759, col: 1, offset: 42002},
 			expr: &choiceExpr{
-				pos: position{line: 1753, col: 5, offset: 41884},
+				pos: position{line: 1760, col: 5, offset: 42018},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1753, col: 5, offset: 41884},
+						pos: position{line: 1760, col: 5, offset: 42018},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1753, col: 5, offset: 41884},
+							pos: position{line: 1760, col: 5, offset: 42018},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1753, col: 5, offset: 41884},
+									pos: position{line: 1760, col: 5, offset: 42018},
 									expr: &litMatcher{
-										pos:        position{line: 1753, col: 5, offset: 41884},
+										pos:        position{line: 1760, col: 5, offset: 42018},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1753, col: 10, offset: 41889},
+									pos: position{line: 1760, col: 10, offset: 42023},
 									expr: &charClassMatcher{
-										pos:        position{line: 1753, col: 10, offset: 41889},
+										pos:        position{line: 1760, col: 10, offset: 42023},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11729,15 +11754,15 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1753, col: 17, offset: 41896},
+									pos:        position{line: 1760, col: 17, offset: 42030},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1753, col: 21, offset: 41900},
+									pos: position{line: 1760, col: 21, offset: 42034},
 									expr: &charClassMatcher{
-										pos:        position{line: 1753, col: 21, offset: 41900},
+										pos:        position{line: 1760, col: 21, offset: 42034},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11745,9 +11770,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1753, col: 28, offset: 41907},
+									pos: position{line: 1760, col: 28, offset: 42041},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1753, col: 28, offset: 41907},
+										pos:  position{line: 1760, col: 28, offset: 42041},
 										name: "ExponentPart",
 									},
 								},
@@ -11755,30 +11780,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1754, col: 5, offset: 41956},
+						pos: position{line: 1761, col: 5, offset: 42090},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1754, col: 5, offset: 41956},
+							pos: position{line: 1761, col: 5, offset: 42090},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1754, col: 5, offset: 41956},
+									pos: position{line: 1761, col: 5, offset: 42090},
 									expr: &litMatcher{
-										pos:        position{line: 1754, col: 5, offset: 41956},
+										pos:        position{line: 1761, col: 5, offset: 42090},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1754, col: 10, offset: 41961},
+									pos:        position{line: 1761, col: 10, offset: 42095},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1754, col: 14, offset: 41965},
+									pos: position{line: 1761, col: 14, offset: 42099},
 									expr: &charClassMatcher{
-										pos:        position{line: 1754, col: 14, offset: 41965},
+										pos:        position{line: 1761, col: 14, offset: 42099},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11786,9 +11811,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1754, col: 21, offset: 41972},
+									pos: position{line: 1761, col: 21, offset: 42106},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1754, col: 21, offset: 41972},
+										pos:  position{line: 1761, col: 21, offset: 42106},
 										name: "ExponentPart",
 									},
 								},
@@ -11796,17 +11821,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1755, col: 5, offset: 42021},
+						pos: position{line: 1762, col: 5, offset: 42155},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1755, col: 6, offset: 42022},
+							pos: position{line: 1762, col: 6, offset: 42156},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1755, col: 6, offset: 42022},
+									pos:  position{line: 1762, col: 6, offset: 42156},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1755, col: 12, offset: 42028},
+									pos:  position{line: 1762, col: 12, offset: 42162},
 									name: "Infinity",
 								},
 							},
@@ -11819,20 +11844,20 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1758, col: 1, offset: 42071},
+			pos:  position{line: 1765, col: 1, offset: 42205},
 			expr: &seqExpr{
-				pos: position{line: 1758, col: 16, offset: 42086},
+				pos: position{line: 1765, col: 16, offset: 42220},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1758, col: 16, offset: 42086},
+						pos:        position{line: 1765, col: 16, offset: 42220},
 						val:        "e",
 						ignoreCase: true,
 						want:       "\"e\"i",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1758, col: 21, offset: 42091},
+						pos: position{line: 1765, col: 21, offset: 42225},
 						expr: &charClassMatcher{
-							pos:        position{line: 1758, col: 21, offset: 42091},
+							pos:        position{line: 1765, col: 21, offset: 42225},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -11840,7 +11865,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1758, col: 27, offset: 42097},
+						pos:  position{line: 1765, col: 27, offset: 42231},
 						name: "UIntString",
 					},
 				},
@@ -11850,9 +11875,9 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1760, col: 1, offset: 42109},
+			pos:  position{line: 1767, col: 1, offset: 42243},
 			expr: &litMatcher{
-				pos:        position{line: 1760, col: 7, offset: 42115},
+				pos:        position{line: 1767, col: 7, offset: 42249},
 				val:        "NaN",
 				ignoreCase: false,
 				want:       "\"NaN\"",
@@ -11862,23 +11887,23 @@ var g = &grammar{
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1762, col: 1, offset: 42122},
+			pos:  position{line: 1769, col: 1, offset: 42256},
 			expr: &seqExpr{
-				pos: position{line: 1762, col: 12, offset: 42133},
+				pos: position{line: 1769, col: 12, offset: 42267},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 1762, col: 12, offset: 42133},
+						pos: position{line: 1769, col: 12, offset: 42267},
 						expr: &choiceExpr{
-							pos: position{line: 1762, col: 13, offset: 42134},
+							pos: position{line: 1769, col: 13, offset: 42268},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1762, col: 13, offset: 42134},
+									pos:        position{line: 1769, col: 13, offset: 42268},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1762, col: 19, offset: 42140},
+									pos:        position{line: 1769, col: 19, offset: 42274},
 									val:        "+",
 									ignoreCase: false,
 									want:       "\"+\"",
@@ -11887,7 +11912,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1762, col: 25, offset: 42146},
+						pos:        position{line: 1769, col: 25, offset: 42280},
 						val:        "Inf",
 						ignoreCase: false,
 						want:       "\"Inf\"",
@@ -11899,14 +11924,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1764, col: 1, offset: 42153},
+			pos:  position{line: 1771, col: 1, offset: 42287},
 			expr: &actionExpr{
-				pos: position{line: 1764, col: 7, offset: 42159},
+				pos: position{line: 1771, col: 7, offset: 42293},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1764, col: 7, offset: 42159},
+					pos: position{line: 1771, col: 7, offset: 42293},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1764, col: 7, offset: 42159},
+						pos:  position{line: 1771, col: 7, offset: 42293},
 						name: "HexDigit",
 					},
 				},
@@ -11916,9 +11941,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1766, col: 1, offset: 42201},
+			pos:  position{line: 1773, col: 1, offset: 42335},
 			expr: &charClassMatcher{
-				pos:        position{line: 1766, col: 12, offset: 42212},
+				pos:        position{line: 1773, col: 12, offset: 42346},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -11929,32 +11954,32 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedString",
-			pos:  position{line: 1768, col: 1, offset: 42225},
+			pos:  position{line: 1775, col: 1, offset: 42359},
 			expr: &actionExpr{
-				pos: position{line: 1769, col: 5, offset: 42248},
+				pos: position{line: 1776, col: 5, offset: 42382},
 				run: (*parser).callonSingleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1769, col: 5, offset: 42248},
+					pos: position{line: 1776, col: 5, offset: 42382},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1769, col: 5, offset: 42248},
+							pos:        position{line: 1776, col: 5, offset: 42382},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1769, col: 9, offset: 42252},
+							pos:   position{line: 1776, col: 9, offset: 42386},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1769, col: 11, offset: 42254},
+								pos: position{line: 1776, col: 11, offset: 42388},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1769, col: 11, offset: 42254},
+									pos:  position{line: 1776, col: 11, offset: 42388},
 									name: "SingleQuotedChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1769, col: 29, offset: 42272},
+							pos:        position{line: 1776, col: 29, offset: 42406},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
@@ -11967,32 +11992,32 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedString",
-			pos:  position{line: 1771, col: 1, offset: 42306},
+			pos:  position{line: 1778, col: 1, offset: 42440},
 			expr: &actionExpr{
-				pos: position{line: 1772, col: 5, offset: 42329},
+				pos: position{line: 1779, col: 5, offset: 42463},
 				run: (*parser).callonDoubleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1772, col: 5, offset: 42329},
+					pos: position{line: 1779, col: 5, offset: 42463},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1772, col: 5, offset: 42329},
+							pos:        position{line: 1779, col: 5, offset: 42463},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1772, col: 9, offset: 42333},
+							pos:   position{line: 1779, col: 9, offset: 42467},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1772, col: 11, offset: 42335},
+								pos: position{line: 1779, col: 11, offset: 42469},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1772, col: 11, offset: 42335},
+									pos:  position{line: 1779, col: 11, offset: 42469},
 									name: "DoubleQuotedChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1772, col: 29, offset: 42353},
+							pos:        position{line: 1779, col: 29, offset: 42487},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -12005,57 +12030,57 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1774, col: 1, offset: 42387},
+			pos:  position{line: 1781, col: 1, offset: 42521},
 			expr: &choiceExpr{
-				pos: position{line: 1775, col: 5, offset: 42408},
+				pos: position{line: 1782, col: 5, offset: 42542},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1775, col: 5, offset: 42408},
+						pos: position{line: 1782, col: 5, offset: 42542},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1775, col: 5, offset: 42408},
+							pos: position{line: 1782, col: 5, offset: 42542},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1775, col: 5, offset: 42408},
+									pos: position{line: 1782, col: 5, offset: 42542},
 									expr: &choiceExpr{
-										pos: position{line: 1775, col: 7, offset: 42410},
+										pos: position{line: 1782, col: 7, offset: 42544},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1775, col: 7, offset: 42410},
+												pos:        position{line: 1782, col: 7, offset: 42544},
 												val:        "\"",
 												ignoreCase: false,
 												want:       "\"\\\"\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1775, col: 13, offset: 42416},
+												pos:  position{line: 1782, col: 13, offset: 42550},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1775, col: 26, offset: 42429,
+									line: 1782, col: 26, offset: 42563,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1776, col: 5, offset: 42466},
+						pos: position{line: 1783, col: 5, offset: 42600},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1776, col: 5, offset: 42466},
+							pos: position{line: 1783, col: 5, offset: 42600},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1776, col: 5, offset: 42466},
+									pos:        position{line: 1783, col: 5, offset: 42600},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1776, col: 10, offset: 42471},
+									pos:   position{line: 1783, col: 10, offset: 42605},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1776, col: 12, offset: 42473},
+										pos:  position{line: 1783, col: 12, offset: 42607},
 										name: "EscapeSequence",
 									},
 								},
@@ -12069,32 +12094,32 @@ var g = &grammar{
 		},
 		{
 			name: "RString",
-			pos:  position{line: 1778, col: 1, offset: 42507},
+			pos:  position{line: 1785, col: 1, offset: 42641},
 			expr: &choiceExpr{
-				pos: position{line: 1779, col: 5, offset: 42519},
+				pos: position{line: 1786, col: 5, offset: 42653},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1779, col: 5, offset: 42519},
+						pos: position{line: 1786, col: 5, offset: 42653},
 						run: (*parser).callonRString2,
 						expr: &seqExpr{
-							pos: position{line: 1779, col: 5, offset: 42519},
+							pos: position{line: 1786, col: 5, offset: 42653},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1779, col: 5, offset: 42519},
+									pos:        position{line: 1786, col: 5, offset: 42653},
 									val:        "r'",
 									ignoreCase: false,
 									want:       "\"r'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1779, col: 10, offset: 42524},
+									pos:   position{line: 1786, col: 10, offset: 42658},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1779, col: 12, offset: 42526},
+										pos:  position{line: 1786, col: 12, offset: 42660},
 										name: "NoSingleQuotes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1779, col: 27, offset: 42541},
+									pos:        position{line: 1786, col: 27, offset: 42675},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -12103,33 +12128,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1780, col: 5, offset: 42576},
+						pos: position{line: 1787, col: 5, offset: 42710},
 						run: (*parser).callonRString8,
 						expr: &seqExpr{
-							pos: position{line: 1780, col: 5, offset: 42576},
+							pos: position{line: 1787, col: 5, offset: 42710},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1780, col: 5, offset: 42576},
+									pos:        position{line: 1787, col: 5, offset: 42710},
 									val:        "r",
 									ignoreCase: false,
 									want:       "\"r\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1780, col: 9, offset: 42580},
+									pos:        position{line: 1787, col: 9, offset: 42714},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1780, col: 13, offset: 42584},
+									pos:   position{line: 1787, col: 13, offset: 42718},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1780, col: 15, offset: 42586},
+										pos:  position{line: 1787, col: 15, offset: 42720},
 										name: "NoDoubleQuotes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1780, col: 30, offset: 42601},
+									pos:        position{line: 1787, col: 30, offset: 42735},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -12144,26 +12169,26 @@ var g = &grammar{
 		},
 		{
 			name: "NoSingleQuotes",
-			pos:  position{line: 1782, col: 1, offset: 42633},
+			pos:  position{line: 1789, col: 1, offset: 42767},
 			expr: &actionExpr{
-				pos: position{line: 1783, col: 5, offset: 42652},
+				pos: position{line: 1790, col: 5, offset: 42786},
 				run: (*parser).callonNoSingleQuotes1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1783, col: 5, offset: 42652},
+					pos: position{line: 1790, col: 5, offset: 42786},
 					expr: &seqExpr{
-						pos: position{line: 1783, col: 6, offset: 42653},
+						pos: position{line: 1790, col: 6, offset: 42787},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 1783, col: 6, offset: 42653},
+								pos: position{line: 1790, col: 6, offset: 42787},
 								expr: &litMatcher{
-									pos:        position{line: 1783, col: 7, offset: 42654},
+									pos:        position{line: 1790, col: 7, offset: 42788},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 							},
 							&anyMatcher{
-								line: 1783, col: 11, offset: 42658,
+								line: 1790, col: 11, offset: 42792,
 							},
 						},
 					},
@@ -12174,26 +12199,26 @@ var g = &grammar{
 		},
 		{
 			name: "NoDoubleQuotes",
-			pos:  position{line: 1785, col: 1, offset: 42694},
+			pos:  position{line: 1792, col: 1, offset: 42828},
 			expr: &actionExpr{
-				pos: position{line: 1786, col: 5, offset: 42713},
+				pos: position{line: 1793, col: 5, offset: 42847},
 				run: (*parser).callonNoDoubleQuotes1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1786, col: 5, offset: 42713},
+					pos: position{line: 1793, col: 5, offset: 42847},
 					expr: &seqExpr{
-						pos: position{line: 1786, col: 6, offset: 42714},
+						pos: position{line: 1793, col: 6, offset: 42848},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 1786, col: 6, offset: 42714},
+								pos: position{line: 1793, col: 6, offset: 42848},
 								expr: &litMatcher{
-									pos:        position{line: 1786, col: 7, offset: 42715},
+									pos:        position{line: 1793, col: 7, offset: 42849},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 							},
 							&anyMatcher{
-								line: 1786, col: 11, offset: 42719,
+								line: 1793, col: 11, offset: 42853,
 							},
 						},
 					},
@@ -12204,32 +12229,32 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickString",
-			pos:  position{line: 1788, col: 1, offset: 42755},
+			pos:  position{line: 1795, col: 1, offset: 42889},
 			expr: &actionExpr{
-				pos: position{line: 1789, col: 5, offset: 42774},
+				pos: position{line: 1796, col: 5, offset: 42908},
 				run: (*parser).callonBacktickString1,
 				expr: &seqExpr{
-					pos: position{line: 1789, col: 5, offset: 42774},
+					pos: position{line: 1796, col: 5, offset: 42908},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1789, col: 5, offset: 42774},
+							pos:        position{line: 1796, col: 5, offset: 42908},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1789, col: 9, offset: 42778},
+							pos:   position{line: 1796, col: 9, offset: 42912},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1789, col: 11, offset: 42780},
+								pos: position{line: 1796, col: 11, offset: 42914},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1789, col: 11, offset: 42780},
+									pos:  position{line: 1796, col: 11, offset: 42914},
 									name: "BacktickChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1789, col: 25, offset: 42794},
+							pos:        position{line: 1796, col: 25, offset: 42928},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
@@ -12242,57 +12267,57 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickChar",
-			pos:  position{line: 1791, col: 1, offset: 42828},
+			pos:  position{line: 1798, col: 1, offset: 42962},
 			expr: &choiceExpr{
-				pos: position{line: 1792, col: 5, offset: 42845},
+				pos: position{line: 1799, col: 5, offset: 42979},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1792, col: 5, offset: 42845},
+						pos: position{line: 1799, col: 5, offset: 42979},
 						run: (*parser).callonBacktickChar2,
 						expr: &seqExpr{
-							pos: position{line: 1792, col: 5, offset: 42845},
+							pos: position{line: 1799, col: 5, offset: 42979},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1792, col: 5, offset: 42845},
+									pos: position{line: 1799, col: 5, offset: 42979},
 									expr: &choiceExpr{
-										pos: position{line: 1792, col: 7, offset: 42847},
+										pos: position{line: 1799, col: 7, offset: 42981},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1792, col: 7, offset: 42847},
+												pos:        position{line: 1799, col: 7, offset: 42981},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1792, col: 13, offset: 42853},
+												pos:  position{line: 1799, col: 13, offset: 42987},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1792, col: 26, offset: 42866,
+									line: 1799, col: 26, offset: 43000,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1793, col: 5, offset: 42903},
+						pos: position{line: 1800, col: 5, offset: 43037},
 						run: (*parser).callonBacktickChar9,
 						expr: &seqExpr{
-							pos: position{line: 1793, col: 5, offset: 42903},
+							pos: position{line: 1800, col: 5, offset: 43037},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1793, col: 5, offset: 42903},
+									pos:        position{line: 1800, col: 5, offset: 43037},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1793, col: 10, offset: 42908},
+									pos:   position{line: 1800, col: 10, offset: 43042},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1793, col: 12, offset: 42910},
+										pos:  position{line: 1800, col: 12, offset: 43044},
 										name: "EscapeSequence",
 									},
 								},
@@ -12306,28 +12331,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1795, col: 1, offset: 42944},
+			pos:  position{line: 1802, col: 1, offset: 43078},
 			expr: &actionExpr{
-				pos: position{line: 1796, col: 5, offset: 42956},
+				pos: position{line: 1803, col: 5, offset: 43090},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1796, col: 5, offset: 42956},
+					pos: position{line: 1803, col: 5, offset: 43090},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1796, col: 5, offset: 42956},
+							pos:   position{line: 1803, col: 5, offset: 43090},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1796, col: 10, offset: 42961},
+								pos:  position{line: 1803, col: 10, offset: 43095},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1796, col: 23, offset: 42974},
+							pos:   position{line: 1803, col: 23, offset: 43108},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1796, col: 28, offset: 42979},
+								pos: position{line: 1803, col: 28, offset: 43113},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1796, col: 28, offset: 42979},
+									pos:  position{line: 1803, col: 28, offset: 43113},
 									name: "KeyWordRest",
 								},
 							},
@@ -12340,16 +12365,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1798, col: 1, offset: 43041},
+			pos:  position{line: 1805, col: 1, offset: 43175},
 			expr: &choiceExpr{
-				pos: position{line: 1799, col: 5, offset: 43058},
+				pos: position{line: 1806, col: 5, offset: 43192},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1799, col: 5, offset: 43058},
+						pos:  position{line: 1806, col: 5, offset: 43192},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1800, col: 5, offset: 43075},
+						pos:  position{line: 1807, col: 5, offset: 43209},
 						name: "KeyWordEsc",
 					},
 				},
@@ -12359,16 +12384,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1802, col: 1, offset: 43087},
+			pos:  position{line: 1809, col: 1, offset: 43221},
 			expr: &choiceExpr{
-				pos: position{line: 1803, col: 5, offset: 43103},
+				pos: position{line: 1810, col: 5, offset: 43237},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1803, col: 5, offset: 43103},
+						pos:  position{line: 1810, col: 5, offset: 43237},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1804, col: 5, offset: 43120},
+						pos:        position{line: 1811, col: 5, offset: 43254},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -12381,19 +12406,19 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1806, col: 1, offset: 43127},
+			pos:  position{line: 1813, col: 1, offset: 43261},
 			expr: &actionExpr{
-				pos: position{line: 1806, col: 16, offset: 43142},
+				pos: position{line: 1813, col: 16, offset: 43276},
 				run: (*parser).callonKeyWordChars1,
 				expr: &choiceExpr{
-					pos: position{line: 1806, col: 17, offset: 43143},
+					pos: position{line: 1813, col: 17, offset: 43277},
 					alternatives: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1806, col: 17, offset: 43143},
+							pos:  position{line: 1813, col: 17, offset: 43277},
 							name: "UnicodeLetter",
 						},
 						&charClassMatcher{
-							pos:        position{line: 1806, col: 33, offset: 43159},
+							pos:        position{line: 1813, col: 33, offset: 43293},
 							val:        "[_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ignoreCase: false,
@@ -12407,31 +12432,31 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1808, col: 1, offset: 43203},
+			pos:  position{line: 1815, col: 1, offset: 43337},
 			expr: &actionExpr{
-				pos: position{line: 1808, col: 14, offset: 43216},
+				pos: position{line: 1815, col: 14, offset: 43350},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1808, col: 14, offset: 43216},
+					pos: position{line: 1815, col: 14, offset: 43350},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1808, col: 14, offset: 43216},
+							pos:        position{line: 1815, col: 14, offset: 43350},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1808, col: 19, offset: 43221},
+							pos:   position{line: 1815, col: 19, offset: 43355},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1808, col: 22, offset: 43224},
+								pos: position{line: 1815, col: 22, offset: 43358},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1808, col: 22, offset: 43224},
+										pos:  position{line: 1815, col: 22, offset: 43358},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1808, col: 38, offset: 43240},
+										pos:  position{line: 1815, col: 38, offset: 43374},
 										name: "EscapeSequence",
 									},
 								},
@@ -12445,42 +12470,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1810, col: 1, offset: 43275},
+			pos:  position{line: 1817, col: 1, offset: 43409},
 			expr: &actionExpr{
-				pos: position{line: 1811, col: 5, offset: 43291},
+				pos: position{line: 1818, col: 5, offset: 43425},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1811, col: 5, offset: 43291},
+					pos: position{line: 1818, col: 5, offset: 43425},
 					exprs: []any{
 						&andExpr{
-							pos: position{line: 1811, col: 5, offset: 43291},
+							pos: position{line: 1818, col: 5, offset: 43425},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1811, col: 6, offset: 43292},
+								pos:  position{line: 1818, col: 6, offset: 43426},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1811, col: 22, offset: 43308},
+							pos: position{line: 1818, col: 22, offset: 43442},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1811, col: 23, offset: 43309},
+								pos:  position{line: 1818, col: 23, offset: 43443},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1811, col: 35, offset: 43321},
+							pos:   position{line: 1818, col: 35, offset: 43455},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1811, col: 40, offset: 43326},
+								pos:  position{line: 1818, col: 40, offset: 43460},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1811, col: 50, offset: 43336},
+							pos:   position{line: 1818, col: 50, offset: 43470},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1811, col: 55, offset: 43341},
+								pos: position{line: 1818, col: 55, offset: 43475},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1811, col: 55, offset: 43341},
+									pos:  position{line: 1818, col: 55, offset: 43475},
 									name: "GlobRest",
 								},
 							},
@@ -12493,28 +12518,28 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1815, col: 1, offset: 43410},
+			pos:  position{line: 1822, col: 1, offset: 43544},
 			expr: &choiceExpr{
-				pos: position{line: 1815, col: 19, offset: 43428},
+				pos: position{line: 1822, col: 19, offset: 43562},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1815, col: 19, offset: 43428},
+						pos:  position{line: 1822, col: 19, offset: 43562},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1815, col: 34, offset: 43443},
+						pos: position{line: 1822, col: 34, offset: 43577},
 						exprs: []any{
 							&oneOrMoreExpr{
-								pos: position{line: 1815, col: 34, offset: 43443},
+								pos: position{line: 1822, col: 34, offset: 43577},
 								expr: &litMatcher{
-									pos:        position{line: 1815, col: 34, offset: 43443},
+									pos:        position{line: 1822, col: 34, offset: 43577},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1815, col: 39, offset: 43448},
+								pos:  position{line: 1822, col: 39, offset: 43582},
 								name: "KeyWordRest",
 							},
 						},
@@ -12526,19 +12551,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1816, col: 1, offset: 43460},
+			pos:  position{line: 1823, col: 1, offset: 43594},
 			expr: &seqExpr{
-				pos: position{line: 1816, col: 15, offset: 43474},
+				pos: position{line: 1823, col: 15, offset: 43608},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1816, col: 15, offset: 43474},
+						pos: position{line: 1823, col: 15, offset: 43608},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1816, col: 15, offset: 43474},
+							pos:  position{line: 1823, col: 15, offset: 43608},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1816, col: 28, offset: 43487},
+						pos:        position{line: 1823, col: 28, offset: 43621},
 						val:        "*",
 						ignoreCase: false,
 						want:       "\"*\"",
@@ -12550,23 +12575,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1818, col: 1, offset: 43492},
+			pos:  position{line: 1825, col: 1, offset: 43626},
 			expr: &choiceExpr{
-				pos: position{line: 1819, col: 5, offset: 43506},
+				pos: position{line: 1826, col: 5, offset: 43640},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1819, col: 5, offset: 43506},
+						pos:  position{line: 1826, col: 5, offset: 43640},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1820, col: 5, offset: 43523},
+						pos:  position{line: 1827, col: 5, offset: 43657},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1821, col: 5, offset: 43535},
+						pos: position{line: 1828, col: 5, offset: 43669},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1821, col: 5, offset: 43535},
+							pos:        position{line: 1828, col: 5, offset: 43669},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -12579,16 +12604,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1823, col: 1, offset: 43560},
+			pos:  position{line: 1830, col: 1, offset: 43694},
 			expr: &choiceExpr{
-				pos: position{line: 1824, col: 5, offset: 43573},
+				pos: position{line: 1831, col: 5, offset: 43707},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1824, col: 5, offset: 43573},
+						pos:  position{line: 1831, col: 5, offset: 43707},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1825, col: 5, offset: 43587},
+						pos:        position{line: 1832, col: 5, offset: 43721},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -12601,31 +12626,31 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1827, col: 1, offset: 43594},
+			pos:  position{line: 1834, col: 1, offset: 43728},
 			expr: &actionExpr{
-				pos: position{line: 1827, col: 11, offset: 43604},
+				pos: position{line: 1834, col: 11, offset: 43738},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1827, col: 11, offset: 43604},
+					pos: position{line: 1834, col: 11, offset: 43738},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1827, col: 11, offset: 43604},
+							pos:        position{line: 1834, col: 11, offset: 43738},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1827, col: 16, offset: 43609},
+							pos:   position{line: 1834, col: 16, offset: 43743},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1827, col: 19, offset: 43612},
+								pos: position{line: 1834, col: 19, offset: 43746},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1827, col: 19, offset: 43612},
+										pos:  position{line: 1834, col: 19, offset: 43746},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1827, col: 32, offset: 43625},
+										pos:  position{line: 1834, col: 32, offset: 43759},
 										name: "EscapeSequence",
 									},
 								},
@@ -12639,32 +12664,32 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1829, col: 1, offset: 43660},
+			pos:  position{line: 1836, col: 1, offset: 43794},
 			expr: &choiceExpr{
-				pos: position{line: 1830, col: 5, offset: 43675},
+				pos: position{line: 1837, col: 5, offset: 43809},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1830, col: 5, offset: 43675},
+						pos: position{line: 1837, col: 5, offset: 43809},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1830, col: 5, offset: 43675},
+							pos:        position{line: 1837, col: 5, offset: 43809},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1831, col: 5, offset: 43703},
+						pos: position{line: 1838, col: 5, offset: 43837},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1831, col: 5, offset: 43703},
+							pos:        position{line: 1838, col: 5, offset: 43837},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1832, col: 5, offset: 43733},
+						pos:        position{line: 1839, col: 5, offset: 43867},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12677,57 +12702,57 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1834, col: 1, offset: 43739},
+			pos:  position{line: 1841, col: 1, offset: 43873},
 			expr: &choiceExpr{
-				pos: position{line: 1835, col: 5, offset: 43760},
+				pos: position{line: 1842, col: 5, offset: 43894},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1835, col: 5, offset: 43760},
+						pos: position{line: 1842, col: 5, offset: 43894},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1835, col: 5, offset: 43760},
+							pos: position{line: 1842, col: 5, offset: 43894},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1835, col: 5, offset: 43760},
+									pos: position{line: 1842, col: 5, offset: 43894},
 									expr: &choiceExpr{
-										pos: position{line: 1835, col: 7, offset: 43762},
+										pos: position{line: 1842, col: 7, offset: 43896},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1835, col: 7, offset: 43762},
+												pos:        position{line: 1842, col: 7, offset: 43896},
 												val:        "'",
 												ignoreCase: false,
 												want:       "\"'\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1835, col: 13, offset: 43768},
+												pos:  position{line: 1842, col: 13, offset: 43902},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1835, col: 26, offset: 43781,
+									line: 1842, col: 26, offset: 43915,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1836, col: 5, offset: 43818},
+						pos: position{line: 1843, col: 5, offset: 43952},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1836, col: 5, offset: 43818},
+							pos: position{line: 1843, col: 5, offset: 43952},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1836, col: 5, offset: 43818},
+									pos:        position{line: 1843, col: 5, offset: 43952},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1836, col: 10, offset: 43823},
+									pos:   position{line: 1843, col: 10, offset: 43957},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1836, col: 12, offset: 43825},
+										pos:  position{line: 1843, col: 12, offset: 43959},
 										name: "EscapeSequence",
 									},
 								},
@@ -12741,16 +12766,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1838, col: 1, offset: 43859},
+			pos:  position{line: 1845, col: 1, offset: 43993},
 			expr: &choiceExpr{
-				pos: position{line: 1839, col: 5, offset: 43878},
+				pos: position{line: 1846, col: 5, offset: 44012},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1839, col: 5, offset: 43878},
+						pos:  position{line: 1846, col: 5, offset: 44012},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1840, col: 5, offset: 43899},
+						pos:  position{line: 1847, col: 5, offset: 44033},
 						name: "UnicodeEscape",
 					},
 				},
@@ -12760,87 +12785,87 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1842, col: 1, offset: 43914},
+			pos:  position{line: 1849, col: 1, offset: 44048},
 			expr: &choiceExpr{
-				pos: position{line: 1843, col: 5, offset: 43935},
+				pos: position{line: 1850, col: 5, offset: 44069},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1843, col: 5, offset: 43935},
+						pos:        position{line: 1850, col: 5, offset: 44069},
 						val:        "'",
 						ignoreCase: false,
 						want:       "\"'\"",
 					},
 					&actionExpr{
-						pos: position{line: 1844, col: 5, offset: 43943},
+						pos: position{line: 1851, col: 5, offset: 44077},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1844, col: 5, offset: 43943},
+							pos:        position{line: 1851, col: 5, offset: 44077},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1845, col: 5, offset: 43983},
+						pos:        position{line: 1852, col: 5, offset: 44117},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
 					},
 					&actionExpr{
-						pos: position{line: 1846, col: 5, offset: 43992},
+						pos: position{line: 1853, col: 5, offset: 44126},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1846, col: 5, offset: 43992},
+							pos:        position{line: 1853, col: 5, offset: 44126},
 							val:        "b",
 							ignoreCase: false,
 							want:       "\"b\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1847, col: 5, offset: 44021},
+						pos: position{line: 1854, col: 5, offset: 44155},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1847, col: 5, offset: 44021},
+							pos:        position{line: 1854, col: 5, offset: 44155},
 							val:        "f",
 							ignoreCase: false,
 							want:       "\"f\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1848, col: 5, offset: 44050},
+						pos: position{line: 1855, col: 5, offset: 44184},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1848, col: 5, offset: 44050},
+							pos:        position{line: 1855, col: 5, offset: 44184},
 							val:        "n",
 							ignoreCase: false,
 							want:       "\"n\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1849, col: 5, offset: 44079},
+						pos: position{line: 1856, col: 5, offset: 44213},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1849, col: 5, offset: 44079},
+							pos:        position{line: 1856, col: 5, offset: 44213},
 							val:        "r",
 							ignoreCase: false,
 							want:       "\"r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1850, col: 5, offset: 44108},
+						pos: position{line: 1857, col: 5, offset: 44242},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1850, col: 5, offset: 44108},
+							pos:        position{line: 1857, col: 5, offset: 44242},
 							val:        "t",
 							ignoreCase: false,
 							want:       "\"t\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1851, col: 5, offset: 44137},
+						pos: position{line: 1858, col: 5, offset: 44271},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1851, col: 5, offset: 44137},
+							pos:        position{line: 1858, col: 5, offset: 44271},
 							val:        "v",
 							ignoreCase: false,
 							want:       "\"v\"",
@@ -12853,32 +12878,32 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1853, col: 1, offset: 44163},
+			pos:  position{line: 1860, col: 1, offset: 44297},
 			expr: &choiceExpr{
-				pos: position{line: 1854, col: 5, offset: 44181},
+				pos: position{line: 1861, col: 5, offset: 44315},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1854, col: 5, offset: 44181},
+						pos: position{line: 1861, col: 5, offset: 44315},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1854, col: 5, offset: 44181},
+							pos:        position{line: 1861, col: 5, offset: 44315},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1855, col: 5, offset: 44209},
+						pos: position{line: 1862, col: 5, offset: 44343},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1855, col: 5, offset: 44209},
+							pos:        position{line: 1862, col: 5, offset: 44343},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1856, col: 5, offset: 44237},
+						pos:        position{line: 1863, col: 5, offset: 44371},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12891,42 +12916,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1858, col: 1, offset: 44243},
+			pos:  position{line: 1865, col: 1, offset: 44377},
 			expr: &choiceExpr{
-				pos: position{line: 1859, col: 5, offset: 44261},
+				pos: position{line: 1866, col: 5, offset: 44395},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1859, col: 5, offset: 44261},
+						pos: position{line: 1866, col: 5, offset: 44395},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1859, col: 5, offset: 44261},
+							pos: position{line: 1866, col: 5, offset: 44395},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1859, col: 5, offset: 44261},
+									pos:        position{line: 1866, col: 5, offset: 44395},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1859, col: 9, offset: 44265},
+									pos:   position{line: 1866, col: 9, offset: 44399},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1859, col: 16, offset: 44272},
+										pos: position{line: 1866, col: 16, offset: 44406},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1859, col: 16, offset: 44272},
+												pos:  position{line: 1866, col: 16, offset: 44406},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1859, col: 25, offset: 44281},
+												pos:  position{line: 1866, col: 25, offset: 44415},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1859, col: 34, offset: 44290},
+												pos:  position{line: 1866, col: 34, offset: 44424},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1859, col: 43, offset: 44299},
+												pos:  position{line: 1866, col: 43, offset: 44433},
 												name: "HexDigit",
 											},
 										},
@@ -12936,65 +12961,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1862, col: 5, offset: 44362},
+						pos: position{line: 1869, col: 5, offset: 44496},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1862, col: 5, offset: 44362},
+							pos: position{line: 1869, col: 5, offset: 44496},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1862, col: 5, offset: 44362},
+									pos:        position{line: 1869, col: 5, offset: 44496},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1862, col: 9, offset: 44366},
+									pos:        position{line: 1869, col: 9, offset: 44500},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1862, col: 13, offset: 44370},
+									pos:   position{line: 1869, col: 13, offset: 44504},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1862, col: 20, offset: 44377},
+										pos: position{line: 1869, col: 20, offset: 44511},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1862, col: 20, offset: 44377},
+												pos:  position{line: 1869, col: 20, offset: 44511},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1862, col: 29, offset: 44386},
+												pos: position{line: 1869, col: 29, offset: 44520},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1862, col: 29, offset: 44386},
+													pos:  position{line: 1869, col: 29, offset: 44520},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1862, col: 39, offset: 44396},
+												pos: position{line: 1869, col: 39, offset: 44530},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1862, col: 39, offset: 44396},
+													pos:  position{line: 1869, col: 39, offset: 44530},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1862, col: 49, offset: 44406},
+												pos: position{line: 1869, col: 49, offset: 44540},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1862, col: 49, offset: 44406},
+													pos:  position{line: 1869, col: 49, offset: 44540},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1862, col: 59, offset: 44416},
+												pos: position{line: 1869, col: 59, offset: 44550},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1862, col: 59, offset: 44416},
+													pos:  position{line: 1869, col: 59, offset: 44550},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1862, col: 69, offset: 44426},
+												pos: position{line: 1869, col: 69, offset: 44560},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1862, col: 69, offset: 44426},
+													pos:  position{line: 1869, col: 69, offset: 44560},
 													name: "HexDigit",
 												},
 											},
@@ -13002,7 +13027,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1862, col: 80, offset: 44437},
+									pos:        position{line: 1869, col: 80, offset: 44571},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -13017,9 +13042,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1867, col: 1, offset: 44492},
+			pos:  position{line: 1874, col: 1, offset: 44626},
 			expr: &charClassMatcher{
-				pos:        position{line: 1868, col: 5, offset: 44508},
+				pos:        position{line: 1875, col: 5, offset: 44642},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -13031,11 +13056,11 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1870, col: 1, offset: 44523},
+			pos:  position{line: 1877, col: 1, offset: 44657},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1870, col: 5, offset: 44527},
+				pos: position{line: 1877, col: 5, offset: 44661},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1870, col: 5, offset: 44527},
+					pos:  position{line: 1877, col: 5, offset: 44661},
 					name: "AnySpace",
 				},
 			},
@@ -13044,11 +13069,11 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 1872, col: 1, offset: 44538},
+			pos:  position{line: 1879, col: 1, offset: 44672},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1872, col: 6, offset: 44543},
+				pos: position{line: 1879, col: 6, offset: 44677},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1872, col: 6, offset: 44543},
+					pos:  position{line: 1879, col: 6, offset: 44677},
 					name: "AnySpace",
 				},
 			},
@@ -13057,20 +13082,20 @@ var g = &grammar{
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1874, col: 1, offset: 44554},
+			pos:  position{line: 1881, col: 1, offset: 44688},
 			expr: &choiceExpr{
-				pos: position{line: 1875, col: 5, offset: 44567},
+				pos: position{line: 1882, col: 5, offset: 44701},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1875, col: 5, offset: 44567},
+						pos:  position{line: 1882, col: 5, offset: 44701},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1876, col: 5, offset: 44582},
+						pos:  position{line: 1883, col: 5, offset: 44716},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1877, col: 5, offset: 44601},
+						pos:  position{line: 1884, col: 5, offset: 44735},
 						name: "Comment",
 					},
 				},
@@ -13080,32 +13105,32 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeLetter",
-			pos:  position{line: 1879, col: 1, offset: 44610},
+			pos:  position{line: 1886, col: 1, offset: 44744},
 			expr: &choiceExpr{
-				pos: position{line: 1880, col: 5, offset: 44628},
+				pos: position{line: 1887, col: 5, offset: 44762},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1880, col: 5, offset: 44628},
+						pos:  position{line: 1887, col: 5, offset: 44762},
 						name: "Lu",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1881, col: 5, offset: 44635},
+						pos:  position{line: 1888, col: 5, offset: 44769},
 						name: "Ll",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1882, col: 5, offset: 44642},
+						pos:  position{line: 1889, col: 5, offset: 44776},
 						name: "Lt",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1883, col: 5, offset: 44649},
+						pos:  position{line: 1890, col: 5, offset: 44783},
 						name: "Lm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1884, col: 5, offset: 44656},
+						pos:  position{line: 1891, col: 5, offset: 44790},
 						name: "Lo",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1885, col: 5, offset: 44663},
+						pos:  position{line: 1892, col: 5, offset: 44797},
 						name: "Nl",
 					},
 				},
@@ -13115,16 +13140,16 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeCombiningMark",
-			pos:  position{line: 1887, col: 1, offset: 44667},
+			pos:  position{line: 1894, col: 1, offset: 44801},
 			expr: &choiceExpr{
-				pos: position{line: 1888, col: 5, offset: 44692},
+				pos: position{line: 1895, col: 5, offset: 44826},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1888, col: 5, offset: 44692},
+						pos:  position{line: 1895, col: 5, offset: 44826},
 						name: "Mn",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1889, col: 5, offset: 44699},
+						pos:  position{line: 1896, col: 5, offset: 44833},
 						name: "Mc",
 					},
 				},
@@ -13134,9 +13159,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeDigit",
-			pos:  position{line: 1891, col: 1, offset: 44703},
+			pos:  position{line: 1898, col: 1, offset: 44837},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1892, col: 5, offset: 44720},
+				pos:  position{line: 1899, col: 5, offset: 44854},
 				name: "Nd",
 			},
 			leader:        false,
@@ -13144,9 +13169,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeConnectorPunctuation",
-			pos:  position{line: 1894, col: 1, offset: 44724},
+			pos:  position{line: 1901, col: 1, offset: 44858},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1895, col: 5, offset: 44756},
+				pos:  position{line: 1902, col: 5, offset: 44890},
 				name: "Pc",
 			},
 			leader:        false,
@@ -13154,9 +13179,9 @@ var g = &grammar{
 		},
 		{
 			name: "Ll",
-			pos:  position{line: 1901, col: 1, offset: 44937},
+			pos:  position{line: 1908, col: 1, offset: 45071},
 			expr: &charClassMatcher{
-				pos:        position{line: 1901, col: 6, offset: 44942},
+				pos:        position{line: 1908, col: 6, offset: 45076},
 				val:        "[\\u0061-\\u007A\\u00B5\\u00DF-\\u00F6\\u00F8-\\u00FF\\u0101\\u0103\\u0105\\u0107\\u0109\\u010B\\u010D\\u010F\\u0111\\u0113\\u0115\\u0117\\u0119\\u011B\\u011D\\u011F\\u0121\\u0123\\u0125\\u0127\\u0129\\u012B\\u012D\\u012F\\u0131\\u0133\\u0135\\u0137-\\u0138\\u013A\\u013C\\u013E\\u0140\\u0142\\u0144\\u0146\\u0148-\\u0149\\u014B\\u014D\\u014F\\u0151\\u0153\\u0155\\u0157\\u0159\\u015B\\u015D\\u015F\\u0161\\u0163\\u0165\\u0167\\u0169\\u016B\\u016D\\u016F\\u0171\\u0173\\u0175\\u0177\\u017A\\u017C\\u017E-\\u0180\\u0183\\u0185\\u0188\\u018C-\\u018D\\u0192\\u0195\\u0199-\\u019B\\u019E\\u01A1\\u01A3\\u01A5\\u01A8\\u01AA-\\u01AB\\u01AD\\u01B0\\u01B4\\u01B6\\u01B9-\\u01BA\\u01BD-\\u01BF\\u01C6\\u01C9\\u01CC\\u01CE\\u01D0\\u01D2\\u01D4\\u01D6\\u01D8\\u01DA\\u01DC-\\u01DD\\u01DF\\u01E1\\u01E3\\u01E5\\u01E7\\u01E9\\u01EB\\u01ED\\u01EF-\\u01F0\\u01F3\\u01F5\\u01F9\\u01FB\\u01FD\\u01FF\\u0201\\u0203\\u0205\\u0207\\u0209\\u020B\\u020D\\u020F\\u0211\\u0213\\u0215\\u0217\\u0219\\u021B\\u021D\\u021F\\u0221\\u0223\\u0225\\u0227\\u0229\\u022B\\u022D\\u022F\\u0231\\u0233-\\u0239\\u023C\\u023F-\\u0240\\u0242\\u0247\\u0249\\u024B\\u024D\\u024F-\\u0293\\u0295-\\u02AF\\u0371\\u0373\\u0377\\u037B-\\u037D\\u0390\\u03AC-\\u03CE\\u03D0-\\u03D1\\u03D5-\\u03D7\\u03D9\\u03DB\\u03DD\\u03DF\\u03E1\\u03E3\\u03E5\\u03E7\\u03E9\\u03EB\\u03ED\\u03EF-\\u03F3\\u03F5\\u03F8\\u03FB-\\u03FC\\u0430-\\u045F\\u0461\\u0463\\u0465\\u0467\\u0469\\u046B\\u046D\\u046F\\u0471\\u0473\\u0475\\u0477\\u0479\\u047B\\u047D\\u047F\\u0481\\u048B\\u048D\\u048F\\u0491\\u0493\\u0495\\u0497\\u0499\\u049B\\u049D\\u049F\\u04A1\\u04A3\\u04A5\\u04A7\\u04A9\\u04AB\\u04AD\\u04AF\\u04B1\\u04B3\\u04B5\\u04B7\\u04B9\\u04BB\\u04BD\\u04BF\\u04C2\\u04C4\\u04C6\\u04C8\\u04CA\\u04CC\\u04CE-\\u04CF\\u04D1\\u04D3\\u04D5\\u04D7\\u04D9\\u04DB\\u04DD\\u04DF\\u04E1\\u04E3\\u04E5\\u04E7\\u04E9\\u04EB\\u04ED\\u04EF\\u04F1\\u04F3\\u04F5\\u04F7\\u04F9\\u04FB\\u04FD\\u04FF\\u0501\\u0503\\u0505\\u0507\\u0509\\u050B\\u050D\\u050F\\u0511\\u0513\\u0515\\u0517\\u0519\\u051B\\u051D\\u051F\\u0521\\u0523\\u0525\\u0527\\u0529\\u052B\\u052D\\u052F\\u0560-\\u0588\\u10D0-\\u10FA\\u10FD-\\u10FF\\u13F8-\\u13FD\\u1C80-\\u1C88\\u1D00-\\u1D2B\\u1D6B-\\u1D77\\u1D79-\\u1D9A\\u1E01\\u1E03\\u1E05\\u1E07\\u1E09\\u1E0B\\u1E0D\\u1E0F\\u1E11\\u1E13\\u1E15\\u1E17\\u1E19\\u1E1B\\u1E1D\\u1E1F\\u1E21\\u1E23\\u1E25\\u1E27\\u1E29\\u1E2B\\u1E2D\\u1E2F\\u1E31\\u1E33\\u1E35\\u1E37\\u1E39\\u1E3B\\u1E3D\\u1E3F\\u1E41\\u1E43\\u1E45\\u1E47\\u1E49\\u1E4B\\u1E4D\\u1E4F\\u1E51\\u1E53\\u1E55\\u1E57\\u1E59\\u1E5B\\u1E5D\\u1E5F\\u1E61\\u1E63\\u1E65\\u1E67\\u1E69\\u1E6B\\u1E6D\\u1E6F\\u1E71\\u1E73\\u1E75\\u1E77\\u1E79\\u1E7B\\u1E7D\\u1E7F\\u1E81\\u1E83\\u1E85\\u1E87\\u1E89\\u1E8B\\u1E8D\\u1E8F\\u1E91\\u1E93\\u1E95-\\u1E9D\\u1E9F\\u1EA1\\u1EA3\\u1EA5\\u1EA7\\u1EA9\\u1EAB\\u1EAD\\u1EAF\\u1EB1\\u1EB3\\u1EB5\\u1EB7\\u1EB9\\u1EBB\\u1EBD\\u1EBF\\u1EC1\\u1EC3\\u1EC5\\u1EC7\\u1EC9\\u1ECB\\u1ECD\\u1ECF\\u1ED1\\u1ED3\\u1ED5\\u1ED7\\u1ED9\\u1EDB\\u1EDD\\u1EDF\\u1EE1\\u1EE3\\u1EE5\\u1EE7\\u1EE9\\u1EEB\\u1EED\\u1EEF\\u1EF1\\u1EF3\\u1EF5\\u1EF7\\u1EF9\\u1EFB\\u1EFD\\u1EFF-\\u1F07\\u1F10-\\u1F15\\u1F20-\\u1F27\\u1F30-\\u1F37\\u1F40-\\u1F45\\u1F50-\\u1F57\\u1F60-\\u1F67\\u1F70-\\u1F7D\\u1F80-\\u1F87\\u1F90-\\u1F97\\u1FA0-\\u1FA7\\u1FB0-\\u1FB4\\u1FB6-\\u1FB7\\u1FBE\\u1FC2-\\u1FC4\\u1FC6-\\u1FC7\\u1FD0-\\u1FD3\\u1FD6-\\u1FD7\\u1FE0-\\u1FE7\\u1FF2-\\u1FF4\\u1FF6-\\u1FF7\\u210A\\u210E-\\u210F\\u2113\\u212F\\u2134\\u2139\\u213C-\\u213D\\u2146-\\u2149\\u214E\\u2184\\u2C30-\\u2C5E\\u2C61\\u2C65-\\u2C66\\u2C68\\u2C6A\\u2C6C\\u2C71\\u2C73-\\u2C74\\u2C76-\\u2C7B\\u2C81\\u2C83\\u2C85\\u2C87\\u2C89\\u2C8B\\u2C8D\\u2C8F\\u2C91\\u2C93\\u2C95\\u2C97\\u2C99\\u2C9B\\u2C9D\\u2C9F\\u2CA1\\u2CA3\\u2CA5\\u2CA7\\u2CA9\\u2CAB\\u2CAD\\u2CAF\\u2CB1\\u2CB3\\u2CB5\\u2CB7\\u2CB9\\u2CBB\\u2CBD\\u2CBF\\u2CC1\\u2CC3\\u2CC5\\u2CC7\\u2CC9\\u2CCB\\u2CCD\\u2CCF\\u2CD1\\u2CD3\\u2CD5\\u2CD7\\u2CD9\\u2CDB\\u2CDD\\u2CDF\\u2CE1\\u2CE3-\\u2CE4\\u2CEC\\u2CEE\\u2CF3\\u2D00-\\u2D25\\u2D27\\u2D2D\\uA641\\uA643\\uA645\\uA647\\uA649\\uA64B\\uA64D\\uA64F\\uA651\\uA653\\uA655\\uA657\\uA659\\uA65B\\uA65D\\uA65F\\uA661\\uA663\\uA665\\uA667\\uA669\\uA66B\\uA66D\\uA681\\uA683\\uA685\\uA687\\uA689\\uA68B\\uA68D\\uA68F\\uA691\\uA693\\uA695\\uA697\\uA699\\uA69B\\uA723\\uA725\\uA727\\uA729\\uA72B\\uA72D\\uA72F-\\uA731\\uA733\\uA735\\uA737\\uA739\\uA73B\\uA73D\\uA73F\\uA741\\uA743\\uA745\\uA747\\uA749\\uA74B\\uA74D\\uA74F\\uA751\\uA753\\uA755\\uA757\\uA759\\uA75B\\uA75D\\uA75F\\uA761\\uA763\\uA765\\uA767\\uA769\\uA76B\\uA76D\\uA76F\\uA771-\\uA778\\uA77A\\uA77C\\uA77F\\uA781\\uA783\\uA785\\uA787\\uA78C\\uA78E\\uA791\\uA793-\\uA795\\uA797\\uA799\\uA79B\\uA79D\\uA79F\\uA7A1\\uA7A3\\uA7A5\\uA7A7\\uA7A9\\uA7AF\\uA7B5\\uA7B7\\uA7B9\\uA7FA\\uAB30-\\uAB5A\\uAB60-\\uAB65\\uAB70-\\uABBF\\uFB00-\\uFB06\\uFB13-\\uFB17\\uFF41-\\uFF5A]",
 				chars:      []rune{'µ', 'ā', 'ă', 'ą', 'ć', 'ĉ', 'ċ', 'č', 'ď', 'đ', 'ē', 'ĕ', 'ė', 'ę', 'ě', 'ĝ', 'ğ', 'ġ', 'ģ', 'ĥ', 'ħ', 'ĩ', 'ī', 'ĭ', 'į', 'ı', 'ĳ', 'ĵ', 'ĺ', 'ļ', 'ľ', 'ŀ', 'ł', 'ń', 'ņ', 'ŋ', 'ō', 'ŏ', 'ő', 'œ', 'ŕ', 'ŗ', 'ř', 'ś', 'ŝ', 'ş', 'š', 'ţ', 'ť', 'ŧ', 'ũ', 'ū', 'ŭ', 'ů', 'ű', 'ų', 'ŵ', 'ŷ', 'ź', 'ż', 'ƃ', 'ƅ', 'ƈ', 'ƒ', 'ƕ', 'ƞ', 'ơ', 'ƣ', 'ƥ', 'ƨ', 'ƭ', 'ư', 'ƴ', 'ƶ', 'ǆ', 'ǉ', 'ǌ', 'ǎ', 'ǐ', 'ǒ', 'ǔ', 'ǖ', 'ǘ', 'ǚ', 'ǟ', 'ǡ', 'ǣ', 'ǥ', 'ǧ', 'ǩ', 'ǫ', 'ǭ', 'ǳ', 'ǵ', 'ǹ', 'ǻ', 'ǽ', 'ǿ', 'ȁ', 'ȃ', 'ȅ', 'ȇ', 'ȉ', 'ȋ', 'ȍ', 'ȏ', 'ȑ', 'ȓ', 'ȕ', 'ȗ', 'ș', 'ț', 'ȝ', 'ȟ', 'ȡ', 'ȣ', 'ȥ', 'ȧ', 'ȩ', 'ȫ', 'ȭ', 'ȯ', 'ȱ', 'ȼ', 'ɂ', 'ɇ', 'ɉ', 'ɋ', 'ɍ', 'ͱ', 'ͳ', 'ͷ', 'ΐ', 'ϙ', 'ϛ', 'ϝ', 'ϟ', 'ϡ', 'ϣ', 'ϥ', 'ϧ', 'ϩ', 'ϫ', 'ϭ', 'ϵ', 'ϸ', 'ѡ', 'ѣ', 'ѥ', 'ѧ', 'ѩ', 'ѫ', 'ѭ', 'ѯ', 'ѱ', 'ѳ', 'ѵ', 'ѷ', 'ѹ', 'ѻ', 'ѽ', 'ѿ', 'ҁ', 'ҋ', 'ҍ', 'ҏ', 'ґ', 'ғ', 'ҕ', 'җ', 'ҙ', 'қ', 'ҝ', 'ҟ', 'ҡ', 'ң', 'ҥ', 'ҧ', 'ҩ', 'ҫ', 'ҭ', 'ү', 'ұ', 'ҳ', 'ҵ', 'ҷ', 'ҹ', 'һ', 'ҽ', 'ҿ', 'ӂ', 'ӄ', 'ӆ', 'ӈ', 'ӊ', 'ӌ', 'ӑ', 'ӓ', 'ӕ', 'ӗ', 'ә', 'ӛ', 'ӝ', 'ӟ', 'ӡ', 'ӣ', 'ӥ', 'ӧ', 'ө', 'ӫ', 'ӭ', 'ӯ', 'ӱ', 'ӳ', 'ӵ', 'ӷ', 'ӹ', 'ӻ', 'ӽ', 'ӿ', 'ԁ', 'ԃ', 'ԅ', 'ԇ', 'ԉ', 'ԋ', 'ԍ', 'ԏ', 'ԑ', 'ԓ', 'ԕ', 'ԗ', 'ԙ', 'ԛ', 'ԝ', 'ԟ', 'ԡ', 'ԣ', 'ԥ', 'ԧ', 'ԩ', 'ԫ', 'ԭ', 'ԯ', 'ḁ', 'ḃ', 'ḅ', 'ḇ', 'ḉ', 'ḋ', 'ḍ', 'ḏ', 'ḑ', 'ḓ', 'ḕ', 'ḗ', 'ḙ', 'ḛ', 'ḝ', 'ḟ', 'ḡ', 'ḣ', 'ḥ', 'ḧ', 'ḩ', 'ḫ', 'ḭ', 'ḯ', 'ḱ', 'ḳ', 'ḵ', 'ḷ', 'ḹ', 'ḻ', 'ḽ', 'ḿ', 'ṁ', 'ṃ', 'ṅ', 'ṇ', 'ṉ', 'ṋ', 'ṍ', 'ṏ', 'ṑ', 'ṓ', 'ṕ', 'ṗ', 'ṙ', 'ṛ', 'ṝ', 'ṟ', 'ṡ', 'ṣ', 'ṥ', 'ṧ', 'ṩ', 'ṫ', 'ṭ', 'ṯ', 'ṱ', 'ṳ', 'ṵ', 'ṷ', 'ṹ', 'ṻ', 'ṽ', 'ṿ', 'ẁ', 'ẃ', 'ẅ', 'ẇ', 'ẉ', 'ẋ', 'ẍ', 'ẏ', 'ẑ', 'ẓ', 'ẟ', 'ạ', 'ả', 'ấ', 'ầ', 'ẩ', 'ẫ', 'ậ', 'ắ', 'ằ', 'ẳ', 'ẵ', 'ặ', 'ẹ', 'ẻ', 'ẽ', 'ế', 'ề', 'ể', 'ễ', 'ệ', 'ỉ', 'ị', 'ọ', 'ỏ', 'ố', 'ồ', 'ổ', 'ỗ', 'ộ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ', 'ụ', 'ủ', 'ứ', 'ừ', 'ử', 'ữ', 'ự', 'ỳ', 'ỵ', 'ỷ', 'ỹ', 'ỻ', 'ỽ', 'ι', 'ℊ', 'ℓ', 'ℯ', 'ℴ', 'ℹ', 'ⅎ', 'ↄ', 'ⱡ', 'ⱨ', 'ⱪ', 'ⱬ', 'ⱱ', 'ⲁ', 'ⲃ', 'ⲅ', 'ⲇ', 'ⲉ', 'ⲋ', 'ⲍ', 'ⲏ', 'ⲑ', 'ⲓ', 'ⲕ', 'ⲗ', 'ⲙ', 'ⲛ', 'ⲝ', 'ⲟ', 'ⲡ', 'ⲣ', 'ⲥ', 'ⲧ', 'ⲩ', 'ⲫ', 'ⲭ', 'ⲯ', 'ⲱ', 'ⲳ', 'ⲵ', 'ⲷ', 'ⲹ', 'ⲻ', 'ⲽ', 'ⲿ', 'ⳁ', 'ⳃ', 'ⳅ', 'ⳇ', 'ⳉ', 'ⳋ', 'ⳍ', 'ⳏ', 'ⳑ', 'ⳓ', 'ⳕ', 'ⳗ', 'ⳙ', 'ⳛ', 'ⳝ', 'ⳟ', 'ⳡ', 'ⳬ', 'ⳮ', 'ⳳ', 'ⴧ', 'ⴭ', 'ꙁ', 'ꙃ', 'ꙅ', 'ꙇ', 'ꙉ', 'ꙋ', 'ꙍ', 'ꙏ', 'ꙑ', 'ꙓ', 'ꙕ', 'ꙗ', 'ꙙ', 'ꙛ', 'ꙝ', 'ꙟ', 'ꙡ', 'ꙣ', 'ꙥ', 'ꙧ', 'ꙩ', 'ꙫ', 'ꙭ', 'ꚁ', 'ꚃ', 'ꚅ', 'ꚇ', 'ꚉ', 'ꚋ', 'ꚍ', 'ꚏ', 'ꚑ', 'ꚓ', 'ꚕ', 'ꚗ', 'ꚙ', 'ꚛ', 'ꜣ', 'ꜥ', 'ꜧ', 'ꜩ', 'ꜫ', 'ꜭ', 'ꜳ', 'ꜵ', 'ꜷ', 'ꜹ', 'ꜻ', 'ꜽ', 'ꜿ', 'ꝁ', 'ꝃ', 'ꝅ', 'ꝇ', 'ꝉ', 'ꝋ', 'ꝍ', 'ꝏ', 'ꝑ', 'ꝓ', 'ꝕ', 'ꝗ', 'ꝙ', 'ꝛ', 'ꝝ', 'ꝟ', 'ꝡ', 'ꝣ', 'ꝥ', 'ꝧ', 'ꝩ', 'ꝫ', 'ꝭ', 'ꝯ', 'ꝺ', 'ꝼ', 'ꝿ', 'ꞁ', 'ꞃ', 'ꞅ', 'ꞇ', 'ꞌ', 'ꞎ', 'ꞑ', 'ꞗ', 'ꞙ', 'ꞛ', 'ꞝ', 'ꞟ', 'ꞡ', 'ꞣ', 'ꞥ', 'ꞧ', 'ꞩ', 'ꞯ', 'ꞵ', 'ꞷ', 'ꞹ', 'ꟺ'},
 				ranges:     []rune{'a', 'z', 'ß', 'ö', 'ø', 'ÿ', 'ķ', 'ĸ', 'ň', 'ŉ', 'ž', 'ƀ', 'ƌ', 'ƍ', 'ƙ', 'ƛ', 'ƪ', 'ƫ', 'ƹ', 'ƺ', 'ƽ', 'ƿ', 'ǜ', 'ǝ', 'ǯ', 'ǰ', 'ȳ', 'ȹ', 'ȿ', 'ɀ', 'ɏ', 'ʓ', 'ʕ', 'ʯ', 'ͻ', 'ͽ', 'ά', 'ώ', 'ϐ', 'ϑ', 'ϕ', 'ϗ', 'ϯ', 'ϳ', 'ϻ', 'ϼ', 'а', 'џ', 'ӎ', 'ӏ', 'ՠ', 'ֈ', 'ა', 'ჺ', 'ჽ', 'ჿ', 'ᏸ', 'ᏽ', 'ᲀ', 'ᲈ', 'ᴀ', 'ᴫ', 'ᵫ', 'ᵷ', 'ᵹ', 'ᶚ', 'ẕ', 'ẝ', 'ỿ', 'ἇ', 'ἐ', 'ἕ', 'ἠ', 'ἧ', 'ἰ', 'ἷ', 'ὀ', 'ὅ', 'ὐ', 'ὗ', 'ὠ', 'ὧ', 'ὰ', 'ώ', 'ᾀ', 'ᾇ', 'ᾐ', 'ᾗ', 'ᾠ', 'ᾧ', 'ᾰ', 'ᾴ', 'ᾶ', 'ᾷ', 'ῂ', 'ῄ', 'ῆ', 'ῇ', 'ῐ', 'ΐ', 'ῖ', 'ῗ', 'ῠ', 'ῧ', 'ῲ', 'ῴ', 'ῶ', 'ῷ', 'ℎ', 'ℏ', 'ℼ', 'ℽ', 'ⅆ', 'ⅉ', 'ⰰ', 'ⱞ', 'ⱥ', 'ⱦ', 'ⱳ', 'ⱴ', 'ⱶ', 'ⱻ', 'ⳣ', 'ⳤ', 'ⴀ', 'ⴥ', 'ꜯ', 'ꜱ', 'ꝱ', 'ꝸ', 'ꞓ', 'ꞕ', 'ꬰ', 'ꭚ', 'ꭠ', 'ꭥ', 'ꭰ', 'ꮿ', 'ﬀ', 'ﬆ', 'ﬓ', 'ﬗ', 'ａ', 'ｚ'},
@@ -13168,9 +13193,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lm",
-			pos:  position{line: 1904, col: 1, offset: 49094},
+			pos:  position{line: 1911, col: 1, offset: 49228},
 			expr: &charClassMatcher{
-				pos:        position{line: 1904, col: 6, offset: 49099},
+				pos:        position{line: 1911, col: 6, offset: 49233},
 				val:        "[\\u02B0-\\u02C1\\u02C6-\\u02D1\\u02E0-\\u02E4\\u02EC\\u02EE\\u0374\\u037A\\u0559\\u0640\\u06E5-\\u06E6\\u07F4-\\u07F5\\u07FA\\u081A\\u0824\\u0828\\u0971\\u0E46\\u0EC6\\u10FC\\u17D7\\u1843\\u1AA7\\u1C78-\\u1C7D\\u1D2C-\\u1D6A\\u1D78\\u1D9B-\\u1DBF\\u2071\\u207F\\u2090-\\u209C\\u2C7C-\\u2C7D\\u2D6F\\u2E2F\\u3005\\u3031-\\u3035\\u303B\\u309D-\\u309E\\u30FC-\\u30FE\\uA015\\uA4F8-\\uA4FD\\uA60C\\uA67F\\uA69C-\\uA69D\\uA717-\\uA71F\\uA770\\uA788\\uA7F8-\\uA7F9\\uA9CF\\uA9E6\\uAA70\\uAADD\\uAAF3-\\uAAF4\\uAB5C-\\uAB5F\\uFF70\\uFF9E-\\uFF9F]",
 				chars:      []rune{'ˬ', 'ˮ', 'ʹ', 'ͺ', 'ՙ', 'ـ', 'ߺ', 'ࠚ', 'ࠤ', 'ࠨ', 'ॱ', 'ๆ', 'ໆ', 'ჼ', 'ៗ', 'ᡃ', 'ᪧ', 'ᵸ', 'ⁱ', 'ⁿ', 'ⵯ', 'ⸯ', '々', '〻', 'ꀕ', 'ꘌ', 'ꙿ', 'ꝰ', 'ꞈ', 'ꧏ', 'ꧦ', 'ꩰ', 'ꫝ', 'ｰ'},
 				ranges:     []rune{'ʰ', 'ˁ', 'ˆ', 'ˑ', 'ˠ', 'ˤ', 'ۥ', 'ۦ', 'ߴ', 'ߵ', 'ᱸ', 'ᱽ', 'ᴬ', 'ᵪ', 'ᶛ', 'ᶿ', 'ₐ', 'ₜ', 'ⱼ', 'ⱽ', '〱', '〵', 'ゝ', 'ゞ', 'ー', 'ヾ', 'ꓸ', 'ꓽ', 'ꚜ', 'ꚝ', 'ꜗ', 'ꜟ', 'ꟸ', 'ꟹ', 'ꫳ', 'ꫴ', 'ꭜ', 'ꭟ', 'ﾞ', 'ﾟ'},
@@ -13182,9 +13207,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lo",
-			pos:  position{line: 1907, col: 1, offset: 49584},
+			pos:  position{line: 1914, col: 1, offset: 49718},
 			expr: &charClassMatcher{
-				pos:        position{line: 1907, col: 6, offset: 49589},
+				pos:        position{line: 1914, col: 6, offset: 49723},
 				val:        "[\\u00AA\\u00BA\\u01BB\\u01C0-\\u01C3\\u0294\\u05D0-\\u05EA\\u05EF-\\u05F2\\u0620-\\u063F\\u0641-\\u064A\\u066E-\\u066F\\u0671-\\u06D3\\u06D5\\u06EE-\\u06EF\\u06FA-\\u06FC\\u06FF\\u0710\\u0712-\\u072F\\u074D-\\u07A5\\u07B1\\u07CA-\\u07EA\\u0800-\\u0815\\u0840-\\u0858\\u0860-\\u086A\\u08A0-\\u08B4\\u08B6-\\u08BD\\u0904-\\u0939\\u093D\\u0950\\u0958-\\u0961\\u0972-\\u0980\\u0985-\\u098C\\u098F-\\u0990\\u0993-\\u09A8\\u09AA-\\u09B0\\u09B2\\u09B6-\\u09B9\\u09BD\\u09CE\\u09DC-\\u09DD\\u09DF-\\u09E1\\u09F0-\\u09F1\\u09FC\\u0A05-\\u0A0A\\u0A0F-\\u0A10\\u0A13-\\u0A28\\u0A2A-\\u0A30\\u0A32-\\u0A33\\u0A35-\\u0A36\\u0A38-\\u0A39\\u0A59-\\u0A5C\\u0A5E\\u0A72-\\u0A74\\u0A85-\\u0A8D\\u0A8F-\\u0A91\\u0A93-\\u0AA8\\u0AAA-\\u0AB0\\u0AB2-\\u0AB3\\u0AB5-\\u0AB9\\u0ABD\\u0AD0\\u0AE0-\\u0AE1\\u0AF9\\u0B05-\\u0B0C\\u0B0F-\\u0B10\\u0B13-\\u0B28\\u0B2A-\\u0B30\\u0B32-\\u0B33\\u0B35-\\u0B39\\u0B3D\\u0B5C-\\u0B5D\\u0B5F-\\u0B61\\u0B71\\u0B83\\u0B85-\\u0B8A\\u0B8E-\\u0B90\\u0B92-\\u0B95\\u0B99-\\u0B9A\\u0B9C\\u0B9E-\\u0B9F\\u0BA3-\\u0BA4\\u0BA8-\\u0BAA\\u0BAE-\\u0BB9\\u0BD0\\u0C05-\\u0C0C\\u0C0E-\\u0C10\\u0C12-\\u0C28\\u0C2A-\\u0C39\\u0C3D\\u0C58-\\u0C5A\\u0C60-\\u0C61\\u0C80\\u0C85-\\u0C8C\\u0C8E-\\u0C90\\u0C92-\\u0CA8\\u0CAA-\\u0CB3\\u0CB5-\\u0CB9\\u0CBD\\u0CDE\\u0CE0-\\u0CE1\\u0CF1-\\u0CF2\\u0D05-\\u0D0C\\u0D0E-\\u0D10\\u0D12-\\u0D3A\\u0D3D\\u0D4E\\u0D54-\\u0D56\\u0D5F-\\u0D61\\u0D7A-\\u0D7F\\u0D85-\\u0D96\\u0D9A-\\u0DB1\\u0DB3-\\u0DBB\\u0DBD\\u0DC0-\\u0DC6\\u0E01-\\u0E30\\u0E32-\\u0E33\\u0E40-\\u0E45\\u0E81-\\u0E82\\u0E84\\u0E87-\\u0E88\\u0E8A\\u0E8D\\u0E94-\\u0E97\\u0E99-\\u0E9F\\u0EA1-\\u0EA3\\u0EA5\\u0EA7\\u0EAA-\\u0EAB\\u0EAD-\\u0EB0\\u0EB2-\\u0EB3\\u0EBD\\u0EC0-\\u0EC4\\u0EDC-\\u0EDF\\u0F00\\u0F40-\\u0F47\\u0F49-\\u0F6C\\u0F88-\\u0F8C\\u1000-\\u102A\\u103F\\u1050-\\u1055\\u105A-\\u105D\\u1061\\u1065-\\u1066\\u106E-\\u1070\\u1075-\\u1081\\u108E\\u1100-\\u1248\\u124A-\\u124D\\u1250-\\u1256\\u1258\\u125A-\\u125D\\u1260-\\u1288\\u128A-\\u128D\\u1290-\\u12B0\\u12B2-\\u12B5\\u12B8-\\u12BE\\u12C0\\u12C2-\\u12C5\\u12C8-\\u12D6\\u12D8-\\u1310\\u1312-\\u1315\\u1318-\\u135A\\u1380-\\u138F\\u1401-\\u166C\\u166F-\\u167F\\u1681-\\u169A\\u16A0-\\u16EA\\u16F1-\\u16F8\\u1700-\\u170C\\u170E-\\u1711\\u1720-\\u1731\\u1740-\\u1751\\u1760-\\u176C\\u176E-\\u1770\\u1780-\\u17B3\\u17DC\\u1820-\\u1842\\u1844-\\u1878\\u1880-\\u1884\\u1887-\\u18A8\\u18AA\\u18B0-\\u18F5\\u1900-\\u191E\\u1950-\\u196D\\u1970-\\u1974\\u1980-\\u19AB\\u19B0-\\u19C9\\u1A00-\\u1A16\\u1A20-\\u1A54\\u1B05-\\u1B33\\u1B45-\\u1B4B\\u1B83-\\u1BA0\\u1BAE-\\u1BAF\\u1BBA-\\u1BE5\\u1C00-\\u1C23\\u1C4D-\\u1C4F\\u1C5A-\\u1C77\\u1CE9-\\u1CEC\\u1CEE-\\u1CF1\\u1CF5-\\u1CF6\\u2135-\\u2138\\u2D30-\\u2D67\\u2D80-\\u2D96\\u2DA0-\\u2DA6\\u2DA8-\\u2DAE\\u2DB0-\\u2DB6\\u2DB8-\\u2DBE\\u2DC0-\\u2DC6\\u2DC8-\\u2DCE\\u2DD0-\\u2DD6\\u2DD8-\\u2DDE\\u3006\\u303C\\u3041-\\u3096\\u309F\\u30A1-\\u30FA\\u30FF\\u3105-\\u312F\\u3131-\\u318E\\u31A0-\\u31BA\\u31F0-\\u31FF\\u3400-\\u4DB5\\u4E00-\\u9FEF\\uA000-\\uA014\\uA016-\\uA48C\\uA4D0-\\uA4F7\\uA500-\\uA60B\\uA610-\\uA61F\\uA62A-\\uA62B\\uA66E\\uA6A0-\\uA6E5\\uA78F\\uA7F7\\uA7FB-\\uA801\\uA803-\\uA805\\uA807-\\uA80A\\uA80C-\\uA822\\uA840-\\uA873\\uA882-\\uA8B3\\uA8F2-\\uA8F7\\uA8FB\\uA8FD-\\uA8FE\\uA90A-\\uA925\\uA930-\\uA946\\uA960-\\uA97C\\uA984-\\uA9B2\\uA9E0-\\uA9E4\\uA9E7-\\uA9EF\\uA9FA-\\uA9FE\\uAA00-\\uAA28\\uAA40-\\uAA42\\uAA44-\\uAA4B\\uAA60-\\uAA6F\\uAA71-\\uAA76\\uAA7A\\uAA7E-\\uAAAF\\uAAB1\\uAAB5-\\uAAB6\\uAAB9-\\uAABD\\uAAC0\\uAAC2\\uAADB-\\uAADC\\uAAE0-\\uAAEA\\uAAF2\\uAB01-\\uAB06\\uAB09-\\uAB0E\\uAB11-\\uAB16\\uAB20-\\uAB26\\uAB28-\\uAB2E\\uABC0-\\uABE2\\uAC00-\\uD7A3\\uD7B0-\\uD7C6\\uD7CB-\\uD7FB\\uF900-\\uFA6D\\uFA70-\\uFAD9\\uFB1D\\uFB1F-\\uFB28\\uFB2A-\\uFB36\\uFB38-\\uFB3C\\uFB3E\\uFB40-\\uFB41\\uFB43-\\uFB44\\uFB46-\\uFBB1\\uFBD3-\\uFD3D\\uFD50-\\uFD8F\\uFD92-\\uFDC7\\uFDF0-\\uFDFB\\uFE70-\\uFE74\\uFE76-\\uFEFC\\uFF66-\\uFF6F\\uFF71-\\uFF9D\\uFFA0-\\uFFBE\\uFFC2-\\uFFC7\\uFFCA-\\uFFCF\\uFFD2-\\uFFD7\\uFFDA-\\uFFDC]",
 				chars:      []rune{'ª', 'º', 'ƻ', 'ʔ', 'ە', 'ۿ', 'ܐ', 'ޱ', 'ऽ', 'ॐ', 'ল', 'ঽ', 'ৎ', 'ৼ', 'ਫ਼', 'ઽ', 'ૐ', 'ૹ', 'ଽ', 'ୱ', 'ஃ', 'ஜ', 'ௐ', 'ఽ', 'ಀ', 'ಽ', 'ೞ', 'ഽ', 'ൎ', 'ල', 'ຄ', 'ຊ', 'ຍ', 'ລ', 'ວ', 'ຽ', 'ༀ', 'ဿ', 'ၡ', 'ႎ', 'ቘ', 'ዀ', 'ៜ', 'ᢪ', '〆', '〼', 'ゟ', 'ヿ', 'ꙮ', 'ꞏ', 'ꟷ', 'ꣻ', 'ꩺ', 'ꪱ', 'ꫀ', 'ꫂ', 'ꫲ', 'יִ', 'מּ'},
 				ranges:     []rune{'ǀ', 'ǃ', 'א', 'ת', 'ׯ', 'ײ', 'ؠ', 'ؿ', 'ف', 'ي', 'ٮ', 'ٯ', 'ٱ', 'ۓ', 'ۮ', 'ۯ', 'ۺ', 'ۼ', 'ܒ', 'ܯ', 'ݍ', 'ޥ', 'ߊ', 'ߪ', 'ࠀ', 'ࠕ', 'ࡀ', 'ࡘ', 'ࡠ', 'ࡪ', 'ࢠ', 'ࢴ', 'ࢶ', 'ࢽ', 'ऄ', 'ह', 'क़', 'ॡ', 'ॲ', 'ঀ', 'অ', 'ঌ', 'এ', 'ঐ', 'ও', 'ন', 'প', 'র', 'শ', 'হ', 'ড়', 'ঢ়', 'য়', 'ৡ', 'ৰ', 'ৱ', 'ਅ', 'ਊ', 'ਏ', 'ਐ', 'ਓ', 'ਨ', 'ਪ', 'ਰ', 'ਲ', 'ਲ਼', 'ਵ', 'ਸ਼', 'ਸ', 'ਹ', 'ਖ਼', 'ੜ', 'ੲ', 'ੴ', 'અ', 'ઍ', 'એ', 'ઑ', 'ઓ', 'ન', 'પ', 'ર', 'લ', 'ળ', 'વ', 'હ', 'ૠ', 'ૡ', 'ଅ', 'ଌ', 'ଏ', 'ଐ', 'ଓ', 'ନ', 'ପ', 'ର', 'ଲ', 'ଳ', 'ଵ', 'ହ', 'ଡ଼', 'ଢ଼', 'ୟ', 'ୡ', 'அ', 'ஊ', 'எ', 'ஐ', 'ஒ', 'க', 'ங', 'ச', 'ஞ', 'ட', 'ண', 'த', 'ந', 'ப', 'ம', 'ஹ', 'అ', 'ఌ', 'ఎ', 'ఐ', 'ఒ', 'న', 'ప', 'హ', 'ౘ', 'ౚ', 'ౠ', 'ౡ', 'ಅ', 'ಌ', 'ಎ', 'ಐ', 'ಒ', 'ನ', 'ಪ', 'ಳ', 'ವ', 'ಹ', 'ೠ', 'ೡ', 'ೱ', 'ೲ', 'അ', 'ഌ', 'എ', 'ഐ', 'ഒ', 'ഺ', 'ൔ', 'ൖ', 'ൟ', 'ൡ', 'ൺ', 'ൿ', 'අ', 'ඖ', 'ක', 'න', 'ඳ', 'ර', 'ව', 'ෆ', 'ก', 'ะ', 'า', 'ำ', 'เ', 'ๅ', 'ກ', 'ຂ', 'ງ', 'ຈ', 'ດ', 'ທ', 'ນ', 'ຟ', 'ມ', 'ຣ', 'ສ', 'ຫ', 'ອ', 'ະ', 'າ', 'ຳ', 'ເ', 'ໄ', 'ໜ', 'ໟ', 'ཀ', 'ཇ', 'ཉ', 'ཬ', 'ྈ', 'ྌ', 'က', 'ဪ', 'ၐ', 'ၕ', 'ၚ', 'ၝ', 'ၥ', 'ၦ', 'ၮ', 'ၰ', 'ၵ', 'ႁ', 'ᄀ', 'ቈ', 'ቊ', 'ቍ', 'ቐ', 'ቖ', 'ቚ', 'ቝ', 'በ', 'ኈ', 'ኊ', 'ኍ', 'ነ', 'ኰ', 'ኲ', 'ኵ', 'ኸ', 'ኾ', 'ዂ', 'ዅ', 'ወ', 'ዖ', 'ዘ', 'ጐ', 'ጒ', 'ጕ', 'ጘ', 'ፚ', 'ᎀ', 'ᎏ', 'ᐁ', 'ᙬ', 'ᙯ', 'ᙿ', 'ᚁ', 'ᚚ', 'ᚠ', 'ᛪ', 'ᛱ', 'ᛸ', 'ᜀ', 'ᜌ', 'ᜎ', 'ᜑ', 'ᜠ', 'ᜱ', 'ᝀ', 'ᝑ', 'ᝠ', 'ᝬ', 'ᝮ', 'ᝰ', 'ក', 'ឳ', 'ᠠ', 'ᡂ', 'ᡄ', 'ᡸ', 'ᢀ', 'ᢄ', 'ᢇ', 'ᢨ', 'ᢰ', 'ᣵ', 'ᤀ', 'ᤞ', 'ᥐ', 'ᥭ', 'ᥰ', 'ᥴ', 'ᦀ', 'ᦫ', 'ᦰ', 'ᧉ', 'ᨀ', 'ᨖ', 'ᨠ', 'ᩔ', 'ᬅ', 'ᬳ', 'ᭅ', 'ᭋ', 'ᮃ', 'ᮠ', 'ᮮ', 'ᮯ', 'ᮺ', 'ᯥ', 'ᰀ', 'ᰣ', 'ᱍ', 'ᱏ', 'ᱚ', 'ᱷ', 'ᳩ', 'ᳬ', 'ᳮ', 'ᳱ', 'ᳵ', 'ᳶ', 'ℵ', 'ℸ', 'ⴰ', 'ⵧ', 'ⶀ', 'ⶖ', 'ⶠ', 'ⶦ', 'ⶨ', 'ⶮ', 'ⶰ', 'ⶶ', 'ⶸ', 'ⶾ', 'ⷀ', 'ⷆ', 'ⷈ', 'ⷎ', 'ⷐ', 'ⷖ', 'ⷘ', 'ⷞ', 'ぁ', 'ゖ', 'ァ', 'ヺ', 'ㄅ', 'ㄯ', 'ㄱ', 'ㆎ', 'ㆠ', 'ㆺ', 'ㇰ', 'ㇿ', '㐀', '䶵', '一', '鿯', 'ꀀ', 'ꀔ', 'ꀖ', 'ꒌ', 'ꓐ', 'ꓷ', 'ꔀ', 'ꘋ', 'ꘐ', 'ꘟ', 'ꘪ', 'ꘫ', 'ꚠ', 'ꛥ', 'ꟻ', 'ꠁ', 'ꠃ', 'ꠅ', 'ꠇ', 'ꠊ', 'ꠌ', 'ꠢ', 'ꡀ', 'ꡳ', 'ꢂ', 'ꢳ', 'ꣲ', 'ꣷ', 'ꣽ', 'ꣾ', 'ꤊ', 'ꤥ', 'ꤰ', 'ꥆ', 'ꥠ', 'ꥼ', 'ꦄ', 'ꦲ', 'ꧠ', 'ꧤ', 'ꧧ', 'ꧯ', 'ꧺ', 'ꧾ', 'ꨀ', 'ꨨ', 'ꩀ', 'ꩂ', 'ꩄ', 'ꩋ', 'ꩠ', 'ꩯ', 'ꩱ', 'ꩶ', 'ꩾ', 'ꪯ', 'ꪵ', 'ꪶ', 'ꪹ', 'ꪽ', 'ꫛ', 'ꫜ', 'ꫠ', 'ꫪ', 'ꬁ', 'ꬆ', 'ꬉ', 'ꬎ', 'ꬑ', 'ꬖ', 'ꬠ', 'ꬦ', 'ꬨ', 'ꬮ', 'ꯀ', 'ꯢ', '가', '힣', 'ힰ', 'ퟆ', 'ퟋ', 'ퟻ', '豈', '舘', '並', '龎', 'ײַ', 'ﬨ', 'שׁ', 'זּ', 'טּ', 'לּ', 'נּ', 'סּ', 'ףּ', 'פּ', 'צּ', 'ﮱ', 'ﯓ', 'ﴽ', 'ﵐ', 'ﶏ', 'ﶒ', 'ﷇ', 'ﷰ', 'ﷻ', 'ﹰ', 'ﹴ', 'ﹶ', 'ﻼ', 'ｦ', 'ｯ', 'ｱ', 'ﾝ', 'ﾠ', 'ﾾ', 'ￂ', 'ￇ', 'ￊ', 'ￏ', 'ￒ', 'ￗ', 'ￚ', 'ￜ'},
@@ -13196,9 +13221,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lt",
-			pos:  position{line: 1910, col: 1, offset: 53036},
+			pos:  position{line: 1917, col: 1, offset: 53170},
 			expr: &charClassMatcher{
-				pos:        position{line: 1910, col: 6, offset: 53041},
+				pos:        position{line: 1917, col: 6, offset: 53175},
 				val:        "[\\u01C5\\u01C8\\u01CB\\u01F2\\u1F88-\\u1F8F\\u1F98-\\u1F9F\\u1FA8-\\u1FAF\\u1FBC\\u1FCC\\u1FFC]",
 				chars:      []rune{'ǅ', 'ǈ', 'ǋ', 'ǲ', 'ᾼ', 'ῌ', 'ῼ'},
 				ranges:     []rune{'ᾈ', 'ᾏ', 'ᾘ', 'ᾟ', 'ᾨ', 'ᾯ'},
@@ -13210,9 +13235,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lu",
-			pos:  position{line: 1913, col: 1, offset: 53147},
+			pos:  position{line: 1920, col: 1, offset: 53281},
 			expr: &charClassMatcher{
-				pos:        position{line: 1913, col: 6, offset: 53152},
+				pos:        position{line: 1920, col: 6, offset: 53286},
 				val:        "[\\u0041-\\u005A\\u00C0-\\u00D6\\u00D8-\\u00DE\\u0100\\u0102\\u0104\\u0106\\u0108\\u010A\\u010C\\u010E\\u0110\\u0112\\u0114\\u0116\\u0118\\u011A\\u011C\\u011E\\u0120\\u0122\\u0124\\u0126\\u0128\\u012A\\u012C\\u012E\\u0130\\u0132\\u0134\\u0136\\u0139\\u013B\\u013D\\u013F\\u0141\\u0143\\u0145\\u0147\\u014A\\u014C\\u014E\\u0150\\u0152\\u0154\\u0156\\u0158\\u015A\\u015C\\u015E\\u0160\\u0162\\u0164\\u0166\\u0168\\u016A\\u016C\\u016E\\u0170\\u0172\\u0174\\u0176\\u0178-\\u0179\\u017B\\u017D\\u0181-\\u0182\\u0184\\u0186-\\u0187\\u0189-\\u018B\\u018E-\\u0191\\u0193-\\u0194\\u0196-\\u0198\\u019C-\\u019D\\u019F-\\u01A0\\u01A2\\u01A4\\u01A6-\\u01A7\\u01A9\\u01AC\\u01AE-\\u01AF\\u01B1-\\u01B3\\u01B5\\u01B7-\\u01B8\\u01BC\\u01C4\\u01C7\\u01CA\\u01CD\\u01CF\\u01D1\\u01D3\\u01D5\\u01D7\\u01D9\\u01DB\\u01DE\\u01E0\\u01E2\\u01E4\\u01E6\\u01E8\\u01EA\\u01EC\\u01EE\\u01F1\\u01F4\\u01F6-\\u01F8\\u01FA\\u01FC\\u01FE\\u0200\\u0202\\u0204\\u0206\\u0208\\u020A\\u020C\\u020E\\u0210\\u0212\\u0214\\u0216\\u0218\\u021A\\u021C\\u021E\\u0220\\u0222\\u0224\\u0226\\u0228\\u022A\\u022C\\u022E\\u0230\\u0232\\u023A-\\u023B\\u023D-\\u023E\\u0241\\u0243-\\u0246\\u0248\\u024A\\u024C\\u024E\\u0370\\u0372\\u0376\\u037F\\u0386\\u0388-\\u038A\\u038C\\u038E-\\u038F\\u0391-\\u03A1\\u03A3-\\u03AB\\u03CF\\u03D2-\\u03D4\\u03D8\\u03DA\\u03DC\\u03DE\\u03E0\\u03E2\\u03E4\\u03E6\\u03E8\\u03EA\\u03EC\\u03EE\\u03F4\\u03F7\\u03F9-\\u03FA\\u03FD-\\u042F\\u0460\\u0462\\u0464\\u0466\\u0468\\u046A\\u046C\\u046E\\u0470\\u0472\\u0474\\u0476\\u0478\\u047A\\u047C\\u047E\\u0480\\u048A\\u048C\\u048E\\u0490\\u0492\\u0494\\u0496\\u0498\\u049A\\u049C\\u049E\\u04A0\\u04A2\\u04A4\\u04A6\\u04A8\\u04AA\\u04AC\\u04AE\\u04B0\\u04B2\\u04B4\\u04B6\\u04B8\\u04BA\\u04BC\\u04BE\\u04C0-\\u04C1\\u04C3\\u04C5\\u04C7\\u04C9\\u04CB\\u04CD\\u04D0\\u04D2\\u04D4\\u04D6\\u04D8\\u04DA\\u04DC\\u04DE\\u04E0\\u04E2\\u04E4\\u04E6\\u04E8\\u04EA\\u04EC\\u04EE\\u04F0\\u04F2\\u04F4\\u04F6\\u04F8\\u04FA\\u04FC\\u04FE\\u0500\\u0502\\u0504\\u0506\\u0508\\u050A\\u050C\\u050E\\u0510\\u0512\\u0514\\u0516\\u0518\\u051A\\u051C\\u051E\\u0520\\u0522\\u0524\\u0526\\u0528\\u052A\\u052C\\u052E\\u0531-\\u0556\\u10A0-\\u10C5\\u10C7\\u10CD\\u13A0-\\u13F5\\u1C90-\\u1CBA\\u1CBD-\\u1CBF\\u1E00\\u1E02\\u1E04\\u1E06\\u1E08\\u1E0A\\u1E0C\\u1E0E\\u1E10\\u1E12\\u1E14\\u1E16\\u1E18\\u1E1A\\u1E1C\\u1E1E\\u1E20\\u1E22\\u1E24\\u1E26\\u1E28\\u1E2A\\u1E2C\\u1E2E\\u1E30\\u1E32\\u1E34\\u1E36\\u1E38\\u1E3A\\u1E3C\\u1E3E\\u1E40\\u1E42\\u1E44\\u1E46\\u1E48\\u1E4A\\u1E4C\\u1E4E\\u1E50\\u1E52\\u1E54\\u1E56\\u1E58\\u1E5A\\u1E5C\\u1E5E\\u1E60\\u1E62\\u1E64\\u1E66\\u1E68\\u1E6A\\u1E6C\\u1E6E\\u1E70\\u1E72\\u1E74\\u1E76\\u1E78\\u1E7A\\u1E7C\\u1E7E\\u1E80\\u1E82\\u1E84\\u1E86\\u1E88\\u1E8A\\u1E8C\\u1E8E\\u1E90\\u1E92\\u1E94\\u1E9E\\u1EA0\\u1EA2\\u1EA4\\u1EA6\\u1EA8\\u1EAA\\u1EAC\\u1EAE\\u1EB0\\u1EB2\\u1EB4\\u1EB6\\u1EB8\\u1EBA\\u1EBC\\u1EBE\\u1EC0\\u1EC2\\u1EC4\\u1EC6\\u1EC8\\u1ECA\\u1ECC\\u1ECE\\u1ED0\\u1ED2\\u1ED4\\u1ED6\\u1ED8\\u1EDA\\u1EDC\\u1EDE\\u1EE0\\u1EE2\\u1EE4\\u1EE6\\u1EE8\\u1EEA\\u1EEC\\u1EEE\\u1EF0\\u1EF2\\u1EF4\\u1EF6\\u1EF8\\u1EFA\\u1EFC\\u1EFE\\u1F08-\\u1F0F\\u1F18-\\u1F1D\\u1F28-\\u1F2F\\u1F38-\\u1F3F\\u1F48-\\u1F4D\\u1F59\\u1F5B\\u1F5D\\u1F5F\\u1F68-\\u1F6F\\u1FB8-\\u1FBB\\u1FC8-\\u1FCB\\u1FD8-\\u1FDB\\u1FE8-\\u1FEC\\u1FF8-\\u1FFB\\u2102\\u2107\\u210B-\\u210D\\u2110-\\u2112\\u2115\\u2119-\\u211D\\u2124\\u2126\\u2128\\u212A-\\u212D\\u2130-\\u2133\\u213E-\\u213F\\u2145\\u2183\\u2C00-\\u2C2E\\u2C60\\u2C62-\\u2C64\\u2C67\\u2C69\\u2C6B\\u2C6D-\\u2C70\\u2C72\\u2C75\\u2C7E-\\u2C80\\u2C82\\u2C84\\u2C86\\u2C88\\u2C8A\\u2C8C\\u2C8E\\u2C90\\u2C92\\u2C94\\u2C96\\u2C98\\u2C9A\\u2C9C\\u2C9E\\u2CA0\\u2CA2\\u2CA4\\u2CA6\\u2CA8\\u2CAA\\u2CAC\\u2CAE\\u2CB0\\u2CB2\\u2CB4\\u2CB6\\u2CB8\\u2CBA\\u2CBC\\u2CBE\\u2CC0\\u2CC2\\u2CC4\\u2CC6\\u2CC8\\u2CCA\\u2CCC\\u2CCE\\u2CD0\\u2CD2\\u2CD4\\u2CD6\\u2CD8\\u2CDA\\u2CDC\\u2CDE\\u2CE0\\u2CE2\\u2CEB\\u2CED\\u2CF2\\uA640\\uA642\\uA644\\uA646\\uA648\\uA64A\\uA64C\\uA64E\\uA650\\uA652\\uA654\\uA656\\uA658\\uA65A\\uA65C\\uA65E\\uA660\\uA662\\uA664\\uA666\\uA668\\uA66A\\uA66C\\uA680\\uA682\\uA684\\uA686\\uA688\\uA68A\\uA68C\\uA68E\\uA690\\uA692\\uA694\\uA696\\uA698\\uA69A\\uA722\\uA724\\uA726\\uA728\\uA72A\\uA72C\\uA72E\\uA732\\uA734\\uA736\\uA738\\uA73A\\uA73C\\uA73E\\uA740\\uA742\\uA744\\uA746\\uA748\\uA74A\\uA74C\\uA74E\\uA750\\uA752\\uA754\\uA756\\uA758\\uA75A\\uA75C\\uA75E\\uA760\\uA762\\uA764\\uA766\\uA768\\uA76A\\uA76C\\uA76E\\uA779\\uA77B\\uA77D-\\uA77E\\uA780\\uA782\\uA784\\uA786\\uA78B\\uA78D\\uA790\\uA792\\uA796\\uA798\\uA79A\\uA79C\\uA79E\\uA7A0\\uA7A2\\uA7A4\\uA7A6\\uA7A8\\uA7AA-\\uA7AE\\uA7B0-\\uA7B4\\uA7B6\\uA7B8\\uFF21-\\uFF3A]",
 				chars:      []rune{'Ā', 'Ă', 'Ą', 'Ć', 'Ĉ', 'Ċ', 'Č', 'Ď', 'Đ', 'Ē', 'Ĕ', 'Ė', 'Ę', 'Ě', 'Ĝ', 'Ğ', 'Ġ', 'Ģ', 'Ĥ', 'Ħ', 'Ĩ', 'Ī', 'Ĭ', 'Į', 'İ', 'Ĳ', 'Ĵ', 'Ķ', 'Ĺ', 'Ļ', 'Ľ', 'Ŀ', 'Ł', 'Ń', 'Ņ', 'Ň', 'Ŋ', 'Ō', 'Ŏ', 'Ő', 'Œ', 'Ŕ', 'Ŗ', 'Ř', 'Ś', 'Ŝ', 'Ş', 'Š', 'Ţ', 'Ť', 'Ŧ', 'Ũ', 'Ū', 'Ŭ', 'Ů', 'Ű', 'Ų', 'Ŵ', 'Ŷ', 'Ż', 'Ž', 'Ƅ', 'Ƣ', 'Ƥ', 'Ʃ', 'Ƭ', 'Ƶ', 'Ƽ', 'Ǆ', 'Ǉ', 'Ǌ', 'Ǎ', 'Ǐ', 'Ǒ', 'Ǔ', 'Ǖ', 'Ǘ', 'Ǚ', 'Ǜ', 'Ǟ', 'Ǡ', 'Ǣ', 'Ǥ', 'Ǧ', 'Ǩ', 'Ǫ', 'Ǭ', 'Ǯ', 'Ǳ', 'Ǵ', 'Ǻ', 'Ǽ', 'Ǿ', 'Ȁ', 'Ȃ', 'Ȅ', 'Ȇ', 'Ȉ', 'Ȋ', 'Ȍ', 'Ȏ', 'Ȑ', 'Ȓ', 'Ȕ', 'Ȗ', 'Ș', 'Ț', 'Ȝ', 'Ȟ', 'Ƞ', 'Ȣ', 'Ȥ', 'Ȧ', 'Ȩ', 'Ȫ', 'Ȭ', 'Ȯ', 'Ȱ', 'Ȳ', 'Ɂ', 'Ɉ', 'Ɋ', 'Ɍ', 'Ɏ', 'Ͱ', 'Ͳ', 'Ͷ', 'Ϳ', 'Ά', 'Ό', 'Ϗ', 'Ϙ', 'Ϛ', 'Ϝ', 'Ϟ', 'Ϡ', 'Ϣ', 'Ϥ', 'Ϧ', 'Ϩ', 'Ϫ', 'Ϭ', 'Ϯ', 'ϴ', 'Ϸ', 'Ѡ', 'Ѣ', 'Ѥ', 'Ѧ', 'Ѩ', 'Ѫ', 'Ѭ', 'Ѯ', 'Ѱ', 'Ѳ', 'Ѵ', 'Ѷ', 'Ѹ', 'Ѻ', 'Ѽ', 'Ѿ', 'Ҁ', 'Ҋ', 'Ҍ', 'Ҏ', 'Ґ', 'Ғ', 'Ҕ', 'Җ', 'Ҙ', 'Қ', 'Ҝ', 'Ҟ', 'Ҡ', 'Ң', 'Ҥ', 'Ҧ', 'Ҩ', 'Ҫ', 'Ҭ', 'Ү', 'Ұ', 'Ҳ', 'Ҵ', 'Ҷ', 'Ҹ', 'Һ', 'Ҽ', 'Ҿ', 'Ӄ', 'Ӆ', 'Ӈ', 'Ӊ', 'Ӌ', 'Ӎ', 'Ӑ', 'Ӓ', 'Ӕ', 'Ӗ', 'Ә', 'Ӛ', 'Ӝ', 'Ӟ', 'Ӡ', 'Ӣ', 'Ӥ', 'Ӧ', 'Ө', 'Ӫ', 'Ӭ', 'Ӯ', 'Ӱ', 'Ӳ', 'Ӵ', 'Ӷ', 'Ӹ', 'Ӻ', 'Ӽ', 'Ӿ', 'Ԁ', 'Ԃ', 'Ԅ', 'Ԇ', 'Ԉ', 'Ԋ', 'Ԍ', 'Ԏ', 'Ԑ', 'Ԓ', 'Ԕ', 'Ԗ', 'Ԙ', 'Ԛ', 'Ԝ', 'Ԟ', 'Ԡ', 'Ԣ', 'Ԥ', 'Ԧ', 'Ԩ', 'Ԫ', 'Ԭ', 'Ԯ', 'Ⴧ', 'Ⴭ', 'Ḁ', 'Ḃ', 'Ḅ', 'Ḇ', 'Ḉ', 'Ḋ', 'Ḍ', 'Ḏ', 'Ḑ', 'Ḓ', 'Ḕ', 'Ḗ', 'Ḙ', 'Ḛ', 'Ḝ', 'Ḟ', 'Ḡ', 'Ḣ', 'Ḥ', 'Ḧ', 'Ḩ', 'Ḫ', 'Ḭ', 'Ḯ', 'Ḱ', 'Ḳ', 'Ḵ', 'Ḷ', 'Ḹ', 'Ḻ', 'Ḽ', 'Ḿ', 'Ṁ', 'Ṃ', 'Ṅ', 'Ṇ', 'Ṉ', 'Ṋ', 'Ṍ', 'Ṏ', 'Ṑ', 'Ṓ', 'Ṕ', 'Ṗ', 'Ṙ', 'Ṛ', 'Ṝ', 'Ṟ', 'Ṡ', 'Ṣ', 'Ṥ', 'Ṧ', 'Ṩ', 'Ṫ', 'Ṭ', 'Ṯ', 'Ṱ', 'Ṳ', 'Ṵ', 'Ṷ', 'Ṹ', 'Ṻ', 'Ṽ', 'Ṿ', 'Ẁ', 'Ẃ', 'Ẅ', 'Ẇ', 'Ẉ', 'Ẋ', 'Ẍ', 'Ẏ', 'Ẑ', 'Ẓ', 'Ẕ', 'ẞ', 'Ạ', 'Ả', 'Ấ', 'Ầ', 'Ẩ', 'Ẫ', 'Ậ', 'Ắ', 'Ằ', 'Ẳ', 'Ẵ', 'Ặ', 'Ẹ', 'Ẻ', 'Ẽ', 'Ế', 'Ề', 'Ể', 'Ễ', 'Ệ', 'Ỉ', 'Ị', 'Ọ', 'Ỏ', 'Ố', 'Ồ', 'Ổ', 'Ỗ', 'Ộ', 'Ớ', 'Ờ', 'Ở', 'Ỡ', 'Ợ', 'Ụ', 'Ủ', 'Ứ', 'Ừ', 'Ử', 'Ữ', 'Ự', 'Ỳ', 'Ỵ', 'Ỷ', 'Ỹ', 'Ỻ', 'Ỽ', 'Ỿ', 'Ὑ', 'Ὓ', 'Ὕ', 'Ὗ', 'ℂ', 'ℇ', 'ℕ', 'ℤ', 'Ω', 'ℨ', 'ⅅ', 'Ↄ', 'Ⱡ', 'Ⱨ', 'Ⱪ', 'Ⱬ', 'Ⱳ', 'Ⱶ', 'Ⲃ', 'Ⲅ', 'Ⲇ', 'Ⲉ', 'Ⲋ', 'Ⲍ', 'Ⲏ', 'Ⲑ', 'Ⲓ', 'Ⲕ', 'Ⲗ', 'Ⲙ', 'Ⲛ', 'Ⲝ', 'Ⲟ', 'Ⲡ', 'Ⲣ', 'Ⲥ', 'Ⲧ', 'Ⲩ', 'Ⲫ', 'Ⲭ', 'Ⲯ', 'Ⲱ', 'Ⲳ', 'Ⲵ', 'Ⲷ', 'Ⲹ', 'Ⲻ', 'Ⲽ', 'Ⲿ', 'Ⳁ', 'Ⳃ', 'Ⳅ', 'Ⳇ', 'Ⳉ', 'Ⳋ', 'Ⳍ', 'Ⳏ', 'Ⳑ', 'Ⳓ', 'Ⳕ', 'Ⳗ', 'Ⳙ', 'Ⳛ', 'Ⳝ', 'Ⳟ', 'Ⳡ', 'Ⳣ', 'Ⳬ', 'Ⳮ', 'Ⳳ', 'Ꙁ', 'Ꙃ', 'Ꙅ', 'Ꙇ', 'Ꙉ', 'Ꙋ', 'Ꙍ', 'Ꙏ', 'Ꙑ', 'Ꙓ', 'Ꙕ', 'Ꙗ', 'Ꙙ', 'Ꙛ', 'Ꙝ', 'Ꙟ', 'Ꙡ', 'Ꙣ', 'Ꙥ', 'Ꙧ', 'Ꙩ', 'Ꙫ', 'Ꙭ', 'Ꚁ', 'Ꚃ', 'Ꚅ', 'Ꚇ', 'Ꚉ', 'Ꚋ', 'Ꚍ', 'Ꚏ', 'Ꚑ', 'Ꚓ', 'Ꚕ', 'Ꚗ', 'Ꚙ', 'Ꚛ', 'Ꜣ', 'Ꜥ', 'Ꜧ', 'Ꜩ', 'Ꜫ', 'Ꜭ', 'Ꜯ', 'Ꜳ', 'Ꜵ', 'Ꜷ', 'Ꜹ', 'Ꜻ', 'Ꜽ', 'Ꜿ', 'Ꝁ', 'Ꝃ', 'Ꝅ', 'Ꝇ', 'Ꝉ', 'Ꝋ', 'Ꝍ', 'Ꝏ', 'Ꝑ', 'Ꝓ', 'Ꝕ', 'Ꝗ', 'Ꝙ', 'Ꝛ', 'Ꝝ', 'Ꝟ', 'Ꝡ', 'Ꝣ', 'Ꝥ', 'Ꝧ', 'Ꝩ', 'Ꝫ', 'Ꝭ', 'Ꝯ', 'Ꝺ', 'Ꝼ', 'Ꞁ', 'Ꞃ', 'Ꞅ', 'Ꞇ', 'Ꞌ', 'Ɥ', 'Ꞑ', 'Ꞓ', 'Ꞗ', 'Ꞙ', 'Ꞛ', 'Ꞝ', 'Ꞟ', 'Ꞡ', 'Ꞣ', 'Ꞥ', 'Ꞧ', 'Ꞩ', 'Ꞷ', 'Ꞹ'},
 				ranges:     []rune{'A', 'Z', 'À', 'Ö', 'Ø', 'Þ', 'Ÿ', 'Ź', 'Ɓ', 'Ƃ', 'Ɔ', 'Ƈ', 'Ɖ', 'Ƌ', 'Ǝ', 'Ƒ', 'Ɠ', 'Ɣ', 'Ɩ', 'Ƙ', 'Ɯ', 'Ɲ', 'Ɵ', 'Ơ', 'Ʀ', 'Ƨ', 'Ʈ', 'Ư', 'Ʊ', 'Ƴ', 'Ʒ', 'Ƹ', 'Ƕ', 'Ǹ', 'Ⱥ', 'Ȼ', 'Ƚ', 'Ⱦ', 'Ƀ', 'Ɇ', 'Έ', 'Ί', 'Ύ', 'Ώ', 'Α', 'Ρ', 'Σ', 'Ϋ', 'ϒ', 'ϔ', 'Ϲ', 'Ϻ', 'Ͻ', 'Я', 'Ӏ', 'Ӂ', 'Ա', 'Ֆ', 'Ⴀ', 'Ⴥ', 'Ꭰ', 'Ᏽ', 'Ა', 'Ჺ', 'Ჽ', 'Ჿ', 'Ἀ', 'Ἇ', 'Ἐ', 'Ἕ', 'Ἠ', 'Ἧ', 'Ἰ', 'Ἷ', 'Ὀ', 'Ὅ', 'Ὠ', 'Ὧ', 'Ᾰ', 'Ά', 'Ὲ', 'Ή', 'Ῐ', 'Ί', 'Ῠ', 'Ῥ', 'Ὸ', 'Ώ', 'ℋ', 'ℍ', 'ℐ', 'ℒ', 'ℙ', 'ℝ', 'K', 'ℭ', 'ℰ', 'ℳ', 'ℾ', 'ℿ', 'Ⰰ', 'Ⱞ', 'Ɫ', 'Ɽ', 'Ɑ', 'Ɒ', 'Ȿ', 'Ⲁ', 'Ᵹ', 'Ꝿ', 'Ɦ', 'Ɪ', 'Ʞ', 'Ꞵ', 'Ａ', 'Ｚ'},
@@ -13224,9 +13249,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mc",
-			pos:  position{line: 1916, col: 1, offset: 57153},
+			pos:  position{line: 1923, col: 1, offset: 57287},
 			expr: &charClassMatcher{
-				pos:        position{line: 1916, col: 6, offset: 57158},
+				pos:        position{line: 1923, col: 6, offset: 57292},
 				val:        "[\\u0903\\u093B\\u093E-\\u0940\\u0949-\\u094C\\u094E-\\u094F\\u0982-\\u0983\\u09BE-\\u09C0\\u09C7-\\u09C8\\u09CB-\\u09CC\\u09D7\\u0A03\\u0A3E-\\u0A40\\u0A83\\u0ABE-\\u0AC0\\u0AC9\\u0ACB-\\u0ACC\\u0B02-\\u0B03\\u0B3E\\u0B40\\u0B47-\\u0B48\\u0B4B-\\u0B4C\\u0B57\\u0BBE-\\u0BBF\\u0BC1-\\u0BC2\\u0BC6-\\u0BC8\\u0BCA-\\u0BCC\\u0BD7\\u0C01-\\u0C03\\u0C41-\\u0C44\\u0C82-\\u0C83\\u0CBE\\u0CC0-\\u0CC4\\u0CC7-\\u0CC8\\u0CCA-\\u0CCB\\u0CD5-\\u0CD6\\u0D02-\\u0D03\\u0D3E-\\u0D40\\u0D46-\\u0D48\\u0D4A-\\u0D4C\\u0D57\\u0D82-\\u0D83\\u0DCF-\\u0DD1\\u0DD8-\\u0DDF\\u0DF2-\\u0DF3\\u0F3E-\\u0F3F\\u0F7F\\u102B-\\u102C\\u1031\\u1038\\u103B-\\u103C\\u1056-\\u1057\\u1062-\\u1064\\u1067-\\u106D\\u1083-\\u1084\\u1087-\\u108C\\u108F\\u109A-\\u109C\\u17B6\\u17BE-\\u17C5\\u17C7-\\u17C8\\u1923-\\u1926\\u1929-\\u192B\\u1930-\\u1931\\u1933-\\u1938\\u1A19-\\u1A1A\\u1A55\\u1A57\\u1A61\\u1A63-\\u1A64\\u1A6D-\\u1A72\\u1B04\\u1B35\\u1B3B\\u1B3D-\\u1B41\\u1B43-\\u1B44\\u1B82\\u1BA1\\u1BA6-\\u1BA7\\u1BAA\\u1BE7\\u1BEA-\\u1BEC\\u1BEE\\u1BF2-\\u1BF3\\u1C24-\\u1C2B\\u1C34-\\u1C35\\u1CE1\\u1CF2-\\u1CF3\\u1CF7\\u302E-\\u302F\\uA823-\\uA824\\uA827\\uA880-\\uA881\\uA8B4-\\uA8C3\\uA952-\\uA953\\uA983\\uA9B4-\\uA9B5\\uA9BA-\\uA9BB\\uA9BD-\\uA9C0\\uAA2F-\\uAA30\\uAA33-\\uAA34\\uAA4D\\uAA7B\\uAA7D\\uAAEB\\uAAEE-\\uAAEF\\uAAF5\\uABE3-\\uABE4\\uABE6-\\uABE7\\uABE9-\\uABEA\\uABEC]",
 				chars:      []rune{'ः', 'ऻ', 'ৗ', 'ਃ', 'ઃ', 'ૉ', 'ା', 'ୀ', 'ୗ', 'ௗ', 'ಾ', 'ൗ', 'ཿ', 'ေ', 'း', 'ႏ', 'ា', 'ᩕ', 'ᩗ', 'ᩡ', 'ᬄ', 'ᬵ', 'ᬻ', 'ᮂ', 'ᮡ', '᮪', 'ᯧ', 'ᯮ', '᳡', '᳷', 'ꠧ', 'ꦃ', 'ꩍ', 'ꩻ', 'ꩽ', 'ꫫ', 'ꫵ', '꯬'},
 				ranges:     []rune{'ा', 'ी', 'ॉ', 'ौ', 'ॎ', 'ॏ', 'ং', 'ঃ', 'া', 'ী', 'ে', 'ৈ', 'ো', 'ৌ', 'ਾ', 'ੀ', 'ા', 'ી', 'ો', 'ૌ', 'ଂ', 'ଃ', 'େ', 'ୈ', 'ୋ', 'ୌ', 'ா', 'ி', 'ு', 'ூ', 'ெ', 'ை', 'ொ', 'ௌ', 'ఁ', 'ః', 'ు', 'ౄ', 'ಂ', 'ಃ', 'ೀ', 'ೄ', 'ೇ', 'ೈ', 'ೊ', 'ೋ', 'ೕ', 'ೖ', 'ം', 'ഃ', 'ാ', 'ീ', 'െ', 'ൈ', 'ൊ', 'ൌ', 'ං', 'ඃ', 'ා', 'ෑ', 'ෘ', 'ෟ', 'ෲ', 'ෳ', '༾', '༿', 'ါ', 'ာ', 'ျ', 'ြ', 'ၖ', 'ၗ', 'ၢ', 'ၤ', 'ၧ', 'ၭ', 'ႃ', 'ႄ', 'ႇ', 'ႌ', 'ႚ', 'ႜ', 'ើ', 'ៅ', 'ះ', 'ៈ', 'ᤣ', 'ᤦ', 'ᤩ', 'ᤫ', 'ᤰ', 'ᤱ', 'ᤳ', 'ᤸ', 'ᨙ', 'ᨚ', 'ᩣ', 'ᩤ', 'ᩭ', 'ᩲ', 'ᬽ', 'ᭁ', 'ᭃ', '᭄', 'ᮦ', 'ᮧ', 'ᯪ', 'ᯬ', '᯲', '᯳', 'ᰤ', 'ᰫ', 'ᰴ', 'ᰵ', 'ᳲ', 'ᳳ', '〮', '〯', 'ꠣ', 'ꠤ', 'ꢀ', 'ꢁ', 'ꢴ', 'ꣃ', 'ꥒ', '꥓', 'ꦴ', 'ꦵ', 'ꦺ', 'ꦻ', 'ꦽ', '꧀', 'ꨯ', 'ꨰ', 'ꨳ', 'ꨴ', 'ꫮ', 'ꫯ', 'ꯣ', 'ꯤ', 'ꯦ', 'ꯧ', 'ꯩ', 'ꯪ'},
@@ -13238,9 +13263,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mn",
-			pos:  position{line: 1919, col: 1, offset: 58346},
+			pos:  position{line: 1926, col: 1, offset: 58480},
 			expr: &charClassMatcher{
-				pos:        position{line: 1919, col: 6, offset: 58351},
+				pos:        position{line: 1926, col: 6, offset: 58485},
 				val:        "[\\u0300-\\u036F\\u0483-\\u0487\\u0591-\\u05BD\\u05BF\\u05C1-\\u05C2\\u05C4-\\u05C5\\u05C7\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7-\\u06E8\\u06EA-\\u06ED\\u0711\\u0730-\\u074A\\u07A6-\\u07B0\\u07EB-\\u07F3\\u07FD\\u0816-\\u0819\\u081B-\\u0823\\u0825-\\u0827\\u0829-\\u082D\\u0859-\\u085B\\u08D3-\\u08E1\\u08E3-\\u0902\\u093A\\u093C\\u0941-\\u0948\\u094D\\u0951-\\u0957\\u0962-\\u0963\\u0981\\u09BC\\u09C1-\\u09C4\\u09CD\\u09E2-\\u09E3\\u09FE\\u0A01-\\u0A02\\u0A3C\\u0A41-\\u0A42\\u0A47-\\u0A48\\u0A4B-\\u0A4D\\u0A51\\u0A70-\\u0A71\\u0A75\\u0A81-\\u0A82\\u0ABC\\u0AC1-\\u0AC5\\u0AC7-\\u0AC8\\u0ACD\\u0AE2-\\u0AE3\\u0AFA-\\u0AFF\\u0B01\\u0B3C\\u0B3F\\u0B41-\\u0B44\\u0B4D\\u0B56\\u0B62-\\u0B63\\u0B82\\u0BC0\\u0BCD\\u0C00\\u0C04\\u0C3E-\\u0C40\\u0C46-\\u0C48\\u0C4A-\\u0C4D\\u0C55-\\u0C56\\u0C62-\\u0C63\\u0C81\\u0CBC\\u0CBF\\u0CC6\\u0CCC-\\u0CCD\\u0CE2-\\u0CE3\\u0D00-\\u0D01\\u0D3B-\\u0D3C\\u0D41-\\u0D44\\u0D4D\\u0D62-\\u0D63\\u0DCA\\u0DD2-\\u0DD4\\u0DD6\\u0E31\\u0E34-\\u0E3A\\u0E47-\\u0E4E\\u0EB1\\u0EB4-\\u0EB9\\u0EBB-\\u0EBC\\u0EC8-\\u0ECD\\u0F18-\\u0F19\\u0F35\\u0F37\\u0F39\\u0F71-\\u0F7E\\u0F80-\\u0F84\\u0F86-\\u0F87\\u0F8D-\\u0F97\\u0F99-\\u0FBC\\u0FC6\\u102D-\\u1030\\u1032-\\u1037\\u1039-\\u103A\\u103D-\\u103E\\u1058-\\u1059\\u105E-\\u1060\\u1071-\\u1074\\u1082\\u1085-\\u1086\\u108D\\u109D\\u135D-\\u135F\\u1712-\\u1714\\u1732-\\u1734\\u1752-\\u1753\\u1772-\\u1773\\u17B4-\\u17B5\\u17B7-\\u17BD\\u17C6\\u17C9-\\u17D3\\u17DD\\u180B-\\u180D\\u1885-\\u1886\\u18A9\\u1920-\\u1922\\u1927-\\u1928\\u1932\\u1939-\\u193B\\u1A17-\\u1A18\\u1A1B\\u1A56\\u1A58-\\u1A5E\\u1A60\\u1A62\\u1A65-\\u1A6C\\u1A73-\\u1A7C\\u1A7F\\u1AB0-\\u1ABD\\u1B00-\\u1B03\\u1B34\\u1B36-\\u1B3A\\u1B3C\\u1B42\\u1B6B-\\u1B73\\u1B80-\\u1B81\\u1BA2-\\u1BA5\\u1BA8-\\u1BA9\\u1BAB-\\u1BAD\\u1BE6\\u1BE8-\\u1BE9\\u1BED\\u1BEF-\\u1BF1\\u1C2C-\\u1C33\\u1C36-\\u1C37\\u1CD0-\\u1CD2\\u1CD4-\\u1CE0\\u1CE2-\\u1CE8\\u1CED\\u1CF4\\u1CF8-\\u1CF9\\u1DC0-\\u1DF9\\u1DFB-\\u1DFF\\u20D0-\\u20DC\\u20E1\\u20E5-\\u20F0\\u2CEF-\\u2CF1\\u2D7F\\u2DE0-\\u2DFF\\u302A-\\u302D\\u3099-\\u309A\\uA66F\\uA674-\\uA67D\\uA69E-\\uA69F\\uA6F0-\\uA6F1\\uA802\\uA806\\uA80B\\uA825-\\uA826\\uA8C4-\\uA8C5\\uA8E0-\\uA8F1\\uA8FF\\uA926-\\uA92D\\uA947-\\uA951\\uA980-\\uA982\\uA9B3\\uA9B6-\\uA9B9\\uA9BC\\uA9E5\\uAA29-\\uAA2E\\uAA31-\\uAA32\\uAA35-\\uAA36\\uAA43\\uAA4C\\uAA7C\\uAAB0\\uAAB2-\\uAAB4\\uAAB7-\\uAAB8\\uAABE-\\uAABF\\uAAC1\\uAAEC-\\uAAED\\uAAF6\\uABE5\\uABE8\\uABED\\uFB1E\\uFE00-\\uFE0F\\uFE20-\\uFE2F]",
 				chars:      []rune{'ֿ', 'ׇ', 'ٰ', 'ܑ', '߽', 'ऺ', '़', '्', 'ঁ', '়', '্', '৾', '਼', 'ੑ', 'ੵ', '઼', '્', 'ଁ', '଼', 'ି', '୍', 'ୖ', 'ஂ', 'ீ', '்', 'ఀ', 'ఄ', 'ಁ', '಼', 'ಿ', 'ೆ', '്', '්', 'ූ', 'ั', 'ັ', '༵', '༷', '༹', '࿆', 'ႂ', 'ႍ', 'ႝ', 'ំ', '៝', 'ᢩ', 'ᤲ', 'ᨛ', 'ᩖ', '᩠', 'ᩢ', '᩿', '᬴', 'ᬼ', 'ᭂ', '᯦', 'ᯭ', '᳭', '᳴', '⃡', '⵿', '꙯', 'ꠂ', '꠆', 'ꠋ', 'ꣿ', '꦳', 'ꦼ', 'ꧥ', 'ꩃ', 'ꩌ', 'ꩼ', 'ꪰ', '꫁', '꫶', 'ꯥ', 'ꯨ', '꯭', 'ﬞ'},
 				ranges:     []rune{'̀', 'ͯ', '҃', '҇', '֑', 'ֽ', 'ׁ', 'ׂ', 'ׄ', 'ׅ', 'ؐ', 'ؚ', 'ً', 'ٟ', 'ۖ', 'ۜ', '۟', 'ۤ', 'ۧ', 'ۨ', '۪', 'ۭ', 'ܰ', '݊', 'ަ', 'ް', '߫', '߳', 'ࠖ', '࠙', 'ࠛ', 'ࠣ', 'ࠥ', 'ࠧ', 'ࠩ', '࠭', '࡙', '࡛', '࣓', '࣡', 'ࣣ', 'ं', 'ु', 'ै', '॑', 'ॗ', 'ॢ', 'ॣ', 'ু', 'ৄ', 'ৢ', 'ৣ', 'ਁ', 'ਂ', 'ੁ', 'ੂ', 'ੇ', 'ੈ', 'ੋ', '੍', 'ੰ', 'ੱ', 'ઁ', 'ં', 'ુ', 'ૅ', 'ે', 'ૈ', 'ૢ', 'ૣ', 'ૺ', '૿', 'ୁ', 'ୄ', 'ୢ', 'ୣ', 'ా', 'ీ', 'ె', 'ై', 'ొ', '్', 'ౕ', 'ౖ', 'ౢ', 'ౣ', 'ೌ', '್', 'ೢ', 'ೣ', 'ഀ', 'ഁ', '഻', '഼', 'ു', 'ൄ', 'ൢ', 'ൣ', 'ි', 'ු', 'ิ', 'ฺ', '็', '๎', 'ິ', 'ູ', 'ົ', 'ຼ', '່', 'ໍ', '༘', '༙', 'ཱ', 'ཾ', 'ྀ', '྄', '྆', '྇', 'ྍ', 'ྗ', 'ྙ', 'ྼ', 'ိ', 'ူ', 'ဲ', '့', '္', '်', 'ွ', 'ှ', 'ၘ', 'ၙ', 'ၞ', 'ၠ', 'ၱ', 'ၴ', 'ႅ', 'ႆ', '፝', '፟', 'ᜒ', '᜔', 'ᜲ', '᜴', 'ᝒ', 'ᝓ', 'ᝲ', 'ᝳ', '឴', '឵', 'ិ', 'ួ', '៉', '៓', '᠋', '᠍', 'ᢅ', 'ᢆ', 'ᤠ', 'ᤢ', 'ᤧ', 'ᤨ', '᤹', '᤻', 'ᨗ', 'ᨘ', 'ᩘ', 'ᩞ', 'ᩥ', 'ᩬ', 'ᩳ', '᩼', '᪰', '᪽', 'ᬀ', 'ᬃ', 'ᬶ', 'ᬺ', '᭫', '᭳', 'ᮀ', 'ᮁ', 'ᮢ', 'ᮥ', 'ᮨ', 'ᮩ', '᮫', 'ᮭ', 'ᯨ', 'ᯩ', 'ᯯ', 'ᯱ', 'ᰬ', 'ᰳ', 'ᰶ', '᰷', '᳐', '᳒', '᳔', '᳠', '᳢', '᳨', '᳸', '᳹', '᷀', '᷹', '᷻', '᷿', '⃐', '⃜', '⃥', '⃰', '⳯', '⳱', 'ⷠ', 'ⷿ', '〪', '〭', '゙', '゚', 'ꙴ', '꙽', 'ꚞ', 'ꚟ', '꛰', '꛱', 'ꠥ', 'ꠦ', '꣄', 'ꣅ', '꣠', '꣱', 'ꤦ', '꤭', 'ꥇ', 'ꥑ', 'ꦀ', 'ꦂ', 'ꦶ', 'ꦹ', 'ꨩ', 'ꨮ', 'ꨱ', 'ꨲ', 'ꨵ', 'ꨶ', 'ꪲ', 'ꪴ', 'ꪷ', 'ꪸ', 'ꪾ', '꪿', 'ꫬ', 'ꫭ', '︀', '️', '︠', '︯'},
@@ -13252,9 +13277,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nd",
-			pos:  position{line: 1922, col: 1, offset: 60531},
+			pos:  position{line: 1929, col: 1, offset: 60665},
 			expr: &charClassMatcher{
-				pos:        position{line: 1922, col: 6, offset: 60536},
+				pos:        position{line: 1929, col: 6, offset: 60670},
 				val:        "[\\u0030-\\u0039\\u0660-\\u0669\\u06F0-\\u06F9\\u07C0-\\u07C9\\u0966-\\u096F\\u09E6-\\u09EF\\u0A66-\\u0A6F\\u0AE6-\\u0AEF\\u0B66-\\u0B6F\\u0BE6-\\u0BEF\\u0C66-\\u0C6F\\u0CE6-\\u0CEF\\u0D66-\\u0D6F\\u0DE6-\\u0DEF\\u0E50-\\u0E59\\u0ED0-\\u0ED9\\u0F20-\\u0F29\\u1040-\\u1049\\u1090-\\u1099\\u17E0-\\u17E9\\u1810-\\u1819\\u1946-\\u194F\\u19D0-\\u19D9\\u1A80-\\u1A89\\u1A90-\\u1A99\\u1B50-\\u1B59\\u1BB0-\\u1BB9\\u1C40-\\u1C49\\u1C50-\\u1C59\\uA620-\\uA629\\uA8D0-\\uA8D9\\uA900-\\uA909\\uA9D0-\\uA9D9\\uA9F0-\\uA9F9\\uAA50-\\uAA59\\uABF0-\\uABF9\\uFF10-\\uFF19]",
 				ranges:     []rune{'0', '9', '٠', '٩', '۰', '۹', '߀', '߉', '०', '९', '০', '৯', '੦', '੯', '૦', '૯', '୦', '୯', '௦', '௯', '౦', '౯', '೦', '೯', '൦', '൯', '෦', '෯', '๐', '๙', '໐', '໙', '༠', '༩', '၀', '၉', '႐', '႙', '០', '៩', '᠐', '᠙', '᥆', '᥏', '᧐', '᧙', '᪀', '᪉', '᪐', '᪙', '᭐', '᭙', '᮰', '᮹', '᱀', '᱉', '᱐', '᱙', '꘠', '꘩', '꣐', '꣙', '꤀', '꤉', '꧐', '꧙', '꧰', '꧹', '꩐', '꩙', '꯰', '꯹', '０', '９'},
 				ignoreCase: false,
@@ -13265,9 +13290,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nl",
-			pos:  position{line: 1925, col: 1, offset: 61039},
+			pos:  position{line: 1932, col: 1, offset: 61173},
 			expr: &charClassMatcher{
-				pos:        position{line: 1925, col: 6, offset: 61044},
+				pos:        position{line: 1932, col: 6, offset: 61178},
 				val:        "[\\u16EE-\\u16F0\\u2160-\\u2182\\u2185-\\u2188\\u3007\\u3021-\\u3029\\u3038-\\u303A\\uA6E6-\\uA6EF]",
 				chars:      []rune{'〇'},
 				ranges:     []rune{'ᛮ', 'ᛰ', 'Ⅰ', 'ↂ', 'ↅ', 'ↈ', '〡', '〩', '〸', '〺', 'ꛦ', 'ꛯ'},
@@ -13279,9 +13304,9 @@ var g = &grammar{
 		},
 		{
 			name: "Pc",
-			pos:  position{line: 1928, col: 1, offset: 61158},
+			pos:  position{line: 1935, col: 1, offset: 61292},
 			expr: &charClassMatcher{
-				pos:        position{line: 1928, col: 6, offset: 61163},
+				pos:        position{line: 1935, col: 6, offset: 61297},
 				val:        "[\\u005F\\u203F-\\u2040\\u2054\\uFE33-\\uFE34\\uFE4D-\\uFE4F\\uFF3F]",
 				chars:      []rune{'_', '⁔', '＿'},
 				ranges:     []rune{'‿', '⁀', '︳', '︴', '﹍', '﹏'},
@@ -13293,9 +13318,9 @@ var g = &grammar{
 		},
 		{
 			name: "Zs",
-			pos:  position{line: 1931, col: 1, offset: 61244},
+			pos:  position{line: 1938, col: 1, offset: 61378},
 			expr: &charClassMatcher{
-				pos:        position{line: 1931, col: 6, offset: 61249},
+				pos:        position{line: 1938, col: 6, offset: 61383},
 				val:        "[\\u0020\\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000]",
 				chars:      []rune{' ', '\u00a0', '\u1680', '\u202f', '\u205f', '\u3000'},
 				ranges:     []rune{'\u2000', '\u200a'},
@@ -13307,9 +13332,9 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1933, col: 1, offset: 61302},
+			pos:  position{line: 1940, col: 1, offset: 61436},
 			expr: &anyMatcher{
-				line: 1934, col: 5, offset: 61322,
+				line: 1941, col: 5, offset: 61456,
 			},
 			leader:        false,
 			leftRecursive: false,
@@ -13317,48 +13342,48 @@ var g = &grammar{
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1936, col: 1, offset: 61325},
+			pos:         position{line: 1943, col: 1, offset: 61459},
 			expr: &choiceExpr{
-				pos: position{line: 1937, col: 5, offset: 61353},
+				pos: position{line: 1944, col: 5, offset: 61487},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1937, col: 5, offset: 61353},
+						pos:        position{line: 1944, col: 5, offset: 61487},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1938, col: 5, offset: 61362},
+						pos:        position{line: 1945, col: 5, offset: 61496},
 						val:        "\v",
 						ignoreCase: false,
 						want:       "\"\\v\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1939, col: 5, offset: 61371},
+						pos:        position{line: 1946, col: 5, offset: 61505},
 						val:        "\f",
 						ignoreCase: false,
 						want:       "\"\\f\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1940, col: 5, offset: 61380},
+						pos:        position{line: 1947, col: 5, offset: 61514},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 1941, col: 5, offset: 61388},
+						pos:        position{line: 1948, col: 5, offset: 61522},
 						val:        "\u00a0",
 						ignoreCase: false,
 						want:       "\"\\u00a0\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1942, col: 5, offset: 61401},
+						pos:        position{line: 1949, col: 5, offset: 61535},
 						val:        "\ufeff",
 						ignoreCase: false,
 						want:       "\"\\ufeff\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1943, col: 5, offset: 61414},
+						pos:  position{line: 1950, col: 5, offset: 61548},
 						name: "Zs",
 					},
 				},
@@ -13368,9 +13393,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1945, col: 1, offset: 61418},
+			pos:  position{line: 1952, col: 1, offset: 61552},
 			expr: &charClassMatcher{
-				pos:        position{line: 1946, col: 5, offset: 61437},
+				pos:        position{line: 1953, col: 5, offset: 61571},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -13382,16 +13407,16 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1948, col: 1, offset: 61457},
+			pos:         position{line: 1955, col: 1, offset: 61591},
 			expr: &choiceExpr{
-				pos: position{line: 1949, col: 5, offset: 61479},
+				pos: position{line: 1956, col: 5, offset: 61613},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1949, col: 5, offset: 61479},
+						pos:  position{line: 1956, col: 5, offset: 61613},
 						name: "MultiLineComment",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1950, col: 5, offset: 61500},
+						pos:  position{line: 1957, col: 5, offset: 61634},
 						name: "SingleLineComment",
 					},
 				},
@@ -13401,39 +13426,39 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1952, col: 1, offset: 61519},
+			pos:  position{line: 1959, col: 1, offset: 61653},
 			expr: &seqExpr{
-				pos: position{line: 1953, col: 5, offset: 61540},
+				pos: position{line: 1960, col: 5, offset: 61674},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1953, col: 5, offset: 61540},
+						pos:        position{line: 1960, col: 5, offset: 61674},
 						val:        "/*",
 						ignoreCase: false,
 						want:       "\"/*\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1953, col: 10, offset: 61545},
+						pos: position{line: 1960, col: 10, offset: 61679},
 						expr: &seqExpr{
-							pos: position{line: 1953, col: 11, offset: 61546},
+							pos: position{line: 1960, col: 11, offset: 61680},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1953, col: 11, offset: 61546},
+									pos: position{line: 1960, col: 11, offset: 61680},
 									expr: &litMatcher{
-										pos:        position{line: 1953, col: 12, offset: 61547},
+										pos:        position{line: 1960, col: 12, offset: 61681},
 										val:        "*/",
 										ignoreCase: false,
 										want:       "\"*/\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1953, col: 17, offset: 61552},
+									pos:  position{line: 1960, col: 17, offset: 61686},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1953, col: 35, offset: 61570},
+						pos:        position{line: 1960, col: 35, offset: 61704},
 						val:        "*/",
 						ignoreCase: false,
 						want:       "\"*/\"",
@@ -13445,30 +13470,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1955, col: 1, offset: 61576},
+			pos:  position{line: 1962, col: 1, offset: 61710},
 			expr: &seqExpr{
-				pos: position{line: 1956, col: 5, offset: 61598},
+				pos: position{line: 1963, col: 5, offset: 61732},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1956, col: 5, offset: 61598},
+						pos:        position{line: 1963, col: 5, offset: 61732},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1956, col: 10, offset: 61603},
+						pos: position{line: 1963, col: 10, offset: 61737},
 						expr: &seqExpr{
-							pos: position{line: 1956, col: 11, offset: 61604},
+							pos: position{line: 1963, col: 11, offset: 61738},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1956, col: 11, offset: 61604},
+									pos: position{line: 1963, col: 11, offset: 61738},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1956, col: 12, offset: 61605},
+										pos:  position{line: 1963, col: 12, offset: 61739},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1956, col: 27, offset: 61620},
+									pos:  position{line: 1963, col: 27, offset: 61754},
 									name: "SourceCharacter",
 								},
 							},
@@ -13481,19 +13506,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1958, col: 1, offset: 61639},
+			pos:  position{line: 1965, col: 1, offset: 61773},
 			expr: &seqExpr{
-				pos: position{line: 1958, col: 7, offset: 61645},
+				pos: position{line: 1965, col: 7, offset: 61779},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1958, col: 7, offset: 61645},
+						pos: position{line: 1965, col: 7, offset: 61779},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1958, col: 7, offset: 61645},
+							pos:  position{line: 1965, col: 7, offset: 61779},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1958, col: 19, offset: 61657},
+						pos:  position{line: 1965, col: 19, offset: 61791},
 						name: "LineTerminator",
 					},
 				},
@@ -13503,16 +13528,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1960, col: 1, offset: 61673},
+			pos:  position{line: 1967, col: 1, offset: 61807},
 			expr: &choiceExpr{
-				pos: position{line: 1960, col: 7, offset: 61679},
+				pos: position{line: 1967, col: 7, offset: 61813},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1960, col: 7, offset: 61679},
+						pos:  position{line: 1967, col: 7, offset: 61813},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1960, col: 11, offset: 61683},
+						pos:  position{line: 1967, col: 11, offset: 61817},
 						name: "EOF",
 					},
 				},
@@ -13522,11 +13547,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1962, col: 1, offset: 61688},
+			pos:  position{line: 1969, col: 1, offset: 61822},
 			expr: &notExpr{
-				pos: position{line: 1962, col: 7, offset: 61694},
+				pos: position{line: 1969, col: 7, offset: 61828},
 				expr: &anyMatcher{
-					line: 1962, col: 8, offset: 61695,
+					line: 1969, col: 8, offset: 61829,
 				},
 			},
 			leader:        false,
@@ -13534,15 +13559,15 @@ var g = &grammar{
 		},
 		{
 			name: "SQLPipe",
-			pos:  position{line: 1966, col: 1, offset: 61720},
+			pos:  position{line: 1973, col: 1, offset: 61854},
 			expr: &actionExpr{
-				pos: position{line: 1967, col: 5, offset: 61732},
+				pos: position{line: 1974, col: 5, offset: 61866},
 				run: (*parser).callonSQLPipe1,
 				expr: &labeledExpr{
-					pos:   position{line: 1967, col: 5, offset: 61732},
+					pos:   position{line: 1974, col: 5, offset: 61866},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1967, col: 7, offset: 61734},
+						pos:  position{line: 1974, col: 7, offset: 61868},
 						name: "Seq",
 					},
 				},
@@ -13552,15 +13577,15 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOp",
-			pos:  position{line: 1975, col: 1, offset: 61881},
+			pos:  position{line: 1982, col: 1, offset: 62015},
 			expr: &actionExpr{
-				pos: position{line: 1976, col: 5, offset: 61891},
+				pos: position{line: 1983, col: 5, offset: 62025},
 				run: (*parser).callonSQLOp1,
 				expr: &labeledExpr{
-					pos:   position{line: 1976, col: 5, offset: 61891},
+					pos:   position{line: 1983, col: 5, offset: 62025},
 					label: "query",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1976, col: 11, offset: 61897},
+						pos:  position{line: 1983, col: 11, offset: 62031},
 						name: "SQLQuery",
 					},
 				},
@@ -13570,42 +13595,42 @@ var g = &grammar{
 		},
 		{
 			name: "SQLQuery",
-			pos:  position{line: 1984, col: 1, offset: 62034},
+			pos:  position{line: 1991, col: 1, offset: 62168},
 			expr: &actionExpr{
-				pos: position{line: 1985, col: 5, offset: 62047},
+				pos: position{line: 1992, col: 5, offset: 62181},
 				run: (*parser).callonSQLQuery1,
 				expr: &seqExpr{
-					pos: position{line: 1985, col: 5, offset: 62047},
+					pos: position{line: 1992, col: 5, offset: 62181},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1985, col: 5, offset: 62047},
+							pos:   position{line: 1992, col: 5, offset: 62181},
 							label: "with",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1985, col: 10, offset: 62052},
+								pos:  position{line: 1992, col: 10, offset: 62186},
 								name: "OptWithClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1986, col: 5, offset: 62070},
+							pos:   position{line: 1993, col: 5, offset: 62204},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1986, col: 10, offset: 62075},
+								pos:  position{line: 1993, col: 10, offset: 62209},
 								name: "SQLBodySetOp",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1987, col: 5, offset: 62092},
+							pos:   position{line: 1994, col: 5, offset: 62226},
 							label: "orderby",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1987, col: 13, offset: 62100},
+								pos:  position{line: 1994, col: 13, offset: 62234},
 								name: "OptOrderByClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1988, col: 5, offset: 62121},
+							pos:   position{line: 1995, col: 5, offset: 62255},
 							label: "loff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1988, col: 10, offset: 62126},
+								pos:  position{line: 1995, col: 10, offset: 62260},
 								name: "OptSQLLimitOffset",
 							},
 						},
@@ -13617,39 +13642,39 @@ var g = &grammar{
 		},
 		{
 			name: "SQLBodySetOp",
-			pos:  position{line: 2006, col: 1, offset: 62543},
+			pos:  position{line: 2013, col: 1, offset: 62677},
 			expr: &actionExpr{
-				pos: position{line: 2007, col: 5, offset: 62560},
+				pos: position{line: 2014, col: 5, offset: 62694},
 				run: (*parser).callonSQLBodySetOp1,
 				expr: &seqExpr{
-					pos: position{line: 2007, col: 5, offset: 62560},
+					pos: position{line: 2014, col: 5, offset: 62694},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2007, col: 5, offset: 62560},
+							pos:   position{line: 2014, col: 5, offset: 62694},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2007, col: 11, offset: 62566},
+								pos:  position{line: 2014, col: 11, offset: 62700},
 								name: "SQLQueryBody",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2007, col: 24, offset: 62579},
+							pos:   position{line: 2014, col: 24, offset: 62713},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2007, col: 29, offset: 62584},
+								pos: position{line: 2014, col: 29, offset: 62718},
 								expr: &seqExpr{
-									pos: position{line: 2007, col: 30, offset: 62585},
+									pos: position{line: 2014, col: 30, offset: 62719},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2007, col: 30, offset: 62585},
+											pos:  position{line: 2014, col: 30, offset: 62719},
 											name: "SetOp",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2007, col: 36, offset: 62591},
+											pos:  position{line: 2014, col: 36, offset: 62725},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2007, col: 38, offset: 62593},
+											pos:  position{line: 2014, col: 38, offset: 62727},
 											name: "SQLQueryBody",
 										},
 									},
@@ -13664,52 +13689,52 @@ var g = &grammar{
 		},
 		{
 			name: "SQLQueryBody",
-			pos:  position{line: 2023, col: 1, offset: 62991},
+			pos:  position{line: 2030, col: 1, offset: 63125},
 			expr: &choiceExpr{
-				pos: position{line: 2024, col: 5, offset: 63008},
+				pos: position{line: 2031, col: 5, offset: 63142},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2024, col: 5, offset: 63008},
+						pos:  position{line: 2031, col: 5, offset: 63142},
 						name: "Select",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2025, col: 5, offset: 63019},
+						pos:  position{line: 2032, col: 5, offset: 63153},
 						name: "FromSelect",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2026, col: 5, offset: 63034},
+						pos:  position{line: 2033, col: 5, offset: 63168},
 						name: "SQLValues",
 					},
 					&actionExpr{
-						pos: position{line: 2027, col: 5, offset: 63048},
+						pos: position{line: 2034, col: 5, offset: 63182},
 						run: (*parser).callonSQLQueryBody5,
 						expr: &seqExpr{
-							pos: position{line: 2027, col: 5, offset: 63048},
+							pos: position{line: 2034, col: 5, offset: 63182},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2027, col: 5, offset: 63048},
+									pos:        position{line: 2034, col: 5, offset: 63182},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2027, col: 9, offset: 63052},
+									pos:  position{line: 2034, col: 9, offset: 63186},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 2027, col: 12, offset: 63055},
+									pos:   position{line: 2034, col: 12, offset: 63189},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2027, col: 14, offset: 63057},
+										pos:  position{line: 2034, col: 14, offset: 63191},
 										name: "SQLQueryOrSetExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2027, col: 32, offset: 63075},
+									pos:  position{line: 2034, col: 32, offset: 63209},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2027, col: 34, offset: 63077},
+									pos:        position{line: 2034, col: 34, offset: 63211},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -13724,16 +13749,16 @@ var g = &grammar{
 		},
 		{
 			name: "SQLQueryOrSetExpr",
-			pos:  position{line: 2029, col: 1, offset: 63100},
+			pos:  position{line: 2036, col: 1, offset: 63234},
 			expr: &choiceExpr{
-				pos: position{line: 2029, col: 21, offset: 63120},
+				pos: position{line: 2036, col: 21, offset: 63254},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2029, col: 21, offset: 63120},
+						pos:  position{line: 2036, col: 21, offset: 63254},
 						name: "SQLQuery",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2029, col: 32, offset: 63131},
+						pos:  position{line: 2036, col: 32, offset: 63265},
 						name: "SQLBodySetOp",
 					},
 				},
@@ -13743,66 +13768,66 @@ var g = &grammar{
 		},
 		{
 			name: "Select",
-			pos:  position{line: 2031, col: 1, offset: 63145},
+			pos:  position{line: 2038, col: 1, offset: 63279},
 			expr: &actionExpr{
-				pos: position{line: 2032, col: 5, offset: 63156},
+				pos: position{line: 2039, col: 5, offset: 63290},
 				run: (*parser).callonSelect1,
 				expr: &seqExpr{
-					pos: position{line: 2032, col: 5, offset: 63156},
+					pos: position{line: 2039, col: 5, offset: 63290},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2032, col: 5, offset: 63156},
+							pos:  position{line: 2039, col: 5, offset: 63290},
 							name: "SELECT",
 						},
 						&labeledExpr{
-							pos:   position{line: 2033, col: 5, offset: 63167},
+							pos:   position{line: 2040, col: 5, offset: 63301},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2033, col: 14, offset: 63176},
+								pos:  position{line: 2040, col: 14, offset: 63310},
 								name: "OptDistinct",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2036, col: 5, offset: 63312},
+							pos:  position{line: 2043, col: 5, offset: 63446},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2036, col: 7, offset: 63314},
+							pos:   position{line: 2043, col: 7, offset: 63448},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2036, col: 17, offset: 63324},
+								pos:  position{line: 2043, col: 17, offset: 63458},
 								name: "Selection",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2037, col: 5, offset: 63338},
+							pos:   position{line: 2044, col: 5, offset: 63472},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2037, col: 10, offset: 63343},
+								pos:  position{line: 2044, col: 10, offset: 63477},
 								name: "OptFromClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2038, col: 5, offset: 63361},
+							pos:   position{line: 2045, col: 5, offset: 63495},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2038, col: 11, offset: 63367},
+								pos:  position{line: 2045, col: 11, offset: 63501},
 								name: "OptWhereClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2039, col: 5, offset: 63386},
+							pos:   position{line: 2046, col: 5, offset: 63520},
 							label: "group",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2039, col: 11, offset: 63392},
+								pos:  position{line: 2046, col: 11, offset: 63526},
 								name: "OptGroupClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2040, col: 5, offset: 63411},
+							pos:   position{line: 2047, col: 5, offset: 63545},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2040, col: 12, offset: 63418},
+								pos:  position{line: 2047, col: 12, offset: 63552},
 								name: "OptHavingClause",
 							},
 						},
@@ -13814,78 +13839,78 @@ var g = &grammar{
 		},
 		{
 			name: "FromSelect",
-			pos:  position{line: 2065, col: 1, offset: 64011},
+			pos:  position{line: 2072, col: 1, offset: 64145},
 			expr: &actionExpr{
-				pos: position{line: 2066, col: 5, offset: 64026},
+				pos: position{line: 2073, col: 5, offset: 64160},
 				run: (*parser).callonFromSelect1,
 				expr: &seqExpr{
-					pos: position{line: 2066, col: 5, offset: 64026},
+					pos: position{line: 2073, col: 5, offset: 64160},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2066, col: 5, offset: 64026},
+							pos:  position{line: 2073, col: 5, offset: 64160},
 							name: "FROM",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2066, col: 10, offset: 64031},
+							pos:  position{line: 2073, col: 10, offset: 64165},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2066, col: 12, offset: 64033},
+							pos:   position{line: 2073, col: 12, offset: 64167},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2066, col: 18, offset: 64039},
+								pos:  position{line: 2073, col: 18, offset: 64173},
 								name: "SQLTableExprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2066, col: 32, offset: 64053},
+							pos:  position{line: 2073, col: 32, offset: 64187},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2066, col: 34, offset: 64055},
+							pos:  position{line: 2073, col: 34, offset: 64189},
 							name: "SELECT",
 						},
 						&labeledExpr{
-							pos:   position{line: 2067, col: 5, offset: 64066},
+							pos:   position{line: 2074, col: 5, offset: 64200},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2067, col: 14, offset: 64075},
+								pos:  position{line: 2074, col: 14, offset: 64209},
 								name: "OptDistinct",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2070, col: 5, offset: 64211},
+							pos:  position{line: 2077, col: 5, offset: 64345},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2070, col: 7, offset: 64213},
+							pos:   position{line: 2077, col: 7, offset: 64347},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2070, col: 17, offset: 64223},
+								pos:  position{line: 2077, col: 17, offset: 64357},
 								name: "Selection",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2071, col: 5, offset: 64237},
+							pos:   position{line: 2078, col: 5, offset: 64371},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2071, col: 11, offset: 64243},
+								pos:  position{line: 2078, col: 11, offset: 64377},
 								name: "OptWhereClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2072, col: 5, offset: 64262},
+							pos:   position{line: 2079, col: 5, offset: 64396},
 							label: "group",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2072, col: 11, offset: 64268},
+								pos:  position{line: 2079, col: 11, offset: 64402},
 								name: "OptGroupClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2073, col: 5, offset: 64287},
+							pos:   position{line: 2080, col: 5, offset: 64421},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2073, col: 12, offset: 64294},
+								pos:  position{line: 2080, col: 12, offset: 64428},
 								name: "OptHavingClause",
 							},
 						},
@@ -13897,26 +13922,26 @@ var g = &grammar{
 		},
 		{
 			name: "SQLValues",
-			pos:  position{line: 2096, col: 1, offset: 64855},
+			pos:  position{line: 2103, col: 1, offset: 64989},
 			expr: &actionExpr{
-				pos: position{line: 2097, col: 5, offset: 64869},
+				pos: position{line: 2104, col: 5, offset: 65003},
 				run: (*parser).callonSQLValues1,
 				expr: &seqExpr{
-					pos: position{line: 2097, col: 5, offset: 64869},
+					pos: position{line: 2104, col: 5, offset: 65003},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2097, col: 5, offset: 64869},
+							pos:  position{line: 2104, col: 5, offset: 65003},
 							name: "VALUES",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2097, col: 12, offset: 64876},
+							pos:  position{line: 2104, col: 12, offset: 65010},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2097, col: 15, offset: 64879},
+							pos:   position{line: 2104, col: 15, offset: 65013},
 							label: "tuples",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2097, col: 22, offset: 64886},
+								pos:  position{line: 2104, col: 22, offset: 65020},
 								name: "SQLTuples",
 							},
 						},
@@ -13928,26 +13953,26 @@ var g = &grammar{
 		},
 		{
 			name: "ValuesOp",
-			pos:  position{line: 2105, col: 1, offset: 65043},
+			pos:  position{line: 2112, col: 1, offset: 65177},
 			expr: &actionExpr{
-				pos: position{line: 2106, col: 5, offset: 65056},
+				pos: position{line: 2113, col: 5, offset: 65190},
 				run: (*parser).callonValuesOp1,
 				expr: &seqExpr{
-					pos: position{line: 2106, col: 5, offset: 65056},
+					pos: position{line: 2113, col: 5, offset: 65190},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2106, col: 5, offset: 65056},
+							pos:  position{line: 2113, col: 5, offset: 65190},
 							name: "VALUES",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2106, col: 12, offset: 65063},
+							pos:  position{line: 2113, col: 12, offset: 65197},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2106, col: 14, offset: 65065},
+							pos:   position{line: 2113, col: 14, offset: 65199},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2106, col: 20, offset: 65071},
+								pos:  position{line: 2113, col: 20, offset: 65205},
 								name: "Exprs",
 							},
 						},
@@ -13959,51 +13984,51 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTuples",
-			pos:  position{line: 2115, col: 1, offset: 65222},
+			pos:  position{line: 2122, col: 1, offset: 65356},
 			expr: &actionExpr{
-				pos: position{line: 2116, col: 5, offset: 65236},
+				pos: position{line: 2123, col: 5, offset: 65370},
 				run: (*parser).callonSQLTuples1,
 				expr: &seqExpr{
-					pos: position{line: 2116, col: 5, offset: 65236},
+					pos: position{line: 2123, col: 5, offset: 65370},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2116, col: 5, offset: 65236},
+							pos:   position{line: 2123, col: 5, offset: 65370},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2116, col: 11, offset: 65242},
+								pos:  position{line: 2123, col: 11, offset: 65376},
 								name: "SQLTuple",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2116, col: 20, offset: 65251},
+							pos:   position{line: 2123, col: 20, offset: 65385},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2116, col: 25, offset: 65256},
+								pos: position{line: 2123, col: 25, offset: 65390},
 								expr: &actionExpr{
-									pos: position{line: 2116, col: 26, offset: 65257},
+									pos: position{line: 2123, col: 26, offset: 65391},
 									run: (*parser).callonSQLTuples7,
 									expr: &seqExpr{
-										pos: position{line: 2116, col: 26, offset: 65257},
+										pos: position{line: 2123, col: 26, offset: 65391},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2116, col: 26, offset: 65257},
+												pos:  position{line: 2123, col: 26, offset: 65391},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2116, col: 29, offset: 65260},
+												pos:        position{line: 2123, col: 29, offset: 65394},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2116, col: 33, offset: 65264},
+												pos:  position{line: 2123, col: 33, offset: 65398},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2116, col: 36, offset: 65267},
+												pos:   position{line: 2123, col: 36, offset: 65401},
 												label: "t",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2116, col: 38, offset: 65269},
+													pos:  position{line: 2123, col: 38, offset: 65403},
 													name: "SQLTuple",
 												},
 											},
@@ -14020,37 +14045,37 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTuple",
-			pos:  position{line: 2120, col: 1, offset: 65346},
+			pos:  position{line: 2127, col: 1, offset: 65480},
 			expr: &actionExpr{
-				pos: position{line: 2121, col: 5, offset: 65359},
+				pos: position{line: 2128, col: 5, offset: 65493},
 				run: (*parser).callonSQLTuple1,
 				expr: &seqExpr{
-					pos: position{line: 2121, col: 5, offset: 65359},
+					pos: position{line: 2128, col: 5, offset: 65493},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2121, col: 5, offset: 65359},
+							pos:        position{line: 2128, col: 5, offset: 65493},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2121, col: 9, offset: 65363},
+							pos:  position{line: 2128, col: 9, offset: 65497},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2121, col: 12, offset: 65366},
+							pos:   position{line: 2128, col: 12, offset: 65500},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2121, col: 18, offset: 65372},
+								pos:  position{line: 2128, col: 18, offset: 65506},
 								name: "Exprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2121, col: 24, offset: 65378},
+							pos:  position{line: 2128, col: 24, offset: 65512},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2121, col: 27, offset: 65381},
+							pos:        position{line: 2128, col: 27, offset: 65515},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -14063,49 +14088,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptDistinct",
-			pos:  position{line: 2129, col: 1, offset: 65525},
+			pos:  position{line: 2136, col: 1, offset: 65659},
 			expr: &choiceExpr{
-				pos: position{line: 2130, col: 5, offset: 65541},
+				pos: position{line: 2137, col: 5, offset: 65675},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2130, col: 5, offset: 65541},
+						pos: position{line: 2137, col: 5, offset: 65675},
 						run: (*parser).callonOptDistinct2,
 						expr: &seqExpr{
-							pos: position{line: 2130, col: 5, offset: 65541},
+							pos: position{line: 2137, col: 5, offset: 65675},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2130, col: 5, offset: 65541},
+									pos:  position{line: 2137, col: 5, offset: 65675},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2130, col: 7, offset: 65543},
+									pos:  position{line: 2137, col: 7, offset: 65677},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2131, col: 5, offset: 65580},
+						pos: position{line: 2138, col: 5, offset: 65714},
 						run: (*parser).callonOptDistinct6,
 						expr: &seqExpr{
-							pos: position{line: 2131, col: 5, offset: 65580},
+							pos: position{line: 2138, col: 5, offset: 65714},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2131, col: 5, offset: 65580},
+									pos:  position{line: 2138, col: 5, offset: 65714},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2131, col: 7, offset: 65582},
+									pos:  position{line: 2138, col: 7, offset: 65716},
 									name: "DISTINCT",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2132, col: 5, offset: 65618},
+						pos: position{line: 2139, col: 5, offset: 65752},
 						run: (*parser).callonOptDistinct10,
 						expr: &litMatcher{
-							pos:        position{line: 2132, col: 5, offset: 65618},
+							pos:        position{line: 2139, col: 5, offset: 65752},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14118,19 +14143,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptWithClause",
-			pos:  position{line: 2134, col: 1, offset: 65657},
+			pos:  position{line: 2141, col: 1, offset: 65791},
 			expr: &choiceExpr{
-				pos: position{line: 2135, col: 5, offset: 65675},
+				pos: position{line: 2142, col: 5, offset: 65809},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2135, col: 5, offset: 65675},
+						pos:  position{line: 2142, col: 5, offset: 65809},
 						name: "WithClause",
 					},
 					&actionExpr{
-						pos: position{line: 2136, col: 5, offset: 65690},
+						pos: position{line: 2143, col: 5, offset: 65824},
 						run: (*parser).callonOptWithClause3,
 						expr: &litMatcher{
-							pos:        position{line: 2136, col: 5, offset: 65690},
+							pos:        position{line: 2143, col: 5, offset: 65824},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14143,39 +14168,39 @@ var g = &grammar{
 		},
 		{
 			name: "WithClause",
-			pos:  position{line: 2138, col: 1, offset: 65723},
+			pos:  position{line: 2145, col: 1, offset: 65857},
 			expr: &actionExpr{
-				pos: position{line: 2139, col: 5, offset: 65738},
+				pos: position{line: 2146, col: 5, offset: 65872},
 				run: (*parser).callonWithClause1,
 				expr: &seqExpr{
-					pos: position{line: 2139, col: 5, offset: 65738},
+					pos: position{line: 2146, col: 5, offset: 65872},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2139, col: 5, offset: 65738},
+							pos:  position{line: 2146, col: 5, offset: 65872},
 							name: "WITH",
 						},
 						&labeledExpr{
-							pos:   position{line: 2139, col: 10, offset: 65743},
+							pos:   position{line: 2146, col: 10, offset: 65877},
 							label: "r",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2139, col: 12, offset: 65745},
+								pos:  position{line: 2146, col: 12, offset: 65879},
 								name: "OptRecursive",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2139, col: 25, offset: 65758},
+							pos:  position{line: 2146, col: 25, offset: 65892},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2139, col: 27, offset: 65760},
+							pos:   position{line: 2146, col: 27, offset: 65894},
 							label: "ctes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2139, col: 32, offset: 65765},
+								pos:  position{line: 2146, col: 32, offset: 65899},
 								name: "CteList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2139, col: 40, offset: 65773},
+							pos:  position{line: 2146, col: 40, offset: 65907},
 							name: "__",
 						},
 					},
@@ -14186,32 +14211,32 @@ var g = &grammar{
 		},
 		{
 			name: "OptRecursive",
-			pos:  position{line: 2147, col: 1, offset: 65932},
+			pos:  position{line: 2154, col: 1, offset: 66066},
 			expr: &choiceExpr{
-				pos: position{line: 2148, col: 5, offset: 65949},
+				pos: position{line: 2155, col: 5, offset: 66083},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2148, col: 5, offset: 65949},
+						pos: position{line: 2155, col: 5, offset: 66083},
 						run: (*parser).callonOptRecursive2,
 						expr: &seqExpr{
-							pos: position{line: 2148, col: 5, offset: 65949},
+							pos: position{line: 2155, col: 5, offset: 66083},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2148, col: 5, offset: 65949},
+									pos:  position{line: 2155, col: 5, offset: 66083},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2148, col: 7, offset: 65951},
+									pos:  position{line: 2155, col: 7, offset: 66085},
 									name: "RECURSIVE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2149, col: 5, offset: 65987},
+						pos: position{line: 2156, col: 5, offset: 66121},
 						run: (*parser).callonOptRecursive6,
 						expr: &litMatcher{
-							pos:        position{line: 2149, col: 5, offset: 65987},
+							pos:        position{line: 2156, col: 5, offset: 66121},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14224,51 +14249,51 @@ var g = &grammar{
 		},
 		{
 			name: "CteList",
-			pos:  position{line: 2151, col: 1, offset: 66026},
+			pos:  position{line: 2158, col: 1, offset: 66160},
 			expr: &actionExpr{
-				pos: position{line: 2151, col: 11, offset: 66036},
+				pos: position{line: 2158, col: 11, offset: 66170},
 				run: (*parser).callonCteList1,
 				expr: &seqExpr{
-					pos: position{line: 2151, col: 11, offset: 66036},
+					pos: position{line: 2158, col: 11, offset: 66170},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2151, col: 11, offset: 66036},
+							pos:   position{line: 2158, col: 11, offset: 66170},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2151, col: 17, offset: 66042},
+								pos:  position{line: 2158, col: 17, offset: 66176},
 								name: "Cte",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2151, col: 21, offset: 66046},
+							pos:   position{line: 2158, col: 21, offset: 66180},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2151, col: 26, offset: 66051},
+								pos: position{line: 2158, col: 26, offset: 66185},
 								expr: &actionExpr{
-									pos: position{line: 2151, col: 28, offset: 66053},
+									pos: position{line: 2158, col: 28, offset: 66187},
 									run: (*parser).callonCteList7,
 									expr: &seqExpr{
-										pos: position{line: 2151, col: 28, offset: 66053},
+										pos: position{line: 2158, col: 28, offset: 66187},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2151, col: 28, offset: 66053},
+												pos:  position{line: 2158, col: 28, offset: 66187},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2151, col: 31, offset: 66056},
+												pos:        position{line: 2158, col: 31, offset: 66190},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2151, col: 35, offset: 66060},
+												pos:  position{line: 2158, col: 35, offset: 66194},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2151, col: 38, offset: 66063},
+												pos:   position{line: 2158, col: 38, offset: 66197},
 												label: "cte",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2151, col: 42, offset: 66067},
+													pos:  position{line: 2158, col: 42, offset: 66201},
 													name: "Cte",
 												},
 											},
@@ -14285,65 +14310,65 @@ var g = &grammar{
 		},
 		{
 			name: "Cte",
-			pos:  position{line: 2155, col: 1, offset: 66135},
+			pos:  position{line: 2162, col: 1, offset: 66269},
 			expr: &actionExpr{
-				pos: position{line: 2156, col: 5, offset: 66143},
+				pos: position{line: 2163, col: 5, offset: 66277},
 				run: (*parser).callonCte1,
 				expr: &seqExpr{
-					pos: position{line: 2156, col: 5, offset: 66143},
+					pos: position{line: 2163, col: 5, offset: 66277},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2156, col: 5, offset: 66143},
+							pos:   position{line: 2163, col: 5, offset: 66277},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2156, col: 10, offset: 66148},
+								pos:  position{line: 2163, col: 10, offset: 66282},
 								name: "SQLIdentifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2156, col: 24, offset: 66162},
+							pos:  position{line: 2163, col: 24, offset: 66296},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2156, col: 26, offset: 66164},
+							pos:  position{line: 2163, col: 26, offset: 66298},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 2156, col: 29, offset: 66167},
+							pos:   position{line: 2163, col: 29, offset: 66301},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2156, col: 31, offset: 66169},
+								pos:  position{line: 2163, col: 31, offset: 66303},
 								name: "OptMaterialized",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2156, col: 47, offset: 66185},
+							pos:  position{line: 2163, col: 47, offset: 66319},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2156, col: 50, offset: 66188},
+							pos:        position{line: 2163, col: 50, offset: 66322},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2156, col: 54, offset: 66192},
+							pos:  position{line: 2163, col: 54, offset: 66326},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2156, col: 57, offset: 66195},
+							pos:   position{line: 2163, col: 57, offset: 66329},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2156, col: 59, offset: 66197},
+								pos:  position{line: 2163, col: 59, offset: 66331},
 								name: "SQLQueryOrSetExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2156, col: 77, offset: 66215},
+							pos:  position{line: 2163, col: 77, offset: 66349},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2156, col: 80, offset: 66218},
+							pos:        position{line: 2163, col: 80, offset: 66352},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -14356,65 +14381,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptMaterialized",
-			pos:  position{line: 2165, col: 1, offset: 66408},
+			pos:  position{line: 2172, col: 1, offset: 66542},
 			expr: &choiceExpr{
-				pos: position{line: 2166, col: 5, offset: 66428},
+				pos: position{line: 2173, col: 5, offset: 66562},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2166, col: 5, offset: 66428},
+						pos: position{line: 2173, col: 5, offset: 66562},
 						run: (*parser).callonOptMaterialized2,
 						expr: &seqExpr{
-							pos: position{line: 2166, col: 5, offset: 66428},
+							pos: position{line: 2173, col: 5, offset: 66562},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2166, col: 5, offset: 66428},
+									pos:  position{line: 2173, col: 5, offset: 66562},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2166, col: 7, offset: 66430},
+									pos:  position{line: 2173, col: 7, offset: 66564},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2166, col: 20, offset: 66443},
+									pos:  position{line: 2173, col: 20, offset: 66577},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2167, col: 5, offset: 66482},
+						pos: position{line: 2174, col: 5, offset: 66616},
 						run: (*parser).callonOptMaterialized7,
 						expr: &seqExpr{
-							pos: position{line: 2167, col: 5, offset: 66482},
+							pos: position{line: 2174, col: 5, offset: 66616},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2167, col: 5, offset: 66482},
+									pos:  position{line: 2174, col: 5, offset: 66616},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2167, col: 7, offset: 66484},
+									pos:  position{line: 2174, col: 7, offset: 66618},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2167, col: 11, offset: 66488},
+									pos:  position{line: 2174, col: 11, offset: 66622},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2167, col: 13, offset: 66490},
+									pos:  position{line: 2174, col: 13, offset: 66624},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2167, col: 26, offset: 66503},
+									pos:  position{line: 2174, col: 26, offset: 66637},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2168, col: 5, offset: 66534},
+						pos: position{line: 2175, col: 5, offset: 66668},
 						run: (*parser).callonOptMaterialized14,
 						expr: &litMatcher{
-							pos:        position{line: 2168, col: 5, offset: 66534},
+							pos:        position{line: 2175, col: 5, offset: 66668},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14427,25 +14452,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAllClause",
-			pos:  position{line: 2170, col: 1, offset: 66589},
+			pos:  position{line: 2177, col: 1, offset: 66723},
 			expr: &choiceExpr{
-				pos: position{line: 2171, col: 5, offset: 66606},
+				pos: position{line: 2178, col: 5, offset: 66740},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2171, col: 5, offset: 66606},
+						pos: position{line: 2178, col: 5, offset: 66740},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2171, col: 5, offset: 66606},
+								pos:  position{line: 2178, col: 5, offset: 66740},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2171, col: 7, offset: 66608},
+								pos:  position{line: 2178, col: 7, offset: 66742},
 								name: "ALL",
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 2172, col: 5, offset: 66616},
+						pos:        position{line: 2179, col: 5, offset: 66750},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -14457,33 +14482,33 @@ var g = &grammar{
 		},
 		{
 			name: "OptFromClause",
-			pos:  position{line: 2174, col: 1, offset: 66620},
+			pos:  position{line: 2181, col: 1, offset: 66754},
 			expr: &choiceExpr{
-				pos: position{line: 2175, col: 5, offset: 66638},
+				pos: position{line: 2182, col: 5, offset: 66772},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2175, col: 5, offset: 66638},
+						pos: position{line: 2182, col: 5, offset: 66772},
 						run: (*parser).callonOptFromClause2,
 						expr: &seqExpr{
-							pos: position{line: 2175, col: 5, offset: 66638},
+							pos: position{line: 2182, col: 5, offset: 66772},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2175, col: 5, offset: 66638},
+									pos:  position{line: 2182, col: 5, offset: 66772},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2175, col: 7, offset: 66640},
+									pos:  position{line: 2182, col: 7, offset: 66774},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2175, col: 12, offset: 66645},
+									pos:  position{line: 2182, col: 12, offset: 66779},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2175, col: 14, offset: 66647},
+									pos:   position{line: 2182, col: 14, offset: 66781},
 									label: "exprs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2175, col: 20, offset: 66653},
+										pos:  position{line: 2182, col: 20, offset: 66787},
 										name: "SQLTableExprs",
 									},
 								},
@@ -14491,10 +14516,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2178, col: 5, offset: 66703},
+						pos: position{line: 2185, col: 5, offset: 66837},
 						run: (*parser).callonOptFromClause9,
 						expr: &litMatcher{
-							pos:        position{line: 2178, col: 5, offset: 66703},
+							pos:        position{line: 2185, col: 5, offset: 66837},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14507,27 +14532,27 @@ var g = &grammar{
 		},
 		{
 			name: "OptWhereClause",
-			pos:  position{line: 2180, col: 1, offset: 66744},
+			pos:  position{line: 2187, col: 1, offset: 66878},
 			expr: &choiceExpr{
-				pos: position{line: 2181, col: 5, offset: 66763},
+				pos: position{line: 2188, col: 5, offset: 66897},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2181, col: 5, offset: 66763},
+						pos: position{line: 2188, col: 5, offset: 66897},
 						run: (*parser).callonOptWhereClause2,
 						expr: &labeledExpr{
-							pos:   position{line: 2181, col: 5, offset: 66763},
+							pos:   position{line: 2188, col: 5, offset: 66897},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2181, col: 11, offset: 66769},
+								pos:  position{line: 2188, col: 11, offset: 66903},
 								name: "WhereClause",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2182, col: 5, offset: 66811},
+						pos: position{line: 2189, col: 5, offset: 66945},
 						run: (*parser).callonOptWhereClause5,
 						expr: &litMatcher{
-							pos:        position{line: 2182, col: 5, offset: 66811},
+							pos:        position{line: 2189, col: 5, offset: 66945},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14540,25 +14565,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptGroupClause",
-			pos:  position{line: 2184, col: 1, offset: 66856},
+			pos:  position{line: 2191, col: 1, offset: 66990},
 			expr: &choiceExpr{
-				pos: position{line: 2185, col: 5, offset: 66875},
+				pos: position{line: 2192, col: 5, offset: 67009},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2185, col: 5, offset: 66875},
+						pos: position{line: 2192, col: 5, offset: 67009},
 						run: (*parser).callonOptGroupClause2,
 						expr: &seqExpr{
-							pos: position{line: 2185, col: 5, offset: 66875},
+							pos: position{line: 2192, col: 5, offset: 67009},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2185, col: 5, offset: 66875},
+									pos:  position{line: 2192, col: 5, offset: 67009},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2185, col: 7, offset: 66877},
+									pos:   position{line: 2192, col: 7, offset: 67011},
 									label: "group",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2185, col: 13, offset: 66883},
+										pos:  position{line: 2192, col: 13, offset: 67017},
 										name: "GroupClause",
 									},
 								},
@@ -14566,10 +14591,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2186, col: 5, offset: 66921},
+						pos: position{line: 2193, col: 5, offset: 67055},
 						run: (*parser).callonOptGroupClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2186, col: 5, offset: 66921},
+							pos:        position{line: 2193, col: 5, offset: 67055},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14582,34 +14607,34 @@ var g = &grammar{
 		},
 		{
 			name: "GroupClause",
-			pos:  position{line: 2188, col: 1, offset: 66962},
+			pos:  position{line: 2195, col: 1, offset: 67096},
 			expr: &actionExpr{
-				pos: position{line: 2189, col: 5, offset: 66978},
+				pos: position{line: 2196, col: 5, offset: 67112},
 				run: (*parser).callonGroupClause1,
 				expr: &seqExpr{
-					pos: position{line: 2189, col: 5, offset: 66978},
+					pos: position{line: 2196, col: 5, offset: 67112},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2189, col: 5, offset: 66978},
+							pos:  position{line: 2196, col: 5, offset: 67112},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2189, col: 11, offset: 66984},
+							pos:  position{line: 2196, col: 11, offset: 67118},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2189, col: 13, offset: 66986},
+							pos:  position{line: 2196, col: 13, offset: 67120},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2189, col: 16, offset: 66989},
+							pos:  position{line: 2196, col: 16, offset: 67123},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2189, col: 18, offset: 66991},
+							pos:   position{line: 2196, col: 18, offset: 67125},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2189, col: 23, offset: 66996},
+								pos:  position{line: 2196, col: 23, offset: 67130},
 								name: "GroupByList",
 							},
 						},
@@ -14621,51 +14646,51 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByList",
-			pos:  position{line: 2191, col: 1, offset: 67030},
+			pos:  position{line: 2198, col: 1, offset: 67164},
 			expr: &actionExpr{
-				pos: position{line: 2192, col: 5, offset: 67046},
+				pos: position{line: 2199, col: 5, offset: 67180},
 				run: (*parser).callonGroupByList1,
 				expr: &seqExpr{
-					pos: position{line: 2192, col: 5, offset: 67046},
+					pos: position{line: 2199, col: 5, offset: 67180},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2192, col: 5, offset: 67046},
+							pos:   position{line: 2199, col: 5, offset: 67180},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2192, col: 11, offset: 67052},
+								pos:  position{line: 2199, col: 11, offset: 67186},
 								name: "GroupByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2192, col: 23, offset: 67064},
+							pos:   position{line: 2199, col: 23, offset: 67198},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2192, col: 28, offset: 67069},
+								pos: position{line: 2199, col: 28, offset: 67203},
 								expr: &actionExpr{
-									pos: position{line: 2192, col: 30, offset: 67071},
+									pos: position{line: 2199, col: 30, offset: 67205},
 									run: (*parser).callonGroupByList7,
 									expr: &seqExpr{
-										pos: position{line: 2192, col: 30, offset: 67071},
+										pos: position{line: 2199, col: 30, offset: 67205},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2192, col: 30, offset: 67071},
+												pos:  position{line: 2199, col: 30, offset: 67205},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2192, col: 33, offset: 67074},
+												pos:        position{line: 2199, col: 33, offset: 67208},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2192, col: 37, offset: 67078},
+												pos:  position{line: 2199, col: 37, offset: 67212},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2192, col: 40, offset: 67081},
+												pos:   position{line: 2199, col: 40, offset: 67215},
 												label: "g",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2192, col: 42, offset: 67083},
+													pos:  position{line: 2199, col: 42, offset: 67217},
 													name: "GroupByItem",
 												},
 											},
@@ -14682,9 +14707,9 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByItem",
-			pos:  position{line: 2196, col: 1, offset: 67164},
+			pos:  position{line: 2203, col: 1, offset: 67298},
 			expr: &ruleRefExpr{
-				pos:  position{line: 2196, col: 15, offset: 67178},
+				pos:  position{line: 2203, col: 15, offset: 67312},
 				name: "Expr",
 			},
 			leader:        false,
@@ -14692,25 +14717,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptHavingClause",
-			pos:  position{line: 2198, col: 1, offset: 67184},
+			pos:  position{line: 2205, col: 1, offset: 67318},
 			expr: &choiceExpr{
-				pos: position{line: 2199, col: 5, offset: 67204},
+				pos: position{line: 2206, col: 5, offset: 67338},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2199, col: 5, offset: 67204},
+						pos: position{line: 2206, col: 5, offset: 67338},
 						run: (*parser).callonOptHavingClause2,
 						expr: &seqExpr{
-							pos: position{line: 2199, col: 5, offset: 67204},
+							pos: position{line: 2206, col: 5, offset: 67338},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2199, col: 5, offset: 67204},
+									pos:  position{line: 2206, col: 5, offset: 67338},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2199, col: 7, offset: 67206},
+									pos:   position{line: 2206, col: 7, offset: 67340},
 									label: "h",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2199, col: 9, offset: 67208},
+										pos:  position{line: 2206, col: 9, offset: 67342},
 										name: "HavingClause",
 									},
 								},
@@ -14718,10 +14743,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2200, col: 5, offset: 67243},
+						pos: position{line: 2207, col: 5, offset: 67377},
 						run: (*parser).callonOptHavingClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2200, col: 5, offset: 67243},
+							pos:        position{line: 2207, col: 5, offset: 67377},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14734,26 +14759,26 @@ var g = &grammar{
 		},
 		{
 			name: "HavingClause",
-			pos:  position{line: 2202, col: 1, offset: 67267},
+			pos:  position{line: 2209, col: 1, offset: 67401},
 			expr: &actionExpr{
-				pos: position{line: 2203, col: 5, offset: 67284},
+				pos: position{line: 2210, col: 5, offset: 67418},
 				run: (*parser).callonHavingClause1,
 				expr: &seqExpr{
-					pos: position{line: 2203, col: 5, offset: 67284},
+					pos: position{line: 2210, col: 5, offset: 67418},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2203, col: 5, offset: 67284},
+							pos:  position{line: 2210, col: 5, offset: 67418},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2203, col: 12, offset: 67291},
+							pos:  position{line: 2210, col: 12, offset: 67425},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2203, col: 14, offset: 67293},
+							pos:   position{line: 2210, col: 14, offset: 67427},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2203, col: 16, offset: 67295},
+								pos:  position{line: 2210, col: 16, offset: 67429},
 								name: "Expr",
 							},
 						},
@@ -14765,16 +14790,16 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOperation",
-			pos:  position{line: 2205, col: 1, offset: 67319},
+			pos:  position{line: 2212, col: 1, offset: 67453},
 			expr: &choiceExpr{
-				pos: position{line: 2206, col: 5, offset: 67337},
+				pos: position{line: 2213, col: 5, offset: 67471},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2206, col: 5, offset: 67337},
+						pos:  position{line: 2213, col: 5, offset: 67471},
 						name: "CrossJoin",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2207, col: 5, offset: 67351},
+						pos:  position{line: 2214, col: 5, offset: 67485},
 						name: "ConditionJoin",
 					},
 				},
@@ -14784,38 +14809,38 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoin",
-			pos:  position{line: 2209, col: 1, offset: 67366},
+			pos:  position{line: 2216, col: 1, offset: 67500},
 			expr: &actionExpr{
-				pos: position{line: 2210, col: 5, offset: 67380},
+				pos: position{line: 2217, col: 5, offset: 67514},
 				run: (*parser).callonCrossJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2210, col: 5, offset: 67380},
+					pos: position{line: 2217, col: 5, offset: 67514},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2210, col: 5, offset: 67380},
+							pos:  position{line: 2217, col: 5, offset: 67514},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2210, col: 7, offset: 67382},
+							pos:  position{line: 2217, col: 7, offset: 67516},
 							name: "CROSS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2210, col: 13, offset: 67388},
+							pos:  position{line: 2217, col: 13, offset: 67522},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2210, col: 15, offset: 67390},
+							pos:  position{line: 2217, col: 15, offset: 67524},
 							name: "JOIN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2210, col: 20, offset: 67395},
+							pos:  position{line: 2217, col: 20, offset: 67529},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2210, col: 22, offset: 67397},
+							pos:   position{line: 2217, col: 22, offset: 67531},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2210, col: 28, offset: 67403},
+								pos:  position{line: 2217, col: 28, offset: 67537},
 								name: "SQLTableExpr",
 							},
 						},
@@ -14827,42 +14852,42 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionJoin",
-			pos:  position{line: 2218, col: 1, offset: 67578},
+			pos:  position{line: 2225, col: 1, offset: 67712},
 			expr: &actionExpr{
-				pos: position{line: 2219, col: 5, offset: 67596},
+				pos: position{line: 2226, col: 5, offset: 67730},
 				run: (*parser).callonConditionJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2219, col: 5, offset: 67596},
+					pos: position{line: 2226, col: 5, offset: 67730},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2219, col: 5, offset: 67596},
+							pos:   position{line: 2226, col: 5, offset: 67730},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2219, col: 11, offset: 67602},
+								pos:  position{line: 2226, col: 11, offset: 67736},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2219, col: 24, offset: 67615},
+							pos:  position{line: 2226, col: 24, offset: 67749},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2219, col: 26, offset: 67617},
+							pos:   position{line: 2226, col: 26, offset: 67751},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2219, col: 32, offset: 67623},
+								pos:  position{line: 2226, col: 32, offset: 67757},
 								name: "SQLTableExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2219, col: 45, offset: 67636},
+							pos:  position{line: 2226, col: 45, offset: 67770},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2219, col: 47, offset: 67638},
+							pos:   position{line: 2226, col: 47, offset: 67772},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2219, col: 49, offset: 67640},
+								pos:  position{line: 2226, col: 49, offset: 67774},
 								name: "JoinCond",
 							},
 						},
@@ -14874,186 +14899,186 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 2229, col: 1, offset: 67872},
+			pos:  position{line: 2236, col: 1, offset: 68006},
 			expr: &choiceExpr{
-				pos: position{line: 2230, col: 5, offset: 67889},
+				pos: position{line: 2237, col: 5, offset: 68023},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2230, col: 5, offset: 67889},
+						pos: position{line: 2237, col: 5, offset: 68023},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 2230, col: 5, offset: 67889},
+							pos: position{line: 2237, col: 5, offset: 68023},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 2230, col: 5, offset: 67889},
+									pos: position{line: 2237, col: 5, offset: 68023},
 									expr: &seqExpr{
-										pos: position{line: 2230, col: 6, offset: 67890},
+										pos: position{line: 2237, col: 6, offset: 68024},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2230, col: 6, offset: 67890},
+												pos:  position{line: 2237, col: 6, offset: 68024},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2230, col: 8, offset: 67892},
+												pos:  position{line: 2237, col: 8, offset: 68026},
 												name: "INNER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2230, col: 16, offset: 67900},
+									pos:  position{line: 2237, col: 16, offset: 68034},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2230, col: 18, offset: 67902},
+									pos:  position{line: 2237, col: 18, offset: 68036},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2231, col: 5, offset: 67947},
+						pos: position{line: 2238, col: 5, offset: 68081},
 						run: (*parser).callonSQLJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 2231, col: 5, offset: 67947},
+							pos: position{line: 2238, col: 5, offset: 68081},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2231, col: 5, offset: 67947},
+									pos:  position{line: 2238, col: 5, offset: 68081},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2231, col: 7, offset: 67949},
+									pos:  position{line: 2238, col: 7, offset: 68083},
 									name: "ANTI",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2231, col: 12, offset: 67954},
+									pos:  position{line: 2238, col: 12, offset: 68088},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2231, col: 14, offset: 67956},
+									pos:  position{line: 2238, col: 14, offset: 68090},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2232, col: 5, offset: 67988},
+						pos: position{line: 2239, col: 5, offset: 68122},
 						run: (*parser).callonSQLJoinStyle16,
 						expr: &seqExpr{
-							pos: position{line: 2232, col: 5, offset: 67988},
+							pos: position{line: 2239, col: 5, offset: 68122},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2232, col: 5, offset: 67988},
+									pos:  position{line: 2239, col: 5, offset: 68122},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2232, col: 7, offset: 67990},
+									pos:  position{line: 2239, col: 7, offset: 68124},
 									name: "FULL",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2232, col: 12, offset: 67995},
+									pos: position{line: 2239, col: 12, offset: 68129},
 									expr: &seqExpr{
-										pos: position{line: 2232, col: 13, offset: 67996},
+										pos: position{line: 2239, col: 13, offset: 68130},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2232, col: 13, offset: 67996},
+												pos:  position{line: 2239, col: 13, offset: 68130},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2232, col: 15, offset: 67998},
+												pos:  position{line: 2239, col: 15, offset: 68132},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2232, col: 23, offset: 68006},
+									pos:  position{line: 2239, col: 23, offset: 68140},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2232, col: 25, offset: 68008},
+									pos:  position{line: 2239, col: 25, offset: 68142},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2233, col: 5, offset: 68042},
+						pos: position{line: 2240, col: 5, offset: 68176},
 						run: (*parser).callonSQLJoinStyle26,
 						expr: &seqExpr{
-							pos: position{line: 2233, col: 5, offset: 68042},
+							pos: position{line: 2240, col: 5, offset: 68176},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2233, col: 5, offset: 68042},
+									pos:  position{line: 2240, col: 5, offset: 68176},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2233, col: 7, offset: 68044},
+									pos:  position{line: 2240, col: 7, offset: 68178},
 									name: "LEFT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2233, col: 12, offset: 68049},
+									pos: position{line: 2240, col: 12, offset: 68183},
 									expr: &seqExpr{
-										pos: position{line: 2233, col: 13, offset: 68050},
+										pos: position{line: 2240, col: 13, offset: 68184},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2233, col: 13, offset: 68050},
+												pos:  position{line: 2240, col: 13, offset: 68184},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2233, col: 15, offset: 68052},
+												pos:  position{line: 2240, col: 15, offset: 68186},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2233, col: 23, offset: 68060},
+									pos:  position{line: 2240, col: 23, offset: 68194},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2233, col: 25, offset: 68062},
+									pos:  position{line: 2240, col: 25, offset: 68196},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2234, col: 5, offset: 68096},
+						pos: position{line: 2241, col: 5, offset: 68230},
 						run: (*parser).callonSQLJoinStyle36,
 						expr: &seqExpr{
-							pos: position{line: 2234, col: 5, offset: 68096},
+							pos: position{line: 2241, col: 5, offset: 68230},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2234, col: 5, offset: 68096},
+									pos:  position{line: 2241, col: 5, offset: 68230},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2234, col: 7, offset: 68098},
+									pos:  position{line: 2241, col: 7, offset: 68232},
 									name: "RIGHT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2234, col: 13, offset: 68104},
+									pos: position{line: 2241, col: 13, offset: 68238},
 									expr: &seqExpr{
-										pos: position{line: 2234, col: 14, offset: 68105},
+										pos: position{line: 2241, col: 14, offset: 68239},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2234, col: 14, offset: 68105},
+												pos:  position{line: 2241, col: 14, offset: 68239},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2234, col: 16, offset: 68107},
+												pos:  position{line: 2241, col: 16, offset: 68241},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2234, col: 24, offset: 68115},
+									pos:  position{line: 2241, col: 24, offset: 68249},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2234, col: 26, offset: 68117},
+									pos:  position{line: 2241, col: 26, offset: 68251},
 									name: "JOIN",
 								},
 							},
@@ -15066,29 +15091,29 @@ var g = &grammar{
 		},
 		{
 			name: "JoinCond",
-			pos:  position{line: 2236, col: 1, offset: 68149},
+			pos:  position{line: 2243, col: 1, offset: 68283},
 			expr: &choiceExpr{
-				pos: position{line: 2237, col: 5, offset: 68162},
+				pos: position{line: 2244, col: 5, offset: 68296},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2237, col: 5, offset: 68162},
+						pos: position{line: 2244, col: 5, offset: 68296},
 						run: (*parser).callonJoinCond2,
 						expr: &seqExpr{
-							pos: position{line: 2237, col: 5, offset: 68162},
+							pos: position{line: 2244, col: 5, offset: 68296},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2237, col: 5, offset: 68162},
+									pos:  position{line: 2244, col: 5, offset: 68296},
 									name: "ON",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2237, col: 8, offset: 68165},
+									pos:  position{line: 2244, col: 8, offset: 68299},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2237, col: 10, offset: 68167},
+									pos:   position{line: 2244, col: 10, offset: 68301},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2237, col: 12, offset: 68169},
+										pos:  position{line: 2244, col: 12, offset: 68303},
 										name: "Expr",
 									},
 								},
@@ -15096,43 +15121,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2244, col: 5, offset: 68322},
+						pos: position{line: 2251, col: 5, offset: 68456},
 						run: (*parser).callonJoinCond8,
 						expr: &seqExpr{
-							pos: position{line: 2244, col: 5, offset: 68322},
+							pos: position{line: 2251, col: 5, offset: 68456},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2244, col: 5, offset: 68322},
+									pos:  position{line: 2251, col: 5, offset: 68456},
 									name: "USING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2244, col: 11, offset: 68328},
+									pos:  position{line: 2251, col: 11, offset: 68462},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2244, col: 14, offset: 68331},
+									pos:        position{line: 2251, col: 14, offset: 68465},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2244, col: 18, offset: 68335},
+									pos:  position{line: 2251, col: 18, offset: 68469},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 2244, col: 21, offset: 68338},
+									pos:   position{line: 2251, col: 21, offset: 68472},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2244, col: 28, offset: 68345},
+										pos:  position{line: 2251, col: 28, offset: 68479},
 										name: "Lvals",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2244, col: 34, offset: 68351},
+									pos:  position{line: 2251, col: 34, offset: 68485},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2244, col: 37, offset: 68354},
+									pos:        position{line: 2251, col: 37, offset: 68488},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -15147,40 +15172,40 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrdinality",
-			pos:  position{line: 2252, col: 1, offset: 68524},
+			pos:  position{line: 2259, col: 1, offset: 68658},
 			expr: &choiceExpr{
-				pos: position{line: 2253, col: 5, offset: 68542},
+				pos: position{line: 2260, col: 5, offset: 68676},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2253, col: 5, offset: 68542},
+						pos: position{line: 2260, col: 5, offset: 68676},
 						run: (*parser).callonOptOrdinality2,
 						expr: &seqExpr{
-							pos: position{line: 2253, col: 5, offset: 68542},
+							pos: position{line: 2260, col: 5, offset: 68676},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2253, col: 5, offset: 68542},
+									pos:  position{line: 2260, col: 5, offset: 68676},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2253, col: 7, offset: 68544},
+									pos:  position{line: 2260, col: 7, offset: 68678},
 									name: "WITH",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2253, col: 12, offset: 68549},
+									pos:  position{line: 2260, col: 12, offset: 68683},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2253, col: 14, offset: 68551},
+									pos:  position{line: 2260, col: 14, offset: 68685},
 									name: "ORDINALITY",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2258, col: 5, offset: 68648},
+						pos: position{line: 2265, col: 5, offset: 68782},
 						run: (*parser).callonOptOrdinality8,
 						expr: &litMatcher{
-							pos:        position{line: 2258, col: 5, offset: 68648},
+							pos:        position{line: 2265, col: 5, offset: 68782},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15193,25 +15218,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAlias",
-			pos:  position{line: 2260, col: 1, offset: 68697},
+			pos:  position{line: 2267, col: 1, offset: 68831},
 			expr: &choiceExpr{
-				pos: position{line: 2261, col: 5, offset: 68710},
+				pos: position{line: 2268, col: 5, offset: 68844},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2261, col: 5, offset: 68710},
+						pos: position{line: 2268, col: 5, offset: 68844},
 						run: (*parser).callonOptAlias2,
 						expr: &seqExpr{
-							pos: position{line: 2261, col: 5, offset: 68710},
+							pos: position{line: 2268, col: 5, offset: 68844},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2261, col: 5, offset: 68710},
+									pos:  position{line: 2268, col: 5, offset: 68844},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2261, col: 7, offset: 68712},
+									pos:   position{line: 2268, col: 7, offset: 68846},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2261, col: 9, offset: 68714},
+										pos:  position{line: 2268, col: 9, offset: 68848},
 										name: "AliasClause",
 									},
 								},
@@ -15219,10 +15244,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2262, col: 5, offset: 68748},
+						pos: position{line: 2269, col: 5, offset: 68882},
 						run: (*parser).callonOptAlias7,
 						expr: &litMatcher{
-							pos:        position{line: 2262, col: 5, offset: 68748},
+							pos:        position{line: 2269, col: 5, offset: 68882},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15235,51 +15260,51 @@ var g = &grammar{
 		},
 		{
 			name: "AliasClause",
-			pos:  position{line: 2264, col: 1, offset: 68785},
+			pos:  position{line: 2271, col: 1, offset: 68919},
 			expr: &actionExpr{
-				pos: position{line: 2265, col: 4, offset: 68800},
+				pos: position{line: 2272, col: 4, offset: 68934},
 				run: (*parser).callonAliasClause1,
 				expr: &seqExpr{
-					pos: position{line: 2265, col: 4, offset: 68800},
+					pos: position{line: 2272, col: 4, offset: 68934},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2265, col: 4, offset: 68800},
+							pos: position{line: 2272, col: 4, offset: 68934},
 							expr: &seqExpr{
-								pos: position{line: 2265, col: 5, offset: 68801},
+								pos: position{line: 2272, col: 5, offset: 68935},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2265, col: 5, offset: 68801},
+										pos:  position{line: 2272, col: 5, offset: 68935},
 										name: "AS",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2265, col: 8, offset: 68804},
+										pos:  position{line: 2272, col: 8, offset: 68938},
 										name: "_",
 									},
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 2265, col: 12, offset: 68808},
+							pos: position{line: 2272, col: 12, offset: 68942},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2265, col: 13, offset: 68809},
+								pos:  position{line: 2272, col: 13, offset: 68943},
 								name: "SQLGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2265, col: 22, offset: 68818},
+							pos:   position{line: 2272, col: 22, offset: 68952},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2265, col: 27, offset: 68823},
+								pos:  position{line: 2272, col: 27, offset: 68957},
 								name: "IdentifierName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2265, col: 42, offset: 68838},
+							pos:   position{line: 2272, col: 42, offset: 68972},
 							label: "cols",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2265, col: 47, offset: 68843},
+								pos: position{line: 2272, col: 47, offset: 68977},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2265, col: 47, offset: 68843},
+									pos:  position{line: 2272, col: 47, offset: 68977},
 									name: "Columns",
 								},
 							},
@@ -15292,65 +15317,65 @@ var g = &grammar{
 		},
 		{
 			name: "Columns",
-			pos:  position{line: 2273, col: 1, offset: 69022},
+			pos:  position{line: 2280, col: 1, offset: 69156},
 			expr: &actionExpr{
-				pos: position{line: 2274, col: 5, offset: 69034},
+				pos: position{line: 2281, col: 5, offset: 69168},
 				run: (*parser).callonColumns1,
 				expr: &seqExpr{
-					pos: position{line: 2274, col: 5, offset: 69034},
+					pos: position{line: 2281, col: 5, offset: 69168},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2274, col: 5, offset: 69034},
+							pos:  position{line: 2281, col: 5, offset: 69168},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2274, col: 8, offset: 69037},
+							pos:        position{line: 2281, col: 8, offset: 69171},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2274, col: 12, offset: 69041},
+							pos:  position{line: 2281, col: 12, offset: 69175},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2274, col: 15, offset: 69044},
+							pos:   position{line: 2281, col: 15, offset: 69178},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2274, col: 21, offset: 69050},
+								pos:  position{line: 2281, col: 21, offset: 69184},
 								name: "SQLIdentifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2274, col: 35, offset: 69064},
+							pos:   position{line: 2281, col: 35, offset: 69198},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2274, col: 40, offset: 69069},
+								pos: position{line: 2281, col: 40, offset: 69203},
 								expr: &actionExpr{
-									pos: position{line: 2274, col: 42, offset: 69071},
+									pos: position{line: 2281, col: 42, offset: 69205},
 									run: (*parser).callonColumns10,
 									expr: &seqExpr{
-										pos: position{line: 2274, col: 42, offset: 69071},
+										pos: position{line: 2281, col: 42, offset: 69205},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2274, col: 42, offset: 69071},
+												pos:  position{line: 2281, col: 42, offset: 69205},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2274, col: 45, offset: 69074},
+												pos:        position{line: 2281, col: 45, offset: 69208},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2274, col: 49, offset: 69078},
+												pos:  position{line: 2281, col: 49, offset: 69212},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2274, col: 52, offset: 69081},
+												pos:   position{line: 2281, col: 52, offset: 69215},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2274, col: 54, offset: 69083},
+													pos:  position{line: 2281, col: 54, offset: 69217},
 													name: "SQLIdentifier",
 												},
 											},
@@ -15360,11 +15385,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2274, col: 87, offset: 69116},
+							pos:  position{line: 2281, col: 87, offset: 69250},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2274, col: 90, offset: 69119},
+							pos:        position{line: 2281, col: 90, offset: 69253},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -15377,51 +15402,51 @@ var g = &grammar{
 		},
 		{
 			name: "Selection",
-			pos:  position{line: 2278, col: 1, offset: 69190},
+			pos:  position{line: 2285, col: 1, offset: 69324},
 			expr: &actionExpr{
-				pos: position{line: 2279, col: 5, offset: 69204},
+				pos: position{line: 2286, col: 5, offset: 69338},
 				run: (*parser).callonSelection1,
 				expr: &seqExpr{
-					pos: position{line: 2279, col: 5, offset: 69204},
+					pos: position{line: 2286, col: 5, offset: 69338},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2279, col: 5, offset: 69204},
+							pos:   position{line: 2286, col: 5, offset: 69338},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2279, col: 11, offset: 69210},
+								pos:  position{line: 2286, col: 11, offset: 69344},
 								name: "SelectElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2279, col: 22, offset: 69221},
+							pos:   position{line: 2286, col: 22, offset: 69355},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2279, col: 27, offset: 69226},
+								pos: position{line: 2286, col: 27, offset: 69360},
 								expr: &actionExpr{
-									pos: position{line: 2279, col: 29, offset: 69228},
+									pos: position{line: 2286, col: 29, offset: 69362},
 									run: (*parser).callonSelection7,
 									expr: &seqExpr{
-										pos: position{line: 2279, col: 29, offset: 69228},
+										pos: position{line: 2286, col: 29, offset: 69362},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2279, col: 29, offset: 69228},
+												pos:  position{line: 2286, col: 29, offset: 69362},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2279, col: 32, offset: 69231},
+												pos:        position{line: 2286, col: 32, offset: 69365},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2279, col: 36, offset: 69235},
+												pos:  position{line: 2286, col: 36, offset: 69369},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2279, col: 39, offset: 69238},
+												pos:   position{line: 2286, col: 39, offset: 69372},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2279, col: 41, offset: 69240},
+													pos:  position{line: 2286, col: 41, offset: 69374},
 													name: "SelectElem",
 												},
 											},
@@ -15438,38 +15463,38 @@ var g = &grammar{
 		},
 		{
 			name: "SelectElem",
-			pos:  position{line: 2287, col: 1, offset: 69445},
+			pos:  position{line: 2294, col: 1, offset: 69579},
 			expr: &choiceExpr{
-				pos: position{line: 2288, col: 5, offset: 69460},
+				pos: position{line: 2295, col: 5, offset: 69594},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2288, col: 5, offset: 69460},
+						pos: position{line: 2295, col: 5, offset: 69594},
 						run: (*parser).callonSelectElem2,
 						expr: &seqExpr{
-							pos: position{line: 2288, col: 5, offset: 69460},
+							pos: position{line: 2295, col: 5, offset: 69594},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2288, col: 5, offset: 69460},
+									pos:   position{line: 2295, col: 5, offset: 69594},
 									label: "expr",
 									expr: &choiceExpr{
-										pos: position{line: 2288, col: 11, offset: 69466},
+										pos: position{line: 2295, col: 11, offset: 69600},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2288, col: 11, offset: 69466},
+												pos:  position{line: 2295, col: 11, offset: 69600},
 												name: "AggAllOrDistinct",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2288, col: 30, offset: 69485},
+												pos:  position{line: 2295, col: 30, offset: 69619},
 												name: "Expr",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2288, col: 36, offset: 69491},
+									pos:   position{line: 2295, col: 36, offset: 69625},
 									label: "as",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2288, col: 39, offset: 69494},
+										pos:  position{line: 2295, col: 39, offset: 69628},
 										name: "OptAsClause",
 									},
 								},
@@ -15477,10 +15502,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2299, col: 5, offset: 69722},
+						pos: position{line: 2306, col: 5, offset: 69856},
 						run: (*parser).callonSelectElem10,
 						expr: &litMatcher{
-							pos:        position{line: 2299, col: 5, offset: 69722},
+							pos:        position{line: 2306, col: 5, offset: 69856},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -15493,33 +15518,33 @@ var g = &grammar{
 		},
 		{
 			name: "OptAsClause",
-			pos:  position{line: 2304, col: 1, offset: 69827},
+			pos:  position{line: 2311, col: 1, offset: 69961},
 			expr: &choiceExpr{
-				pos: position{line: 2305, col: 5, offset: 69843},
+				pos: position{line: 2312, col: 5, offset: 69977},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2305, col: 5, offset: 69843},
+						pos: position{line: 2312, col: 5, offset: 69977},
 						run: (*parser).callonOptAsClause2,
 						expr: &seqExpr{
-							pos: position{line: 2305, col: 5, offset: 69843},
+							pos: position{line: 2312, col: 5, offset: 69977},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2305, col: 5, offset: 69843},
+									pos:  position{line: 2312, col: 5, offset: 69977},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2305, col: 7, offset: 69845},
+									pos:  position{line: 2312, col: 7, offset: 69979},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2305, col: 10, offset: 69848},
+									pos:  position{line: 2312, col: 10, offset: 69982},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2305, col: 12, offset: 69850},
+									pos:   position{line: 2312, col: 12, offset: 69984},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2305, col: 15, offset: 69853},
+										pos:  position{line: 2312, col: 15, offset: 69987},
 										name: "SQLIdentifier",
 									},
 								},
@@ -15527,27 +15552,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2306, col: 5, offset: 69890},
+						pos: position{line: 2313, col: 5, offset: 70024},
 						run: (*parser).callonOptAsClause9,
 						expr: &seqExpr{
-							pos: position{line: 2306, col: 5, offset: 69890},
+							pos: position{line: 2313, col: 5, offset: 70024},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2306, col: 5, offset: 69890},
+									pos:  position{line: 2313, col: 5, offset: 70024},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 2306, col: 7, offset: 69892},
+									pos: position{line: 2313, col: 7, offset: 70026},
 									expr: &ruleRefExpr{
-										pos:  position{line: 2306, col: 8, offset: 69893},
+										pos:  position{line: 2313, col: 8, offset: 70027},
 										name: "SQLGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2306, col: 17, offset: 69902},
+									pos:   position{line: 2313, col: 17, offset: 70036},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2306, col: 20, offset: 69905},
+										pos:  position{line: 2313, col: 20, offset: 70039},
 										name: "SQLIdentifier",
 									},
 								},
@@ -15555,10 +15580,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2307, col: 5, offset: 69942},
+						pos: position{line: 2314, col: 5, offset: 70076},
 						run: (*parser).callonOptAsClause16,
 						expr: &litMatcher{
-							pos:        position{line: 2307, col: 5, offset: 69942},
+							pos:        position{line: 2314, col: 5, offset: 70076},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15571,41 +15596,41 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrderByClause",
-			pos:  position{line: 2309, col: 1, offset: 69967},
+			pos:  position{line: 2316, col: 1, offset: 70101},
 			expr: &choiceExpr{
-				pos: position{line: 2310, col: 5, offset: 69988},
+				pos: position{line: 2317, col: 5, offset: 70122},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2310, col: 5, offset: 69988},
+						pos: position{line: 2317, col: 5, offset: 70122},
 						run: (*parser).callonOptOrderByClause2,
 						expr: &seqExpr{
-							pos: position{line: 2310, col: 5, offset: 69988},
+							pos: position{line: 2317, col: 5, offset: 70122},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2310, col: 5, offset: 69988},
+									pos:  position{line: 2317, col: 5, offset: 70122},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2310, col: 7, offset: 69990},
+									pos:  position{line: 2317, col: 7, offset: 70124},
 									name: "ORDER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2310, col: 13, offset: 69996},
+									pos:  position{line: 2317, col: 13, offset: 70130},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2310, col: 15, offset: 69998},
+									pos:  position{line: 2317, col: 15, offset: 70132},
 									name: "BY",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2310, col: 18, offset: 70001},
+									pos:  position{line: 2317, col: 18, offset: 70135},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2310, col: 20, offset: 70003},
+									pos:   position{line: 2317, col: 20, offset: 70137},
 									label: "list",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2310, col: 25, offset: 70008},
+										pos:  position{line: 2317, col: 25, offset: 70142},
 										name: "OrderByList",
 									},
 								},
@@ -15613,10 +15638,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2316, col: 5, offset: 70142},
+						pos: position{line: 2323, col: 5, offset: 70276},
 						run: (*parser).callonOptOrderByClause11,
 						expr: &litMatcher{
-							pos:        position{line: 2316, col: 5, offset: 70142},
+							pos:        position{line: 2323, col: 5, offset: 70276},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15629,51 +15654,51 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByList",
-			pos:  position{line: 2318, col: 1, offset: 70175},
+			pos:  position{line: 2325, col: 1, offset: 70309},
 			expr: &actionExpr{
-				pos: position{line: 2319, col: 5, offset: 70191},
+				pos: position{line: 2326, col: 5, offset: 70325},
 				run: (*parser).callonOrderByList1,
 				expr: &seqExpr{
-					pos: position{line: 2319, col: 5, offset: 70191},
+					pos: position{line: 2326, col: 5, offset: 70325},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2319, col: 5, offset: 70191},
+							pos:   position{line: 2326, col: 5, offset: 70325},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2319, col: 11, offset: 70197},
+								pos:  position{line: 2326, col: 11, offset: 70331},
 								name: "OrderByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2319, col: 23, offset: 70209},
+							pos:   position{line: 2326, col: 23, offset: 70343},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2319, col: 28, offset: 70214},
+								pos: position{line: 2326, col: 28, offset: 70348},
 								expr: &actionExpr{
-									pos: position{line: 2319, col: 30, offset: 70216},
+									pos: position{line: 2326, col: 30, offset: 70350},
 									run: (*parser).callonOrderByList7,
 									expr: &seqExpr{
-										pos: position{line: 2319, col: 30, offset: 70216},
+										pos: position{line: 2326, col: 30, offset: 70350},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2319, col: 30, offset: 70216},
+												pos:  position{line: 2326, col: 30, offset: 70350},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2319, col: 33, offset: 70219},
+												pos:        position{line: 2326, col: 33, offset: 70353},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2319, col: 37, offset: 70223},
+												pos:  position{line: 2326, col: 37, offset: 70357},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2319, col: 40, offset: 70226},
+												pos:   position{line: 2326, col: 40, offset: 70360},
 												label: "o",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2319, col: 42, offset: 70228},
+													pos:  position{line: 2326, col: 42, offset: 70362},
 													name: "OrderByItem",
 												},
 											},
@@ -15690,34 +15715,34 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByItem",
-			pos:  position{line: 2323, col: 1, offset: 70329},
+			pos:  position{line: 2330, col: 1, offset: 70463},
 			expr: &actionExpr{
-				pos: position{line: 2324, col: 5, offset: 70345},
+				pos: position{line: 2331, col: 5, offset: 70479},
 				run: (*parser).callonOrderByItem1,
 				expr: &seqExpr{
-					pos: position{line: 2324, col: 5, offset: 70345},
+					pos: position{line: 2331, col: 5, offset: 70479},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2324, col: 5, offset: 70345},
+							pos:   position{line: 2331, col: 5, offset: 70479},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2324, col: 7, offset: 70347},
+								pos:  position{line: 2331, col: 7, offset: 70481},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2324, col: 12, offset: 70352},
+							pos:   position{line: 2331, col: 12, offset: 70486},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2324, col: 18, offset: 70358},
+								pos:  position{line: 2331, col: 18, offset: 70492},
 								name: "OptAscDesc",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2324, col: 29, offset: 70369},
+							pos:   position{line: 2331, col: 29, offset: 70503},
 							label: "nulls",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2324, col: 35, offset: 70375},
+								pos:  position{line: 2331, col: 35, offset: 70509},
 								name: "OptNullsOrder",
 							},
 						},
@@ -15729,49 +15754,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptAscDesc",
-			pos:  position{line: 2335, col: 1, offset: 70607},
+			pos:  position{line: 2342, col: 1, offset: 70741},
 			expr: &choiceExpr{
-				pos: position{line: 2336, col: 5, offset: 70622},
+				pos: position{line: 2343, col: 5, offset: 70756},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2336, col: 5, offset: 70622},
+						pos: position{line: 2343, col: 5, offset: 70756},
 						run: (*parser).callonOptAscDesc2,
 						expr: &seqExpr{
-							pos: position{line: 2336, col: 5, offset: 70622},
+							pos: position{line: 2343, col: 5, offset: 70756},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2336, col: 5, offset: 70622},
+									pos:  position{line: 2343, col: 5, offset: 70756},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2336, col: 7, offset: 70624},
+									pos:  position{line: 2343, col: 7, offset: 70758},
 									name: "ASC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2337, col: 5, offset: 70684},
+						pos: position{line: 2344, col: 5, offset: 70818},
 						run: (*parser).callonOptAscDesc6,
 						expr: &seqExpr{
-							pos: position{line: 2337, col: 5, offset: 70684},
+							pos: position{line: 2344, col: 5, offset: 70818},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2337, col: 5, offset: 70684},
+									pos:  position{line: 2344, col: 5, offset: 70818},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2337, col: 7, offset: 70686},
+									pos:  position{line: 2344, col: 7, offset: 70820},
 									name: "DESC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2338, col: 5, offset: 70746},
+						pos: position{line: 2345, col: 5, offset: 70880},
 						run: (*parser).callonOptAscDesc10,
 						expr: &litMatcher{
-							pos:        position{line: 2338, col: 5, offset: 70746},
+							pos:        position{line: 2345, col: 5, offset: 70880},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15784,65 +15809,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptNullsOrder",
-			pos:  position{line: 2340, col: 1, offset: 70778},
+			pos:  position{line: 2347, col: 1, offset: 70912},
 			expr: &choiceExpr{
-				pos: position{line: 2341, col: 5, offset: 70796},
+				pos: position{line: 2348, col: 5, offset: 70930},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2341, col: 5, offset: 70796},
+						pos: position{line: 2348, col: 5, offset: 70930},
 						run: (*parser).callonOptNullsOrder2,
 						expr: &seqExpr{
-							pos: position{line: 2341, col: 5, offset: 70796},
+							pos: position{line: 2348, col: 5, offset: 70930},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2341, col: 5, offset: 70796},
+									pos:  position{line: 2348, col: 5, offset: 70930},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2341, col: 7, offset: 70798},
+									pos:  position{line: 2348, col: 7, offset: 70932},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2341, col: 13, offset: 70804},
+									pos:  position{line: 2348, col: 13, offset: 70938},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2341, col: 15, offset: 70806},
+									pos:  position{line: 2348, col: 15, offset: 70940},
 									name: "FIRST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2342, col: 5, offset: 70870},
+						pos: position{line: 2349, col: 5, offset: 71004},
 						run: (*parser).callonOptNullsOrder8,
 						expr: &seqExpr{
-							pos: position{line: 2342, col: 5, offset: 70870},
+							pos: position{line: 2349, col: 5, offset: 71004},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2342, col: 5, offset: 70870},
+									pos:  position{line: 2349, col: 5, offset: 71004},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2342, col: 7, offset: 70872},
+									pos:  position{line: 2349, col: 7, offset: 71006},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2342, col: 13, offset: 70878},
+									pos:  position{line: 2349, col: 13, offset: 71012},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2342, col: 15, offset: 70880},
+									pos:  position{line: 2349, col: 15, offset: 71014},
 									name: "LAST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2343, col: 5, offset: 70943},
+						pos: position{line: 2350, col: 5, offset: 71077},
 						run: (*parser).callonOptNullsOrder14,
 						expr: &litMatcher{
-							pos:        position{line: 2343, col: 5, offset: 70943},
+							pos:        position{line: 2350, col: 5, offset: 71077},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15855,25 +15880,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptSQLLimitOffset",
-			pos:  position{line: 2345, col: 1, offset: 70988},
+			pos:  position{line: 2352, col: 1, offset: 71122},
 			expr: &choiceExpr{
-				pos: position{line: 2346, col: 5, offset: 71010},
+				pos: position{line: 2353, col: 5, offset: 71144},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2346, col: 5, offset: 71010},
+						pos: position{line: 2353, col: 5, offset: 71144},
 						run: (*parser).callonOptSQLLimitOffset2,
 						expr: &seqExpr{
-							pos: position{line: 2346, col: 5, offset: 71010},
+							pos: position{line: 2353, col: 5, offset: 71144},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2346, col: 5, offset: 71010},
+									pos:  position{line: 2353, col: 5, offset: 71144},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2346, col: 7, offset: 71012},
+									pos:   position{line: 2353, col: 7, offset: 71146},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2346, col: 10, offset: 71015},
+										pos:  position{line: 2353, col: 10, offset: 71149},
 										name: "SQLLimitOffset",
 									},
 								},
@@ -15881,10 +15906,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2347, col: 5, offset: 71053},
+						pos: position{line: 2354, col: 5, offset: 71187},
 						run: (*parser).callonOptSQLLimitOffset7,
 						expr: &litMatcher{
-							pos:        position{line: 2347, col: 5, offset: 71053},
+							pos:        position{line: 2354, col: 5, offset: 71187},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15897,29 +15922,29 @@ var g = &grammar{
 		},
 		{
 			name: "SQLLimitOffset",
-			pos:  position{line: 2349, col: 1, offset: 71094},
+			pos:  position{line: 2356, col: 1, offset: 71228},
 			expr: &choiceExpr{
-				pos: position{line: 2350, col: 5, offset: 71113},
+				pos: position{line: 2357, col: 5, offset: 71247},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2350, col: 5, offset: 71113},
+						pos: position{line: 2357, col: 5, offset: 71247},
 						run: (*parser).callonSQLLimitOffset2,
 						expr: &seqExpr{
-							pos: position{line: 2350, col: 5, offset: 71113},
+							pos: position{line: 2357, col: 5, offset: 71247},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2350, col: 5, offset: 71113},
+									pos:   position{line: 2357, col: 5, offset: 71247},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2350, col: 7, offset: 71115},
+										pos:  position{line: 2357, col: 7, offset: 71249},
 										name: "LimitClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2350, col: 19, offset: 71127},
+									pos:   position{line: 2357, col: 19, offset: 71261},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2350, col: 21, offset: 71129},
+										pos:  position{line: 2357, col: 21, offset: 71263},
 										name: "OptOffsetClause",
 									},
 								},
@@ -15927,24 +15952,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2362, col: 5, offset: 71361},
+						pos: position{line: 2369, col: 5, offset: 71495},
 						run: (*parser).callonSQLLimitOffset8,
 						expr: &seqExpr{
-							pos: position{line: 2362, col: 5, offset: 71361},
+							pos: position{line: 2369, col: 5, offset: 71495},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2362, col: 5, offset: 71361},
+									pos:   position{line: 2369, col: 5, offset: 71495},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2362, col: 7, offset: 71363},
+										pos:  position{line: 2369, col: 7, offset: 71497},
 										name: "OffsetClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2362, col: 20, offset: 71376},
+									pos:   position{line: 2369, col: 20, offset: 71510},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2362, col: 22, offset: 71378},
+										pos:  position{line: 2369, col: 22, offset: 71512},
 										name: "OptLimitClause",
 									},
 								},
@@ -15958,25 +15983,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptLimitClause",
-			pos:  position{line: 2373, col: 1, offset: 71575},
+			pos:  position{line: 2380, col: 1, offset: 71709},
 			expr: &choiceExpr{
-				pos: position{line: 2374, col: 5, offset: 71594},
+				pos: position{line: 2381, col: 5, offset: 71728},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2374, col: 5, offset: 71594},
+						pos: position{line: 2381, col: 5, offset: 71728},
 						run: (*parser).callonOptLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2374, col: 5, offset: 71594},
+							pos: position{line: 2381, col: 5, offset: 71728},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2374, col: 5, offset: 71594},
+									pos:  position{line: 2381, col: 5, offset: 71728},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2374, col: 7, offset: 71596},
+									pos:   position{line: 2381, col: 7, offset: 71730},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2374, col: 9, offset: 71598},
+										pos:  position{line: 2381, col: 9, offset: 71732},
 										name: "LimitClause",
 									},
 								},
@@ -15984,10 +16009,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2375, col: 5, offset: 71632},
+						pos: position{line: 2382, col: 5, offset: 71766},
 						run: (*parser).callonOptLimitClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2375, col: 5, offset: 71632},
+							pos:        position{line: 2382, col: 5, offset: 71766},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -16000,50 +16025,50 @@ var g = &grammar{
 		},
 		{
 			name: "LimitClause",
-			pos:  position{line: 2377, col: 1, offset: 71669},
+			pos:  position{line: 2384, col: 1, offset: 71803},
 			expr: &choiceExpr{
-				pos: position{line: 2378, col: 5, offset: 71685},
+				pos: position{line: 2385, col: 5, offset: 71819},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2378, col: 5, offset: 71685},
+						pos: position{line: 2385, col: 5, offset: 71819},
 						run: (*parser).callonLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2378, col: 5, offset: 71685},
+							pos: position{line: 2385, col: 5, offset: 71819},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2378, col: 5, offset: 71685},
+									pos:  position{line: 2385, col: 5, offset: 71819},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2378, col: 11, offset: 71691},
+									pos:  position{line: 2385, col: 11, offset: 71825},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2378, col: 13, offset: 71693},
+									pos:  position{line: 2385, col: 13, offset: 71827},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2379, col: 5, offset: 71721},
+						pos: position{line: 2386, col: 5, offset: 71855},
 						run: (*parser).callonLimitClause7,
 						expr: &seqExpr{
-							pos: position{line: 2379, col: 5, offset: 71721},
+							pos: position{line: 2386, col: 5, offset: 71855},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2379, col: 5, offset: 71721},
+									pos:  position{line: 2386, col: 5, offset: 71855},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2379, col: 11, offset: 71727},
+									pos:  position{line: 2386, col: 11, offset: 71861},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2379, col: 13, offset: 71729},
+									pos:   position{line: 2386, col: 13, offset: 71863},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2379, col: 15, offset: 71731},
+										pos:  position{line: 2386, col: 15, offset: 71865},
 										name: "Expr",
 									},
 								},
@@ -16057,25 +16082,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptOffsetClause",
-			pos:  position{line: 2381, col: 1, offset: 71755},
+			pos:  position{line: 2388, col: 1, offset: 71889},
 			expr: &choiceExpr{
-				pos: position{line: 2382, col: 5, offset: 71775},
+				pos: position{line: 2389, col: 5, offset: 71909},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2382, col: 5, offset: 71775},
+						pos: position{line: 2389, col: 5, offset: 71909},
 						run: (*parser).callonOptOffsetClause2,
 						expr: &seqExpr{
-							pos: position{line: 2382, col: 5, offset: 71775},
+							pos: position{line: 2389, col: 5, offset: 71909},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2382, col: 5, offset: 71775},
+									pos:  position{line: 2389, col: 5, offset: 71909},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2382, col: 7, offset: 71777},
+									pos:   position{line: 2389, col: 7, offset: 71911},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2382, col: 9, offset: 71779},
+										pos:  position{line: 2389, col: 9, offset: 71913},
 										name: "OffsetClause",
 									},
 								},
@@ -16083,10 +16108,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2383, col: 5, offset: 71815},
+						pos: position{line: 2390, col: 5, offset: 71949},
 						run: (*parser).callonOptOffsetClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2383, col: 5, offset: 71815},
+							pos:        position{line: 2390, col: 5, offset: 71949},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -16099,26 +16124,26 @@ var g = &grammar{
 		},
 		{
 			name: "OffsetClause",
-			pos:  position{line: 2385, col: 1, offset: 71840},
+			pos:  position{line: 2392, col: 1, offset: 71974},
 			expr: &actionExpr{
-				pos: position{line: 2386, col: 5, offset: 71857},
+				pos: position{line: 2393, col: 5, offset: 71991},
 				run: (*parser).callonOffsetClause1,
 				expr: &seqExpr{
-					pos: position{line: 2386, col: 5, offset: 71857},
+					pos: position{line: 2393, col: 5, offset: 71991},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2386, col: 5, offset: 71857},
+							pos:  position{line: 2393, col: 5, offset: 71991},
 							name: "OFFSET",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2386, col: 12, offset: 71864},
+							pos:  position{line: 2393, col: 12, offset: 71998},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2386, col: 14, offset: 71866},
+							pos:   position{line: 2393, col: 14, offset: 72000},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2386, col: 16, offset: 71868},
+								pos:  position{line: 2393, col: 16, offset: 72002},
 								name: "Expr",
 							},
 						},
@@ -16130,60 +16155,60 @@ var g = &grammar{
 		},
 		{
 			name: "SetOp",
-			pos:  position{line: 2388, col: 1, offset: 71893},
+			pos:  position{line: 2395, col: 1, offset: 72027},
 			expr: &choiceExpr{
-				pos: position{line: 2389, col: 5, offset: 71903},
+				pos: position{line: 2396, col: 5, offset: 72037},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2389, col: 5, offset: 71903},
+						pos: position{line: 2396, col: 5, offset: 72037},
 						run: (*parser).callonSetOp2,
 						expr: &seqExpr{
-							pos: position{line: 2389, col: 5, offset: 71903},
+							pos: position{line: 2396, col: 5, offset: 72037},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2389, col: 5, offset: 71903},
+									pos:  position{line: 2396, col: 5, offset: 72037},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2389, col: 7, offset: 71905},
+									pos:  position{line: 2396, col: 7, offset: 72039},
 									name: "UNION",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2389, col: 13, offset: 71911},
+									pos:  position{line: 2396, col: 13, offset: 72045},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2389, col: 15, offset: 71913},
+									pos:  position{line: 2396, col: 15, offset: 72047},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2390, col: 5, offset: 71949},
+						pos: position{line: 2397, col: 5, offset: 72083},
 						run: (*parser).callonSetOp8,
 						expr: &seqExpr{
-							pos: position{line: 2390, col: 5, offset: 71949},
+							pos: position{line: 2397, col: 5, offset: 72083},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2390, col: 5, offset: 71949},
+									pos:  position{line: 2397, col: 5, offset: 72083},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2390, col: 7, offset: 71951},
+									pos:  position{line: 2397, col: 7, offset: 72085},
 									name: "UNION",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2390, col: 13, offset: 71957},
+									pos: position{line: 2397, col: 13, offset: 72091},
 									expr: &seqExpr{
-										pos: position{line: 2390, col: 14, offset: 71958},
+										pos: position{line: 2397, col: 14, offset: 72092},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2390, col: 14, offset: 71958},
+												pos:  position{line: 2397, col: 14, offset: 72092},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2390, col: 16, offset: 71960},
+												pos:  position{line: 2397, col: 16, offset: 72094},
 												name: "DISTINCT",
 											},
 										},
@@ -16199,88 +16224,88 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGuard",
-			pos:  position{line: 2393, col: 1, offset: 72012},
+			pos:  position{line: 2400, col: 1, offset: 72146},
 			expr: &choiceExpr{
-				pos: position{line: 2394, col: 5, offset: 72027},
+				pos: position{line: 2401, col: 5, offset: 72161},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2394, col: 5, offset: 72027},
+						pos:  position{line: 2401, col: 5, offset: 72161},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2394, col: 12, offset: 72034},
+						pos:  position{line: 2401, col: 12, offset: 72168},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2394, col: 20, offset: 72042},
+						pos:  position{line: 2401, col: 20, offset: 72176},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2394, col: 29, offset: 72051},
+						pos:  position{line: 2401, col: 29, offset: 72185},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2394, col: 38, offset: 72060},
+						pos:  position{line: 2401, col: 38, offset: 72194},
 						name: "RECURSIVE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2395, col: 5, offset: 72074},
+						pos:  position{line: 2402, col: 5, offset: 72208},
 						name: "ANTI",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2395, col: 12, offset: 72081},
+						pos:  position{line: 2402, col: 12, offset: 72215},
 						name: "INNER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2395, col: 20, offset: 72089},
+						pos:  position{line: 2402, col: 20, offset: 72223},
 						name: "LEFT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2395, col: 27, offset: 72096},
+						pos:  position{line: 2402, col: 27, offset: 72230},
 						name: "RIGHT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2395, col: 35, offset: 72104},
+						pos:  position{line: 2402, col: 35, offset: 72238},
 						name: "OUTER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2395, col: 43, offset: 72112},
+						pos:  position{line: 2402, col: 43, offset: 72246},
 						name: "CROSS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2395, col: 51, offset: 72120},
+						pos:  position{line: 2402, col: 51, offset: 72254},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2396, col: 5, offset: 72129},
+						pos:  position{line: 2403, col: 5, offset: 72263},
 						name: "UNION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2397, col: 5, offset: 72139},
+						pos:  position{line: 2404, col: 5, offset: 72273},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2398, col: 5, offset: 72149},
+						pos:  position{line: 2405, col: 5, offset: 72283},
 						name: "OFFSET",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2399, col: 5, offset: 72160},
+						pos:  position{line: 2406, col: 5, offset: 72294},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2400, col: 5, offset: 72170},
+						pos:  position{line: 2407, col: 5, offset: 72304},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2401, col: 5, offset: 72180},
+						pos:  position{line: 2408, col: 5, offset: 72314},
 						name: "WITH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2402, col: 5, offset: 72189},
+						pos:  position{line: 2409, col: 5, offset: 72323},
 						name: "USING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2403, col: 5, offset: 72199},
+						pos:  position{line: 2410, col: 5, offset: 72333},
 						name: "ON",
 					},
 				},
@@ -16290,20 +16315,20 @@ var g = &grammar{
 		},
 		{
 			name: "AGGREGATE",
-			pos:  position{line: 2405, col: 1, offset: 72203},
+			pos:  position{line: 2412, col: 1, offset: 72337},
 			expr: &seqExpr{
-				pos: position{line: 2405, col: 14, offset: 72216},
+				pos: position{line: 2412, col: 14, offset: 72350},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2405, col: 14, offset: 72216},
+						pos:        position{line: 2412, col: 14, offset: 72350},
 						val:        "aggregate",
 						ignoreCase: true,
 						want:       "\"AGGREGATE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2405, col: 33, offset: 72235},
+						pos: position{line: 2412, col: 33, offset: 72369},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2405, col: 34, offset: 72236},
+							pos:  position{line: 2412, col: 34, offset: 72370},
 							name: "IdentifierRest",
 						},
 					},
@@ -16314,20 +16339,20 @@ var g = &grammar{
 		},
 		{
 			name: "ALL",
-			pos:  position{line: 2406, col: 1, offset: 72251},
+			pos:  position{line: 2413, col: 1, offset: 72385},
 			expr: &seqExpr{
-				pos: position{line: 2406, col: 14, offset: 72264},
+				pos: position{line: 2413, col: 14, offset: 72398},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2406, col: 14, offset: 72264},
+						pos:        position{line: 2413, col: 14, offset: 72398},
 						val:        "all",
 						ignoreCase: true,
 						want:       "\"ALL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2406, col: 33, offset: 72283},
+						pos: position{line: 2413, col: 33, offset: 72417},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2406, col: 34, offset: 72284},
+							pos:  position{line: 2413, col: 34, offset: 72418},
 							name: "IdentifierRest",
 						},
 					},
@@ -16338,23 +16363,23 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 2407, col: 1, offset: 72299},
+			pos:  position{line: 2414, col: 1, offset: 72433},
 			expr: &actionExpr{
-				pos: position{line: 2407, col: 14, offset: 72312},
+				pos: position{line: 2414, col: 14, offset: 72446},
 				run: (*parser).callonAND1,
 				expr: &seqExpr{
-					pos: position{line: 2407, col: 14, offset: 72312},
+					pos: position{line: 2414, col: 14, offset: 72446},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2407, col: 14, offset: 72312},
+							pos:        position{line: 2414, col: 14, offset: 72446},
 							val:        "and",
 							ignoreCase: true,
 							want:       "\"AND\"i",
 						},
 						&notExpr{
-							pos: position{line: 2407, col: 33, offset: 72331},
+							pos: position{line: 2414, col: 33, offset: 72465},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2407, col: 34, offset: 72332},
+								pos:  position{line: 2414, col: 34, offset: 72466},
 								name: "IdentifierRest",
 							},
 						},
@@ -16366,20 +16391,20 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 2408, col: 1, offset: 72369},
+			pos:  position{line: 2415, col: 1, offset: 72503},
 			expr: &seqExpr{
-				pos: position{line: 2408, col: 14, offset: 72382},
+				pos: position{line: 2415, col: 14, offset: 72516},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2408, col: 14, offset: 72382},
+						pos:        position{line: 2415, col: 14, offset: 72516},
 						val:        "anti",
 						ignoreCase: true,
 						want:       "\"ANTI\"i",
 					},
 					&notExpr{
-						pos: position{line: 2408, col: 33, offset: 72401},
+						pos: position{line: 2415, col: 33, offset: 72535},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2408, col: 34, offset: 72402},
+							pos:  position{line: 2415, col: 34, offset: 72536},
 							name: "IdentifierRest",
 						},
 					},
@@ -16390,20 +16415,20 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 2409, col: 1, offset: 72417},
+			pos:  position{line: 2416, col: 1, offset: 72551},
 			expr: &seqExpr{
-				pos: position{line: 2409, col: 14, offset: 72430},
+				pos: position{line: 2416, col: 14, offset: 72564},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2409, col: 14, offset: 72430},
+						pos:        position{line: 2416, col: 14, offset: 72564},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2409, col: 33, offset: 72449},
+						pos: position{line: 2416, col: 33, offset: 72583},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2409, col: 34, offset: 72450},
+							pos:  position{line: 2416, col: 34, offset: 72584},
 							name: "IdentifierRest",
 						},
 					},
@@ -16414,23 +16439,23 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 2410, col: 1, offset: 72465},
+			pos:  position{line: 2417, col: 1, offset: 72599},
 			expr: &actionExpr{
-				pos: position{line: 2410, col: 14, offset: 72478},
+				pos: position{line: 2417, col: 14, offset: 72612},
 				run: (*parser).callonASC1,
 				expr: &seqExpr{
-					pos: position{line: 2410, col: 14, offset: 72478},
+					pos: position{line: 2417, col: 14, offset: 72612},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2410, col: 14, offset: 72478},
+							pos:        position{line: 2417, col: 14, offset: 72612},
 							val:        "asc",
 							ignoreCase: true,
 							want:       "\"ASC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2410, col: 33, offset: 72497},
+							pos: position{line: 2417, col: 33, offset: 72631},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2410, col: 34, offset: 72498},
+								pos:  position{line: 2417, col: 34, offset: 72632},
 								name: "IdentifierRest",
 							},
 						},
@@ -16442,20 +16467,20 @@ var g = &grammar{
 		},
 		{
 			name: "ASSERT",
-			pos:  position{line: 2411, col: 1, offset: 72535},
+			pos:  position{line: 2418, col: 1, offset: 72669},
 			expr: &seqExpr{
-				pos: position{line: 2411, col: 14, offset: 72548},
+				pos: position{line: 2418, col: 14, offset: 72682},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2411, col: 14, offset: 72548},
+						pos:        position{line: 2418, col: 14, offset: 72682},
 						val:        "assert",
 						ignoreCase: true,
 						want:       "\"ASSERT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2411, col: 33, offset: 72567},
+						pos: position{line: 2418, col: 33, offset: 72701},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2411, col: 34, offset: 72568},
+							pos:  position{line: 2418, col: 34, offset: 72702},
 							name: "IdentifierRest",
 						},
 					},
@@ -16466,20 +16491,20 @@ var g = &grammar{
 		},
 		{
 			name: "AT",
-			pos:  position{line: 2412, col: 1, offset: 72583},
+			pos:  position{line: 2419, col: 1, offset: 72717},
 			expr: &seqExpr{
-				pos: position{line: 2412, col: 14, offset: 72596},
+				pos: position{line: 2419, col: 14, offset: 72730},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2412, col: 14, offset: 72596},
+						pos:        position{line: 2419, col: 14, offset: 72730},
 						val:        "at",
 						ignoreCase: true,
 						want:       "\"AT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2412, col: 33, offset: 72615},
+						pos: position{line: 2419, col: 33, offset: 72749},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2412, col: 34, offset: 72616},
+							pos:  position{line: 2419, col: 34, offset: 72750},
 							name: "IdentifierRest",
 						},
 					},
@@ -16490,20 +16515,20 @@ var g = &grammar{
 		},
 		{
 			name: "BETWEEN",
-			pos:  position{line: 2413, col: 1, offset: 72631},
+			pos:  position{line: 2420, col: 1, offset: 72765},
 			expr: &seqExpr{
-				pos: position{line: 2413, col: 14, offset: 72644},
+				pos: position{line: 2420, col: 14, offset: 72778},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2413, col: 14, offset: 72644},
+						pos:        position{line: 2420, col: 14, offset: 72778},
 						val:        "between",
 						ignoreCase: true,
 						want:       "\"BETWEEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2413, col: 33, offset: 72663},
+						pos: position{line: 2420, col: 33, offset: 72797},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2413, col: 34, offset: 72664},
+							pos:  position{line: 2420, col: 34, offset: 72798},
 							name: "IdentifierRest",
 						},
 					},
@@ -16514,20 +16539,20 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 2414, col: 1, offset: 72679},
+			pos:  position{line: 2421, col: 1, offset: 72813},
 			expr: &seqExpr{
-				pos: position{line: 2414, col: 14, offset: 72692},
+				pos: position{line: 2421, col: 14, offset: 72826},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2414, col: 14, offset: 72692},
+						pos:        position{line: 2421, col: 14, offset: 72826},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2414, col: 33, offset: 72711},
+						pos: position{line: 2421, col: 33, offset: 72845},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2414, col: 34, offset: 72712},
+							pos:  position{line: 2421, col: 34, offset: 72846},
 							name: "IdentifierRest",
 						},
 					},
@@ -16538,20 +16563,20 @@ var g = &grammar{
 		},
 		{
 			name: "CALL",
-			pos:  position{line: 2415, col: 1, offset: 72727},
+			pos:  position{line: 2422, col: 1, offset: 72861},
 			expr: &seqExpr{
-				pos: position{line: 2415, col: 14, offset: 72740},
+				pos: position{line: 2422, col: 14, offset: 72874},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2415, col: 14, offset: 72740},
+						pos:        position{line: 2422, col: 14, offset: 72874},
 						val:        "call",
 						ignoreCase: true,
 						want:       "\"CALL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2415, col: 33, offset: 72759},
+						pos: position{line: 2422, col: 33, offset: 72893},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2415, col: 34, offset: 72760},
+							pos:  position{line: 2422, col: 34, offset: 72894},
 							name: "IdentifierRest",
 						},
 					},
@@ -16562,20 +16587,20 @@ var g = &grammar{
 		},
 		{
 			name: "CASE",
-			pos:  position{line: 2416, col: 1, offset: 72775},
+			pos:  position{line: 2423, col: 1, offset: 72909},
 			expr: &seqExpr{
-				pos: position{line: 2416, col: 14, offset: 72788},
+				pos: position{line: 2423, col: 14, offset: 72922},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2416, col: 14, offset: 72788},
+						pos:        position{line: 2423, col: 14, offset: 72922},
 						val:        "case",
 						ignoreCase: true,
 						want:       "\"CASE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2416, col: 33, offset: 72807},
+						pos: position{line: 2423, col: 33, offset: 72941},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2416, col: 34, offset: 72808},
+							pos:  position{line: 2423, col: 34, offset: 72942},
 							name: "IdentifierRest",
 						},
 					},
@@ -16586,20 +16611,20 @@ var g = &grammar{
 		},
 		{
 			name: "CAST",
-			pos:  position{line: 2417, col: 1, offset: 72823},
+			pos:  position{line: 2424, col: 1, offset: 72957},
 			expr: &seqExpr{
-				pos: position{line: 2417, col: 14, offset: 72836},
+				pos: position{line: 2424, col: 14, offset: 72970},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2417, col: 14, offset: 72836},
+						pos:        position{line: 2424, col: 14, offset: 72970},
 						val:        "cast",
 						ignoreCase: true,
 						want:       "\"CAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2417, col: 33, offset: 72855},
+						pos: position{line: 2424, col: 33, offset: 72989},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2417, col: 34, offset: 72856},
+							pos:  position{line: 2424, col: 34, offset: 72990},
 							name: "IdentifierRest",
 						},
 					},
@@ -16610,20 +16635,20 @@ var g = &grammar{
 		},
 		{
 			name: "CONST",
-			pos:  position{line: 2418, col: 1, offset: 72871},
+			pos:  position{line: 2425, col: 1, offset: 73005},
 			expr: &seqExpr{
-				pos: position{line: 2418, col: 14, offset: 72884},
+				pos: position{line: 2425, col: 14, offset: 73018},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2418, col: 14, offset: 72884},
+						pos:        position{line: 2425, col: 14, offset: 73018},
 						val:        "const",
 						ignoreCase: true,
 						want:       "\"CONST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2418, col: 33, offset: 72903},
+						pos: position{line: 2425, col: 33, offset: 73037},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2418, col: 34, offset: 72904},
+							pos:  position{line: 2425, col: 34, offset: 73038},
 							name: "IdentifierRest",
 						},
 					},
@@ -16634,20 +16659,20 @@ var g = &grammar{
 		},
 		{
 			name: "COUNT",
-			pos:  position{line: 2419, col: 1, offset: 72919},
+			pos:  position{line: 2426, col: 1, offset: 73053},
 			expr: &seqExpr{
-				pos: position{line: 2419, col: 14, offset: 72932},
+				pos: position{line: 2426, col: 14, offset: 73066},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2419, col: 14, offset: 72932},
+						pos:        position{line: 2426, col: 14, offset: 73066},
 						val:        "count",
 						ignoreCase: true,
 						want:       "\"COUNT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2419, col: 33, offset: 72951},
+						pos: position{line: 2426, col: 33, offset: 73085},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2419, col: 34, offset: 72952},
+							pos:  position{line: 2426, col: 34, offset: 73086},
 							name: "IdentifierRest",
 						},
 					},
@@ -16658,20 +16683,20 @@ var g = &grammar{
 		},
 		{
 			name: "CROSS",
-			pos:  position{line: 2420, col: 1, offset: 72967},
+			pos:  position{line: 2427, col: 1, offset: 73101},
 			expr: &seqExpr{
-				pos: position{line: 2420, col: 14, offset: 72980},
+				pos: position{line: 2427, col: 14, offset: 73114},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2420, col: 14, offset: 72980},
+						pos:        position{line: 2427, col: 14, offset: 73114},
 						val:        "cross",
 						ignoreCase: true,
 						want:       "\"CROSS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2420, col: 33, offset: 72999},
+						pos: position{line: 2427, col: 33, offset: 73133},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2420, col: 34, offset: 73000},
+							pos:  position{line: 2427, col: 34, offset: 73134},
 							name: "IdentifierRest",
 						},
 					},
@@ -16682,20 +16707,20 @@ var g = &grammar{
 		},
 		{
 			name: "CUT",
-			pos:  position{line: 2421, col: 1, offset: 73015},
+			pos:  position{line: 2428, col: 1, offset: 73149},
 			expr: &seqExpr{
-				pos: position{line: 2421, col: 14, offset: 73028},
+				pos: position{line: 2428, col: 14, offset: 73162},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2421, col: 14, offset: 73028},
+						pos:        position{line: 2428, col: 14, offset: 73162},
 						val:        "cut",
 						ignoreCase: true,
 						want:       "\"CUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2421, col: 33, offset: 73047},
+						pos: position{line: 2428, col: 33, offset: 73181},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2421, col: 34, offset: 73048},
+							pos:  position{line: 2428, col: 34, offset: 73182},
 							name: "IdentifierRest",
 						},
 					},
@@ -16706,23 +16731,23 @@ var g = &grammar{
 		},
 		{
 			name: "DATE",
-			pos:  position{line: 2422, col: 1, offset: 73063},
+			pos:  position{line: 2429, col: 1, offset: 73197},
 			expr: &actionExpr{
-				pos: position{line: 2422, col: 14, offset: 73076},
+				pos: position{line: 2429, col: 14, offset: 73210},
 				run: (*parser).callonDATE1,
 				expr: &seqExpr{
-					pos: position{line: 2422, col: 14, offset: 73076},
+					pos: position{line: 2429, col: 14, offset: 73210},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2422, col: 14, offset: 73076},
+							pos:        position{line: 2429, col: 14, offset: 73210},
 							val:        "date",
 							ignoreCase: true,
 							want:       "\"DATE\"i",
 						},
 						&notExpr{
-							pos: position{line: 2422, col: 33, offset: 73095},
+							pos: position{line: 2429, col: 33, offset: 73229},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2422, col: 34, offset: 73096},
+								pos:  position{line: 2429, col: 34, offset: 73230},
 								name: "IdentifierRest",
 							},
 						},
@@ -16734,20 +16759,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEBUG",
-			pos:  position{line: 2423, col: 1, offset: 73134},
+			pos:  position{line: 2430, col: 1, offset: 73268},
 			expr: &seqExpr{
-				pos: position{line: 2423, col: 14, offset: 73147},
+				pos: position{line: 2430, col: 14, offset: 73281},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2423, col: 14, offset: 73147},
+						pos:        position{line: 2430, col: 14, offset: 73281},
 						val:        "debug",
 						ignoreCase: true,
 						want:       "\"DEBUG\"i",
 					},
 					&notExpr{
-						pos: position{line: 2423, col: 33, offset: 73166},
+						pos: position{line: 2430, col: 33, offset: 73300},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2423, col: 34, offset: 73167},
+							pos:  position{line: 2430, col: 34, offset: 73301},
 							name: "IdentifierRest",
 						},
 					},
@@ -16758,20 +16783,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEFAULT",
-			pos:  position{line: 2424, col: 1, offset: 73182},
+			pos:  position{line: 2431, col: 1, offset: 73316},
 			expr: &seqExpr{
-				pos: position{line: 2424, col: 14, offset: 73195},
+				pos: position{line: 2431, col: 14, offset: 73329},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2424, col: 14, offset: 73195},
+						pos:        position{line: 2431, col: 14, offset: 73329},
 						val:        "default",
 						ignoreCase: true,
 						want:       "\"DEFAULT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2424, col: 33, offset: 73214},
+						pos: position{line: 2431, col: 33, offset: 73348},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2424, col: 34, offset: 73215},
+							pos:  position{line: 2431, col: 34, offset: 73349},
 							name: "IdentifierRest",
 						},
 					},
@@ -16782,23 +16807,23 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 2425, col: 1, offset: 73230},
+			pos:  position{line: 2432, col: 1, offset: 73364},
 			expr: &actionExpr{
-				pos: position{line: 2425, col: 14, offset: 73243},
+				pos: position{line: 2432, col: 14, offset: 73377},
 				run: (*parser).callonDESC1,
 				expr: &seqExpr{
-					pos: position{line: 2425, col: 14, offset: 73243},
+					pos: position{line: 2432, col: 14, offset: 73377},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2425, col: 14, offset: 73243},
+							pos:        position{line: 2432, col: 14, offset: 73377},
 							val:        "desc",
 							ignoreCase: true,
 							want:       "\"DESC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2425, col: 33, offset: 73262},
+							pos: position{line: 2432, col: 33, offset: 73396},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2425, col: 34, offset: 73263},
+								pos:  position{line: 2432, col: 34, offset: 73397},
 								name: "IdentifierRest",
 							},
 						},
@@ -16810,20 +16835,20 @@ var g = &grammar{
 		},
 		{
 			name: "DISTINCT",
-			pos:  position{line: 2426, col: 1, offset: 73301},
+			pos:  position{line: 2433, col: 1, offset: 73435},
 			expr: &seqExpr{
-				pos: position{line: 2426, col: 14, offset: 73314},
+				pos: position{line: 2433, col: 14, offset: 73448},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2426, col: 14, offset: 73314},
+						pos:        position{line: 2433, col: 14, offset: 73448},
 						val:        "distinct",
 						ignoreCase: true,
 						want:       "\"DISTINCT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2426, col: 33, offset: 73333},
+						pos: position{line: 2433, col: 33, offset: 73467},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2426, col: 34, offset: 73334},
+							pos:  position{line: 2433, col: 34, offset: 73468},
 							name: "IdentifierRest",
 						},
 					},
@@ -16834,20 +16859,20 @@ var g = &grammar{
 		},
 		{
 			name: "DROP",
-			pos:  position{line: 2427, col: 1, offset: 73349},
+			pos:  position{line: 2434, col: 1, offset: 73483},
 			expr: &seqExpr{
-				pos: position{line: 2427, col: 14, offset: 73362},
+				pos: position{line: 2434, col: 14, offset: 73496},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2427, col: 14, offset: 73362},
+						pos:        position{line: 2434, col: 14, offset: 73496},
 						val:        "drop",
 						ignoreCase: true,
 						want:       "\"DROP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2427, col: 33, offset: 73381},
+						pos: position{line: 2434, col: 33, offset: 73515},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2427, col: 34, offset: 73382},
+							pos:  position{line: 2434, col: 34, offset: 73516},
 							name: "IdentifierRest",
 						},
 					},
@@ -16858,20 +16883,20 @@ var g = &grammar{
 		},
 		{
 			name: "ELSE",
-			pos:  position{line: 2428, col: 1, offset: 73397},
+			pos:  position{line: 2435, col: 1, offset: 73531},
 			expr: &seqExpr{
-				pos: position{line: 2428, col: 14, offset: 73410},
+				pos: position{line: 2435, col: 14, offset: 73544},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2428, col: 14, offset: 73410},
+						pos:        position{line: 2435, col: 14, offset: 73544},
 						val:        "else",
 						ignoreCase: true,
 						want:       "\"ELSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2428, col: 33, offset: 73429},
+						pos: position{line: 2435, col: 33, offset: 73563},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2428, col: 34, offset: 73430},
+							pos:  position{line: 2435, col: 34, offset: 73564},
 							name: "IdentifierRest",
 						},
 					},
@@ -16882,20 +16907,20 @@ var g = &grammar{
 		},
 		{
 			name: "END",
-			pos:  position{line: 2429, col: 1, offset: 73445},
+			pos:  position{line: 2436, col: 1, offset: 73579},
 			expr: &seqExpr{
-				pos: position{line: 2429, col: 14, offset: 73458},
+				pos: position{line: 2436, col: 14, offset: 73592},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2429, col: 14, offset: 73458},
+						pos:        position{line: 2436, col: 14, offset: 73592},
 						val:        "end",
 						ignoreCase: true,
 						want:       "\"END\"i",
 					},
 					&notExpr{
-						pos: position{line: 2429, col: 33, offset: 73477},
+						pos: position{line: 2436, col: 33, offset: 73611},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2429, col: 34, offset: 73478},
+							pos:  position{line: 2436, col: 34, offset: 73612},
 							name: "IdentifierRest",
 						},
 					},
@@ -16906,20 +16931,20 @@ var g = &grammar{
 		},
 		{
 			name: "ENUM",
-			pos:  position{line: 2430, col: 1, offset: 73493},
+			pos:  position{line: 2437, col: 1, offset: 73627},
 			expr: &seqExpr{
-				pos: position{line: 2430, col: 14, offset: 73506},
+				pos: position{line: 2437, col: 14, offset: 73640},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2430, col: 14, offset: 73506},
+						pos:        position{line: 2437, col: 14, offset: 73640},
 						val:        "enum",
 						ignoreCase: true,
 						want:       "\"ENUM\"i",
 					},
 					&notExpr{
-						pos: position{line: 2430, col: 33, offset: 73525},
+						pos: position{line: 2437, col: 33, offset: 73659},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2430, col: 34, offset: 73526},
+							pos:  position{line: 2437, col: 34, offset: 73660},
 							name: "IdentifierRest",
 						},
 					},
@@ -16930,20 +16955,20 @@ var g = &grammar{
 		},
 		{
 			name: "ERROR",
-			pos:  position{line: 2431, col: 1, offset: 73541},
+			pos:  position{line: 2438, col: 1, offset: 73675},
 			expr: &seqExpr{
-				pos: position{line: 2431, col: 14, offset: 73554},
+				pos: position{line: 2438, col: 14, offset: 73688},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2431, col: 14, offset: 73554},
+						pos:        position{line: 2438, col: 14, offset: 73688},
 						val:        "error",
 						ignoreCase: true,
 						want:       "\"ERROR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2431, col: 33, offset: 73573},
+						pos: position{line: 2438, col: 33, offset: 73707},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2431, col: 34, offset: 73574},
+							pos:  position{line: 2438, col: 34, offset: 73708},
 							name: "IdentifierRest",
 						},
 					},
@@ -16954,20 +16979,20 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL",
-			pos:  position{line: 2432, col: 1, offset: 73589},
+			pos:  position{line: 2439, col: 1, offset: 73723},
 			expr: &seqExpr{
-				pos: position{line: 2432, col: 14, offset: 73602},
+				pos: position{line: 2439, col: 14, offset: 73736},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2432, col: 14, offset: 73602},
+						pos:        position{line: 2439, col: 14, offset: 73736},
 						val:        "eval",
 						ignoreCase: true,
 						want:       "\"EVAL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2432, col: 33, offset: 73621},
+						pos: position{line: 2439, col: 33, offset: 73755},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2432, col: 34, offset: 73622},
+							pos:  position{line: 2439, col: 34, offset: 73756},
 							name: "IdentifierRest",
 						},
 					},
@@ -16978,20 +17003,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXISTS",
-			pos:  position{line: 2433, col: 1, offset: 73637},
+			pos:  position{line: 2440, col: 1, offset: 73771},
 			expr: &seqExpr{
-				pos: position{line: 2433, col: 14, offset: 73650},
+				pos: position{line: 2440, col: 14, offset: 73784},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2433, col: 14, offset: 73650},
+						pos:        position{line: 2440, col: 14, offset: 73784},
 						val:        "exists",
 						ignoreCase: true,
 						want:       "\"EXISTS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2433, col: 33, offset: 73669},
+						pos: position{line: 2440, col: 33, offset: 73803},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2433, col: 34, offset: 73670},
+							pos:  position{line: 2440, col: 34, offset: 73804},
 							name: "IdentifierRest",
 						},
 					},
@@ -17002,20 +17027,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXPLODE",
-			pos:  position{line: 2434, col: 1, offset: 73685},
+			pos:  position{line: 2441, col: 1, offset: 73819},
 			expr: &seqExpr{
-				pos: position{line: 2434, col: 14, offset: 73698},
+				pos: position{line: 2441, col: 14, offset: 73832},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2434, col: 14, offset: 73698},
+						pos:        position{line: 2441, col: 14, offset: 73832},
 						val:        "explode",
 						ignoreCase: true,
 						want:       "\"EXPLODE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2434, col: 33, offset: 73717},
+						pos: position{line: 2441, col: 33, offset: 73851},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2434, col: 34, offset: 73718},
+							pos:  position{line: 2441, col: 34, offset: 73852},
 							name: "IdentifierRest",
 						},
 					},
@@ -17026,20 +17051,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXTRACT",
-			pos:  position{line: 2435, col: 1, offset: 73733},
+			pos:  position{line: 2442, col: 1, offset: 73867},
 			expr: &seqExpr{
-				pos: position{line: 2435, col: 14, offset: 73746},
+				pos: position{line: 2442, col: 14, offset: 73880},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2435, col: 14, offset: 73746},
+						pos:        position{line: 2442, col: 14, offset: 73880},
 						val:        "extract",
 						ignoreCase: true,
 						want:       "\"EXTRACT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2435, col: 33, offset: 73765},
+						pos: position{line: 2442, col: 33, offset: 73899},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2435, col: 34, offset: 73766},
+							pos:  position{line: 2442, col: 34, offset: 73900},
 							name: "IdentifierRest",
 						},
 					},
@@ -17050,20 +17075,20 @@ var g = &grammar{
 		},
 		{
 			name: "FALSE",
-			pos:  position{line: 2436, col: 1, offset: 73781},
+			pos:  position{line: 2443, col: 1, offset: 73915},
 			expr: &seqExpr{
-				pos: position{line: 2436, col: 14, offset: 73794},
+				pos: position{line: 2443, col: 14, offset: 73928},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2436, col: 14, offset: 73794},
+						pos:        position{line: 2443, col: 14, offset: 73928},
 						val:        "false",
 						ignoreCase: true,
 						want:       "\"FALSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2436, col: 33, offset: 73813},
+						pos: position{line: 2443, col: 33, offset: 73947},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2436, col: 34, offset: 73814},
+							pos:  position{line: 2443, col: 34, offset: 73948},
 							name: "IdentifierRest",
 						},
 					},
@@ -17074,20 +17099,20 @@ var g = &grammar{
 		},
 		{
 			name: "FIRST",
-			pos:  position{line: 2437, col: 1, offset: 73829},
+			pos:  position{line: 2444, col: 1, offset: 73963},
 			expr: &seqExpr{
-				pos: position{line: 2437, col: 14, offset: 73842},
+				pos: position{line: 2444, col: 14, offset: 73976},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2437, col: 14, offset: 73842},
+						pos:        position{line: 2444, col: 14, offset: 73976},
 						val:        "first",
 						ignoreCase: true,
 						want:       "\"FIRST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2437, col: 33, offset: 73861},
+						pos: position{line: 2444, col: 33, offset: 73995},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2437, col: 34, offset: 73862},
+							pos:  position{line: 2444, col: 34, offset: 73996},
 							name: "IdentifierRest",
 						},
 					},
@@ -17098,20 +17123,20 @@ var g = &grammar{
 		},
 		{
 			name: "FN",
-			pos:  position{line: 2438, col: 1, offset: 73877},
+			pos:  position{line: 2445, col: 1, offset: 74011},
 			expr: &seqExpr{
-				pos: position{line: 2438, col: 14, offset: 73890},
+				pos: position{line: 2445, col: 14, offset: 74024},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2438, col: 14, offset: 73890},
+						pos:        position{line: 2445, col: 14, offset: 74024},
 						val:        "fn",
 						ignoreCase: true,
 						want:       "\"FN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2438, col: 33, offset: 73909},
+						pos: position{line: 2445, col: 33, offset: 74043},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2438, col: 34, offset: 73910},
+							pos:  position{line: 2445, col: 34, offset: 74044},
 							name: "IdentifierRest",
 						},
 					},
@@ -17122,20 +17147,20 @@ var g = &grammar{
 		},
 		{
 			name: "FOR",
-			pos:  position{line: 2439, col: 1, offset: 73925},
+			pos:  position{line: 2446, col: 1, offset: 74059},
 			expr: &seqExpr{
-				pos: position{line: 2439, col: 14, offset: 73938},
+				pos: position{line: 2446, col: 14, offset: 74072},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2439, col: 14, offset: 73938},
+						pos:        position{line: 2446, col: 14, offset: 74072},
 						val:        "for",
 						ignoreCase: true,
 						want:       "\"FOR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2439, col: 33, offset: 73957},
+						pos: position{line: 2446, col: 33, offset: 74091},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2439, col: 34, offset: 73958},
+							pos:  position{line: 2446, col: 34, offset: 74092},
 							name: "IdentifierRest",
 						},
 					},
@@ -17146,20 +17171,20 @@ var g = &grammar{
 		},
 		{
 			name: "FORK",
-			pos:  position{line: 2440, col: 1, offset: 73973},
+			pos:  position{line: 2447, col: 1, offset: 74107},
 			expr: &seqExpr{
-				pos: position{line: 2440, col: 14, offset: 73986},
+				pos: position{line: 2447, col: 14, offset: 74120},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2440, col: 14, offset: 73986},
+						pos:        position{line: 2447, col: 14, offset: 74120},
 						val:        "fork",
 						ignoreCase: true,
 						want:       "\"FORK\"i",
 					},
 					&notExpr{
-						pos: position{line: 2440, col: 33, offset: 74005},
+						pos: position{line: 2447, col: 33, offset: 74139},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2440, col: 34, offset: 74006},
+							pos:  position{line: 2447, col: 34, offset: 74140},
 							name: "IdentifierRest",
 						},
 					},
@@ -17170,20 +17195,20 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 2441, col: 1, offset: 74021},
+			pos:  position{line: 2448, col: 1, offset: 74155},
 			expr: &seqExpr{
-				pos: position{line: 2441, col: 14, offset: 74034},
+				pos: position{line: 2448, col: 14, offset: 74168},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2441, col: 14, offset: 74034},
+						pos:        position{line: 2448, col: 14, offset: 74168},
 						val:        "from",
 						ignoreCase: true,
 						want:       "\"FROM\"i",
 					},
 					&notExpr{
-						pos: position{line: 2441, col: 33, offset: 74053},
+						pos: position{line: 2448, col: 33, offset: 74187},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2441, col: 34, offset: 74054},
+							pos:  position{line: 2448, col: 34, offset: 74188},
 							name: "IdentifierRest",
 						},
 					},
@@ -17194,20 +17219,20 @@ var g = &grammar{
 		},
 		{
 			name: "FULL",
-			pos:  position{line: 2442, col: 1, offset: 74069},
+			pos:  position{line: 2449, col: 1, offset: 74203},
 			expr: &seqExpr{
-				pos: position{line: 2442, col: 14, offset: 74082},
+				pos: position{line: 2449, col: 14, offset: 74216},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2442, col: 14, offset: 74082},
+						pos:        position{line: 2449, col: 14, offset: 74216},
 						val:        "full",
 						ignoreCase: true,
 						want:       "\"FULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2442, col: 33, offset: 74101},
+						pos: position{line: 2449, col: 33, offset: 74235},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2442, col: 34, offset: 74102},
+							pos:  position{line: 2449, col: 34, offset: 74236},
 							name: "IdentifierRest",
 						},
 					},
@@ -17218,20 +17243,20 @@ var g = &grammar{
 		},
 		{
 			name: "FUSE",
-			pos:  position{line: 2443, col: 1, offset: 74117},
+			pos:  position{line: 2450, col: 1, offset: 74251},
 			expr: &seqExpr{
-				pos: position{line: 2443, col: 14, offset: 74130},
+				pos: position{line: 2450, col: 14, offset: 74264},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2443, col: 14, offset: 74130},
+						pos:        position{line: 2450, col: 14, offset: 74264},
 						val:        "fuse",
 						ignoreCase: true,
 						want:       "\"FUSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2443, col: 33, offset: 74149},
+						pos: position{line: 2450, col: 33, offset: 74283},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2443, col: 34, offset: 74150},
+							pos:  position{line: 2450, col: 34, offset: 74284},
 							name: "IdentifierRest",
 						},
 					},
@@ -17242,20 +17267,20 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 2444, col: 1, offset: 74165},
+			pos:  position{line: 2451, col: 1, offset: 74299},
 			expr: &seqExpr{
-				pos: position{line: 2444, col: 14, offset: 74178},
+				pos: position{line: 2451, col: 14, offset: 74312},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2444, col: 14, offset: 74178},
+						pos:        position{line: 2451, col: 14, offset: 74312},
 						val:        "group",
 						ignoreCase: true,
 						want:       "\"GROUP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2444, col: 33, offset: 74197},
+						pos: position{line: 2451, col: 33, offset: 74331},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2444, col: 34, offset: 74198},
+							pos:  position{line: 2451, col: 34, offset: 74332},
 							name: "IdentifierRest",
 						},
 					},
@@ -17266,20 +17291,20 @@ var g = &grammar{
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 2445, col: 1, offset: 74213},
+			pos:  position{line: 2452, col: 1, offset: 74347},
 			expr: &seqExpr{
-				pos: position{line: 2445, col: 14, offset: 74226},
+				pos: position{line: 2452, col: 14, offset: 74360},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2445, col: 14, offset: 74226},
+						pos:        position{line: 2452, col: 14, offset: 74360},
 						val:        "having",
 						ignoreCase: true,
 						want:       "\"HAVING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2445, col: 33, offset: 74245},
+						pos: position{line: 2452, col: 33, offset: 74379},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2445, col: 34, offset: 74246},
+							pos:  position{line: 2452, col: 34, offset: 74380},
 							name: "IdentifierRest",
 						},
 					},
@@ -17290,20 +17315,20 @@ var g = &grammar{
 		},
 		{
 			name: "HEAD",
-			pos:  position{line: 2446, col: 1, offset: 74261},
+			pos:  position{line: 2453, col: 1, offset: 74395},
 			expr: &seqExpr{
-				pos: position{line: 2446, col: 14, offset: 74274},
+				pos: position{line: 2453, col: 14, offset: 74408},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2446, col: 14, offset: 74274},
+						pos:        position{line: 2453, col: 14, offset: 74408},
 						val:        "head",
 						ignoreCase: true,
 						want:       "\"HEAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2446, col: 33, offset: 74293},
+						pos: position{line: 2453, col: 33, offset: 74427},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2446, col: 34, offset: 74294},
+							pos:  position{line: 2453, col: 34, offset: 74428},
 							name: "IdentifierRest",
 						},
 					},
@@ -17314,20 +17339,20 @@ var g = &grammar{
 		},
 		{
 			name: "IN",
-			pos:  position{line: 2447, col: 1, offset: 74309},
+			pos:  position{line: 2454, col: 1, offset: 74443},
 			expr: &seqExpr{
-				pos: position{line: 2447, col: 14, offset: 74322},
+				pos: position{line: 2454, col: 14, offset: 74456},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2447, col: 14, offset: 74322},
+						pos:        position{line: 2454, col: 14, offset: 74456},
 						val:        "in",
 						ignoreCase: true,
 						want:       "\"IN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2447, col: 33, offset: 74341},
+						pos: position{line: 2454, col: 33, offset: 74475},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2447, col: 34, offset: 74342},
+							pos:  position{line: 2454, col: 34, offset: 74476},
 							name: "IdentifierRest",
 						},
 					},
@@ -17338,20 +17363,20 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 2448, col: 1, offset: 74357},
+			pos:  position{line: 2455, col: 1, offset: 74491},
 			expr: &seqExpr{
-				pos: position{line: 2448, col: 14, offset: 74370},
+				pos: position{line: 2455, col: 14, offset: 74504},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2448, col: 14, offset: 74370},
+						pos:        position{line: 2455, col: 14, offset: 74504},
 						val:        "inner",
 						ignoreCase: true,
 						want:       "\"INNER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2448, col: 33, offset: 74389},
+						pos: position{line: 2455, col: 33, offset: 74523},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2448, col: 34, offset: 74390},
+							pos:  position{line: 2455, col: 34, offset: 74524},
 							name: "IdentifierRest",
 						},
 					},
@@ -17362,20 +17387,20 @@ var g = &grammar{
 		},
 		{
 			name: "IS",
-			pos:  position{line: 2449, col: 1, offset: 74405},
+			pos:  position{line: 2456, col: 1, offset: 74539},
 			expr: &seqExpr{
-				pos: position{line: 2449, col: 14, offset: 74418},
+				pos: position{line: 2456, col: 14, offset: 74552},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2449, col: 14, offset: 74418},
+						pos:        position{line: 2456, col: 14, offset: 74552},
 						val:        "is",
 						ignoreCase: true,
 						want:       "\"IS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2449, col: 33, offset: 74437},
+						pos: position{line: 2456, col: 33, offset: 74571},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2449, col: 34, offset: 74438},
+							pos:  position{line: 2456, col: 34, offset: 74572},
 							name: "IdentifierRest",
 						},
 					},
@@ -17386,20 +17411,20 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 2450, col: 1, offset: 74453},
+			pos:  position{line: 2457, col: 1, offset: 74587},
 			expr: &seqExpr{
-				pos: position{line: 2450, col: 14, offset: 74466},
+				pos: position{line: 2457, col: 14, offset: 74600},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2450, col: 14, offset: 74466},
+						pos:        position{line: 2457, col: 14, offset: 74600},
 						val:        "join",
 						ignoreCase: true,
 						want:       "\"JOIN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2450, col: 33, offset: 74485},
+						pos: position{line: 2457, col: 33, offset: 74619},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2450, col: 34, offset: 74486},
+							pos:  position{line: 2457, col: 34, offset: 74620},
 							name: "IdentifierRest",
 						},
 					},
@@ -17410,20 +17435,20 @@ var g = &grammar{
 		},
 		{
 			name: "LAMBDA",
-			pos:  position{line: 2451, col: 1, offset: 74501},
+			pos:  position{line: 2458, col: 1, offset: 74635},
 			expr: &seqExpr{
-				pos: position{line: 2451, col: 14, offset: 74514},
+				pos: position{line: 2458, col: 14, offset: 74648},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2451, col: 14, offset: 74514},
+						pos:        position{line: 2458, col: 14, offset: 74648},
 						val:        "lambda",
 						ignoreCase: true,
 						want:       "\"LAMBDA\"i",
 					},
 					&notExpr{
-						pos: position{line: 2451, col: 33, offset: 74533},
+						pos: position{line: 2458, col: 33, offset: 74667},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2451, col: 34, offset: 74534},
+							pos:  position{line: 2458, col: 34, offset: 74668},
 							name: "IdentifierRest",
 						},
 					},
@@ -17434,20 +17459,20 @@ var g = &grammar{
 		},
 		{
 			name: "LAST",
-			pos:  position{line: 2452, col: 1, offset: 74549},
+			pos:  position{line: 2459, col: 1, offset: 74683},
 			expr: &seqExpr{
-				pos: position{line: 2452, col: 14, offset: 74562},
+				pos: position{line: 2459, col: 14, offset: 74696},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2452, col: 14, offset: 74562},
+						pos:        position{line: 2459, col: 14, offset: 74696},
 						val:        "last",
 						ignoreCase: true,
 						want:       "\"LAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2452, col: 33, offset: 74581},
+						pos: position{line: 2459, col: 33, offset: 74715},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2452, col: 34, offset: 74582},
+							pos:  position{line: 2459, col: 34, offset: 74716},
 							name: "IdentifierRest",
 						},
 					},
@@ -17458,20 +17483,20 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 2453, col: 1, offset: 74597},
+			pos:  position{line: 2460, col: 1, offset: 74731},
 			expr: &seqExpr{
-				pos: position{line: 2453, col: 14, offset: 74610},
+				pos: position{line: 2460, col: 14, offset: 74744},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2453, col: 14, offset: 74610},
+						pos:        position{line: 2460, col: 14, offset: 74744},
 						val:        "left",
 						ignoreCase: true,
 						want:       "\"LEFT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2453, col: 33, offset: 74629},
+						pos: position{line: 2460, col: 33, offset: 74763},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2453, col: 34, offset: 74630},
+							pos:  position{line: 2460, col: 34, offset: 74764},
 							name: "IdentifierRest",
 						},
 					},
@@ -17482,20 +17507,20 @@ var g = &grammar{
 		},
 		{
 			name: "LET",
-			pos:  position{line: 2454, col: 1, offset: 74645},
+			pos:  position{line: 2461, col: 1, offset: 74779},
 			expr: &seqExpr{
-				pos: position{line: 2454, col: 14, offset: 74658},
+				pos: position{line: 2461, col: 14, offset: 74792},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2454, col: 14, offset: 74658},
+						pos:        position{line: 2461, col: 14, offset: 74792},
 						val:        "let",
 						ignoreCase: true,
 						want:       "\"LET\"i",
 					},
 					&notExpr{
-						pos: position{line: 2454, col: 33, offset: 74677},
+						pos: position{line: 2461, col: 33, offset: 74811},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2454, col: 34, offset: 74678},
+							pos:  position{line: 2461, col: 34, offset: 74812},
 							name: "IdentifierRest",
 						},
 					},
@@ -17506,20 +17531,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIKE",
-			pos:  position{line: 2455, col: 1, offset: 74693},
+			pos:  position{line: 2462, col: 1, offset: 74827},
 			expr: &seqExpr{
-				pos: position{line: 2455, col: 14, offset: 74706},
+				pos: position{line: 2462, col: 14, offset: 74840},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2455, col: 14, offset: 74706},
+						pos:        position{line: 2462, col: 14, offset: 74840},
 						val:        "like",
 						ignoreCase: true,
 						want:       "\"LIKE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2455, col: 33, offset: 74725},
+						pos: position{line: 2462, col: 33, offset: 74859},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2455, col: 34, offset: 74726},
+							pos:  position{line: 2462, col: 34, offset: 74860},
 							name: "IdentifierRest",
 						},
 					},
@@ -17530,20 +17555,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 2456, col: 1, offset: 74741},
+			pos:  position{line: 2463, col: 1, offset: 74875},
 			expr: &seqExpr{
-				pos: position{line: 2456, col: 14, offset: 74754},
+				pos: position{line: 2463, col: 14, offset: 74888},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2456, col: 14, offset: 74754},
+						pos:        position{line: 2463, col: 14, offset: 74888},
 						val:        "limit",
 						ignoreCase: true,
 						want:       "\"LIMIT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2456, col: 33, offset: 74773},
+						pos: position{line: 2463, col: 33, offset: 74907},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2456, col: 34, offset: 74774},
+							pos:  position{line: 2463, col: 34, offset: 74908},
 							name: "IdentifierRest",
 						},
 					},
@@ -17554,20 +17579,20 @@ var g = &grammar{
 		},
 		{
 			name: "LOAD",
-			pos:  position{line: 2457, col: 1, offset: 74789},
+			pos:  position{line: 2464, col: 1, offset: 74923},
 			expr: &seqExpr{
-				pos: position{line: 2457, col: 14, offset: 74802},
+				pos: position{line: 2464, col: 14, offset: 74936},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2457, col: 14, offset: 74802},
+						pos:        position{line: 2464, col: 14, offset: 74936},
 						val:        "load",
 						ignoreCase: true,
 						want:       "\"LOAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2457, col: 33, offset: 74821},
+						pos: position{line: 2464, col: 33, offset: 74955},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2457, col: 34, offset: 74822},
+							pos:  position{line: 2464, col: 34, offset: 74956},
 							name: "IdentifierRest",
 						},
 					},
@@ -17578,20 +17603,20 @@ var g = &grammar{
 		},
 		{
 			name: "MATERIALIZED",
-			pos:  position{line: 2458, col: 1, offset: 74837},
+			pos:  position{line: 2465, col: 1, offset: 74971},
 			expr: &seqExpr{
-				pos: position{line: 2458, col: 16, offset: 74852},
+				pos: position{line: 2465, col: 16, offset: 74986},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2458, col: 16, offset: 74852},
+						pos:        position{line: 2465, col: 16, offset: 74986},
 						val:        "materialized",
 						ignoreCase: true,
 						want:       "\"MATERIALIZED\"i",
 					},
 					&notExpr{
-						pos: position{line: 2458, col: 33, offset: 74869},
+						pos: position{line: 2465, col: 33, offset: 75003},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2458, col: 34, offset: 74870},
+							pos:  position{line: 2465, col: 34, offset: 75004},
 							name: "IdentifierRest",
 						},
 					},
@@ -17602,20 +17627,20 @@ var g = &grammar{
 		},
 		{
 			name: "MAP",
-			pos:  position{line: 2459, col: 1, offset: 74885},
+			pos:  position{line: 2466, col: 1, offset: 75019},
 			expr: &seqExpr{
-				pos: position{line: 2459, col: 14, offset: 74898},
+				pos: position{line: 2466, col: 14, offset: 75032},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2459, col: 14, offset: 74898},
+						pos:        position{line: 2466, col: 14, offset: 75032},
 						val:        "map",
 						ignoreCase: true,
 						want:       "\"MAP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2459, col: 33, offset: 74917},
+						pos: position{line: 2466, col: 33, offset: 75051},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2459, col: 34, offset: 74918},
+							pos:  position{line: 2466, col: 34, offset: 75052},
 							name: "IdentifierRest",
 						},
 					},
@@ -17626,20 +17651,20 @@ var g = &grammar{
 		},
 		{
 			name: "MERGE",
-			pos:  position{line: 2460, col: 1, offset: 74933},
+			pos:  position{line: 2467, col: 1, offset: 75067},
 			expr: &seqExpr{
-				pos: position{line: 2460, col: 14, offset: 74946},
+				pos: position{line: 2467, col: 14, offset: 75080},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2460, col: 14, offset: 74946},
+						pos:        position{line: 2467, col: 14, offset: 75080},
 						val:        "merge",
 						ignoreCase: true,
 						want:       "\"MERGE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2460, col: 33, offset: 74965},
+						pos: position{line: 2467, col: 33, offset: 75099},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2460, col: 34, offset: 74966},
+							pos:  position{line: 2467, col: 34, offset: 75100},
 							name: "IdentifierRest",
 						},
 					},
@@ -17650,20 +17675,20 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 2461, col: 1, offset: 74981},
+			pos:  position{line: 2468, col: 1, offset: 75115},
 			expr: &seqExpr{
-				pos: position{line: 2461, col: 14, offset: 74994},
+				pos: position{line: 2468, col: 14, offset: 75128},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2461, col: 14, offset: 74994},
+						pos:        position{line: 2468, col: 14, offset: 75128},
 						val:        "not",
 						ignoreCase: true,
 						want:       "\"NOT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2461, col: 33, offset: 75013},
+						pos: position{line: 2468, col: 33, offset: 75147},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2461, col: 34, offset: 75014},
+							pos:  position{line: 2468, col: 34, offset: 75148},
 							name: "IdentifierRest",
 						},
 					},
@@ -17674,20 +17699,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULL",
-			pos:  position{line: 2462, col: 1, offset: 75029},
+			pos:  position{line: 2469, col: 1, offset: 75163},
 			expr: &seqExpr{
-				pos: position{line: 2462, col: 14, offset: 75042},
+				pos: position{line: 2469, col: 14, offset: 75176},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2462, col: 14, offset: 75042},
+						pos:        position{line: 2469, col: 14, offset: 75176},
 						val:        "null",
 						ignoreCase: true,
 						want:       "\"NULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2462, col: 33, offset: 75061},
+						pos: position{line: 2469, col: 33, offset: 75195},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2462, col: 34, offset: 75062},
+							pos:  position{line: 2469, col: 34, offset: 75196},
 							name: "IdentifierRest",
 						},
 					},
@@ -17698,20 +17723,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULLS",
-			pos:  position{line: 2463, col: 1, offset: 75077},
+			pos:  position{line: 2470, col: 1, offset: 75211},
 			expr: &seqExpr{
-				pos: position{line: 2463, col: 14, offset: 75090},
+				pos: position{line: 2470, col: 14, offset: 75224},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2463, col: 14, offset: 75090},
+						pos:        position{line: 2470, col: 14, offset: 75224},
 						val:        "nulls",
 						ignoreCase: true,
 						want:       "\"NULLS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2463, col: 33, offset: 75109},
+						pos: position{line: 2470, col: 33, offset: 75243},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2463, col: 34, offset: 75110},
+							pos:  position{line: 2470, col: 34, offset: 75244},
 							name: "IdentifierRest",
 						},
 					},
@@ -17722,20 +17747,20 @@ var g = &grammar{
 		},
 		{
 			name: "OFFSET",
-			pos:  position{line: 2464, col: 1, offset: 75125},
+			pos:  position{line: 2471, col: 1, offset: 75259},
 			expr: &seqExpr{
-				pos: position{line: 2464, col: 14, offset: 75138},
+				pos: position{line: 2471, col: 14, offset: 75272},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2464, col: 14, offset: 75138},
+						pos:        position{line: 2471, col: 14, offset: 75272},
 						val:        "offset",
 						ignoreCase: true,
 						want:       "\"OFFSET\"i",
 					},
 					&notExpr{
-						pos: position{line: 2464, col: 33, offset: 75157},
+						pos: position{line: 2471, col: 33, offset: 75291},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2464, col: 34, offset: 75158},
+							pos:  position{line: 2471, col: 34, offset: 75292},
 							name: "IdentifierRest",
 						},
 					},
@@ -17746,20 +17771,20 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 2465, col: 1, offset: 75173},
+			pos:  position{line: 2472, col: 1, offset: 75307},
 			expr: &seqExpr{
-				pos: position{line: 2465, col: 14, offset: 75186},
+				pos: position{line: 2472, col: 14, offset: 75320},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2465, col: 14, offset: 75186},
+						pos:        position{line: 2472, col: 14, offset: 75320},
 						val:        "on",
 						ignoreCase: true,
 						want:       "\"ON\"i",
 					},
 					&notExpr{
-						pos: position{line: 2465, col: 33, offset: 75205},
+						pos: position{line: 2472, col: 33, offset: 75339},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2465, col: 34, offset: 75206},
+							pos:  position{line: 2472, col: 34, offset: 75340},
 							name: "IdentifierRest",
 						},
 					},
@@ -17770,20 +17795,20 @@ var g = &grammar{
 		},
 		{
 			name: "OP",
-			pos:  position{line: 2466, col: 1, offset: 75221},
+			pos:  position{line: 2473, col: 1, offset: 75355},
 			expr: &seqExpr{
-				pos: position{line: 2466, col: 14, offset: 75234},
+				pos: position{line: 2473, col: 14, offset: 75368},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2466, col: 14, offset: 75234},
+						pos:        position{line: 2473, col: 14, offset: 75368},
 						val:        "op",
 						ignoreCase: true,
 						want:       "\"OP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2466, col: 33, offset: 75253},
+						pos: position{line: 2473, col: 33, offset: 75387},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2466, col: 34, offset: 75254},
+							pos:  position{line: 2473, col: 34, offset: 75388},
 							name: "IdentifierRest",
 						},
 					},
@@ -17794,23 +17819,23 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 2467, col: 1, offset: 75269},
+			pos:  position{line: 2474, col: 1, offset: 75403},
 			expr: &actionExpr{
-				pos: position{line: 2467, col: 14, offset: 75282},
+				pos: position{line: 2474, col: 14, offset: 75416},
 				run: (*parser).callonOR1,
 				expr: &seqExpr{
-					pos: position{line: 2467, col: 14, offset: 75282},
+					pos: position{line: 2474, col: 14, offset: 75416},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2467, col: 14, offset: 75282},
+							pos:        position{line: 2474, col: 14, offset: 75416},
 							val:        "or",
 							ignoreCase: true,
 							want:       "\"OR\"i",
 						},
 						&notExpr{
-							pos: position{line: 2467, col: 33, offset: 75301},
+							pos: position{line: 2474, col: 33, offset: 75435},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2467, col: 34, offset: 75302},
+								pos:  position{line: 2474, col: 34, offset: 75436},
 								name: "IdentifierRest",
 							},
 						},
@@ -17822,20 +17847,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 2468, col: 1, offset: 75338},
+			pos:  position{line: 2475, col: 1, offset: 75472},
 			expr: &seqExpr{
-				pos: position{line: 2468, col: 14, offset: 75351},
+				pos: position{line: 2475, col: 14, offset: 75485},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2468, col: 14, offset: 75351},
+						pos:        position{line: 2475, col: 14, offset: 75485},
 						val:        "order",
 						ignoreCase: true,
 						want:       "\"ORDER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2468, col: 33, offset: 75370},
+						pos: position{line: 2475, col: 33, offset: 75504},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2468, col: 34, offset: 75371},
+							pos:  position{line: 2475, col: 34, offset: 75505},
 							name: "IdentifierRest",
 						},
 					},
@@ -17846,20 +17871,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDINALITY",
-			pos:  position{line: 2469, col: 1, offset: 75386},
+			pos:  position{line: 2476, col: 1, offset: 75520},
 			expr: &seqExpr{
-				pos: position{line: 2469, col: 14, offset: 75399},
+				pos: position{line: 2476, col: 14, offset: 75533},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2469, col: 14, offset: 75399},
+						pos:        position{line: 2476, col: 14, offset: 75533},
 						val:        "ordinality",
 						ignoreCase: true,
 						want:       "\"ORDINALITY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2469, col: 33, offset: 75418},
+						pos: position{line: 2476, col: 33, offset: 75552},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2469, col: 34, offset: 75419},
+							pos:  position{line: 2476, col: 34, offset: 75553},
 							name: "IdentifierRest",
 						},
 					},
@@ -17870,20 +17895,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTER",
-			pos:  position{line: 2470, col: 1, offset: 75434},
+			pos:  position{line: 2477, col: 1, offset: 75568},
 			expr: &seqExpr{
-				pos: position{line: 2470, col: 14, offset: 75447},
+				pos: position{line: 2477, col: 14, offset: 75581},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2470, col: 14, offset: 75447},
+						pos:        position{line: 2477, col: 14, offset: 75581},
 						val:        "outer",
 						ignoreCase: true,
 						want:       "\"OUTER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2470, col: 33, offset: 75466},
+						pos: position{line: 2477, col: 33, offset: 75600},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2470, col: 34, offset: 75467},
+							pos:  position{line: 2477, col: 34, offset: 75601},
 							name: "IdentifierRest",
 						},
 					},
@@ -17894,20 +17919,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTPUT",
-			pos:  position{line: 2471, col: 1, offset: 75482},
+			pos:  position{line: 2478, col: 1, offset: 75616},
 			expr: &seqExpr{
-				pos: position{line: 2471, col: 14, offset: 75495},
+				pos: position{line: 2478, col: 14, offset: 75629},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2471, col: 14, offset: 75495},
+						pos:        position{line: 2478, col: 14, offset: 75629},
 						val:        "output",
 						ignoreCase: true,
 						want:       "\"OUTPUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2471, col: 33, offset: 75514},
+						pos: position{line: 2478, col: 33, offset: 75648},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2471, col: 34, offset: 75515},
+							pos:  position{line: 2478, col: 34, offset: 75649},
 							name: "IdentifierRest",
 						},
 					},
@@ -17918,20 +17943,20 @@ var g = &grammar{
 		},
 		{
 			name: "PASS",
-			pos:  position{line: 2472, col: 1, offset: 75530},
+			pos:  position{line: 2479, col: 1, offset: 75664},
 			expr: &seqExpr{
-				pos: position{line: 2472, col: 14, offset: 75543},
+				pos: position{line: 2479, col: 14, offset: 75677},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2472, col: 14, offset: 75543},
+						pos:        position{line: 2479, col: 14, offset: 75677},
 						val:        "pass",
 						ignoreCase: true,
 						want:       "\"PASS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2472, col: 33, offset: 75562},
+						pos: position{line: 2479, col: 33, offset: 75696},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2472, col: 34, offset: 75563},
+							pos:  position{line: 2479, col: 34, offset: 75697},
 							name: "IdentifierRest",
 						},
 					},
@@ -17942,20 +17967,20 @@ var g = &grammar{
 		},
 		{
 			name: "PUT",
-			pos:  position{line: 2473, col: 1, offset: 75578},
+			pos:  position{line: 2480, col: 1, offset: 75712},
 			expr: &seqExpr{
-				pos: position{line: 2473, col: 14, offset: 75591},
+				pos: position{line: 2480, col: 14, offset: 75725},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2473, col: 14, offset: 75591},
+						pos:        position{line: 2480, col: 14, offset: 75725},
 						val:        "put",
 						ignoreCase: true,
 						want:       "\"PUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2473, col: 33, offset: 75610},
+						pos: position{line: 2480, col: 33, offset: 75744},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2473, col: 34, offset: 75611},
+							pos:  position{line: 2480, col: 34, offset: 75745},
 							name: "IdentifierRest",
 						},
 					},
@@ -17966,20 +17991,20 @@ var g = &grammar{
 		},
 		{
 			name: "PRAGMA",
-			pos:  position{line: 2474, col: 1, offset: 75626},
+			pos:  position{line: 2481, col: 1, offset: 75760},
 			expr: &seqExpr{
-				pos: position{line: 2474, col: 14, offset: 75639},
+				pos: position{line: 2481, col: 14, offset: 75773},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2474, col: 14, offset: 75639},
+						pos:        position{line: 2481, col: 14, offset: 75773},
 						val:        "pragma",
 						ignoreCase: true,
 						want:       "\"PRAGMA\"i",
 					},
 					&notExpr{
-						pos: position{line: 2474, col: 33, offset: 75658},
+						pos: position{line: 2481, col: 33, offset: 75792},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2474, col: 34, offset: 75659},
+							pos:  position{line: 2481, col: 34, offset: 75793},
 							name: "IdentifierRest",
 						},
 					},
@@ -17990,20 +18015,20 @@ var g = &grammar{
 		},
 		{
 			name: "RECURSIVE",
-			pos:  position{line: 2475, col: 1, offset: 75674},
+			pos:  position{line: 2482, col: 1, offset: 75808},
 			expr: &seqExpr{
-				pos: position{line: 2475, col: 14, offset: 75687},
+				pos: position{line: 2482, col: 14, offset: 75821},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2475, col: 14, offset: 75687},
+						pos:        position{line: 2482, col: 14, offset: 75821},
 						val:        "recursive",
 						ignoreCase: true,
 						want:       "\"RECURSIVE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2475, col: 33, offset: 75706},
+						pos: position{line: 2482, col: 33, offset: 75840},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2475, col: 34, offset: 75707},
+							pos:  position{line: 2482, col: 34, offset: 75841},
 							name: "IdentifierRest",
 						},
 					},
@@ -18014,20 +18039,20 @@ var g = &grammar{
 		},
 		{
 			name: "RENAME",
-			pos:  position{line: 2476, col: 1, offset: 75722},
+			pos:  position{line: 2483, col: 1, offset: 75856},
 			expr: &seqExpr{
-				pos: position{line: 2476, col: 14, offset: 75735},
+				pos: position{line: 2483, col: 14, offset: 75869},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2476, col: 14, offset: 75735},
+						pos:        position{line: 2483, col: 14, offset: 75869},
 						val:        "rename",
 						ignoreCase: true,
 						want:       "\"RENAME\"i",
 					},
 					&notExpr{
-						pos: position{line: 2476, col: 33, offset: 75754},
+						pos: position{line: 2483, col: 33, offset: 75888},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2476, col: 34, offset: 75755},
+							pos:  position{line: 2483, col: 34, offset: 75889},
 							name: "IdentifierRest",
 						},
 					},
@@ -18038,20 +18063,20 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 2477, col: 1, offset: 75770},
+			pos:  position{line: 2484, col: 1, offset: 75904},
 			expr: &seqExpr{
-				pos: position{line: 2477, col: 14, offset: 75783},
+				pos: position{line: 2484, col: 14, offset: 75917},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2477, col: 14, offset: 75783},
+						pos:        position{line: 2484, col: 14, offset: 75917},
 						val:        "right",
 						ignoreCase: true,
 						want:       "\"RIGHT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2477, col: 33, offset: 75802},
+						pos: position{line: 2484, col: 33, offset: 75936},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2477, col: 34, offset: 75803},
+							pos:  position{line: 2484, col: 34, offset: 75937},
 							name: "IdentifierRest",
 						},
 					},
@@ -18062,20 +18087,20 @@ var g = &grammar{
 		},
 		{
 			name: "SHAPES",
-			pos:  position{line: 2478, col: 1, offset: 75818},
+			pos:  position{line: 2485, col: 1, offset: 75952},
 			expr: &seqExpr{
-				pos: position{line: 2478, col: 14, offset: 75831},
+				pos: position{line: 2485, col: 14, offset: 75965},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2478, col: 14, offset: 75831},
+						pos:        position{line: 2485, col: 14, offset: 75965},
 						val:        "shapes",
 						ignoreCase: true,
 						want:       "\"SHAPES\"i",
 					},
 					&notExpr{
-						pos: position{line: 2478, col: 33, offset: 75850},
+						pos: position{line: 2485, col: 33, offset: 75984},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2478, col: 34, offset: 75851},
+							pos:  position{line: 2485, col: 34, offset: 75985},
 							name: "IdentifierRest",
 						},
 					},
@@ -18086,20 +18111,20 @@ var g = &grammar{
 		},
 		{
 			name: "SEARCH",
-			pos:  position{line: 2479, col: 1, offset: 75866},
+			pos:  position{line: 2486, col: 1, offset: 76000},
 			expr: &seqExpr{
-				pos: position{line: 2479, col: 14, offset: 75879},
+				pos: position{line: 2486, col: 14, offset: 76013},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2479, col: 14, offset: 75879},
+						pos:        position{line: 2486, col: 14, offset: 76013},
 						val:        "search",
 						ignoreCase: true,
 						want:       "\"SEARCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2479, col: 33, offset: 75898},
+						pos: position{line: 2486, col: 33, offset: 76032},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2479, col: 34, offset: 75899},
+							pos:  position{line: 2486, col: 34, offset: 76033},
 							name: "IdentifierRest",
 						},
 					},
@@ -18110,20 +18135,20 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 2480, col: 1, offset: 75914},
+			pos:  position{line: 2487, col: 1, offset: 76048},
 			expr: &seqExpr{
-				pos: position{line: 2480, col: 14, offset: 75927},
+				pos: position{line: 2487, col: 14, offset: 76061},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2480, col: 14, offset: 75927},
+						pos:        position{line: 2487, col: 14, offset: 76061},
 						val:        "select",
 						ignoreCase: true,
 						want:       "\"SELECT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2480, col: 33, offset: 75946},
+						pos: position{line: 2487, col: 33, offset: 76080},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2480, col: 34, offset: 75947},
+							pos:  position{line: 2487, col: 34, offset: 76081},
 							name: "IdentifierRest",
 						},
 					},
@@ -18134,20 +18159,20 @@ var g = &grammar{
 		},
 		{
 			name: "SHAPE",
-			pos:  position{line: 2481, col: 1, offset: 75962},
+			pos:  position{line: 2488, col: 1, offset: 76096},
 			expr: &seqExpr{
-				pos: position{line: 2481, col: 14, offset: 75975},
+				pos: position{line: 2488, col: 14, offset: 76109},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2481, col: 14, offset: 75975},
+						pos:        position{line: 2488, col: 14, offset: 76109},
 						val:        "shape",
 						ignoreCase: true,
 						want:       "\"SHAPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2481, col: 33, offset: 75994},
+						pos: position{line: 2488, col: 33, offset: 76128},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2481, col: 34, offset: 75995},
+							pos:  position{line: 2488, col: 34, offset: 76129},
 							name: "IdentifierRest",
 						},
 					},
@@ -18158,20 +18183,20 @@ var g = &grammar{
 		},
 		{
 			name: "SKIP",
-			pos:  position{line: 2482, col: 1, offset: 76010},
+			pos:  position{line: 2489, col: 1, offset: 76144},
 			expr: &seqExpr{
-				pos: position{line: 2482, col: 14, offset: 76023},
+				pos: position{line: 2489, col: 14, offset: 76157},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2482, col: 14, offset: 76023},
+						pos:        position{line: 2489, col: 14, offset: 76157},
 						val:        "skip",
 						ignoreCase: true,
 						want:       "\"SKIP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2482, col: 33, offset: 76042},
+						pos: position{line: 2489, col: 33, offset: 76176},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2482, col: 34, offset: 76043},
+							pos:  position{line: 2489, col: 34, offset: 76177},
 							name: "IdentifierRest",
 						},
 					},
@@ -18182,20 +18207,20 @@ var g = &grammar{
 		},
 		{
 			name: "SORT",
-			pos:  position{line: 2483, col: 1, offset: 76058},
+			pos:  position{line: 2490, col: 1, offset: 76192},
 			expr: &seqExpr{
-				pos: position{line: 2483, col: 14, offset: 76071},
+				pos: position{line: 2490, col: 14, offset: 76205},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2483, col: 14, offset: 76071},
+						pos:        position{line: 2490, col: 14, offset: 76205},
 						val:        "sort",
 						ignoreCase: true,
 						want:       "\"SORT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2483, col: 33, offset: 76090},
+						pos: position{line: 2490, col: 33, offset: 76224},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2483, col: 34, offset: 76091},
+							pos:  position{line: 2490, col: 34, offset: 76225},
 							name: "IdentifierRest",
 						},
 					},
@@ -18206,20 +18231,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUBSTRING",
-			pos:  position{line: 2484, col: 1, offset: 76106},
+			pos:  position{line: 2491, col: 1, offset: 76240},
 			expr: &seqExpr{
-				pos: position{line: 2484, col: 14, offset: 76119},
+				pos: position{line: 2491, col: 14, offset: 76253},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2484, col: 14, offset: 76119},
+						pos:        position{line: 2491, col: 14, offset: 76253},
 						val:        "substring",
 						ignoreCase: true,
 						want:       "\"SUBSTRING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2484, col: 33, offset: 76138},
+						pos: position{line: 2491, col: 33, offset: 76272},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2484, col: 34, offset: 76139},
+							pos:  position{line: 2491, col: 34, offset: 76273},
 							name: "IdentifierRest",
 						},
 					},
@@ -18230,20 +18255,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUMMARIZE",
-			pos:  position{line: 2485, col: 1, offset: 76154},
+			pos:  position{line: 2492, col: 1, offset: 76288},
 			expr: &seqExpr{
-				pos: position{line: 2485, col: 14, offset: 76167},
+				pos: position{line: 2492, col: 14, offset: 76301},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2485, col: 14, offset: 76167},
+						pos:        position{line: 2492, col: 14, offset: 76301},
 						val:        "summarize",
 						ignoreCase: true,
 						want:       "\"SUMMARIZE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2485, col: 33, offset: 76186},
+						pos: position{line: 2492, col: 33, offset: 76320},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2485, col: 34, offset: 76187},
+							pos:  position{line: 2492, col: 34, offset: 76321},
 							name: "IdentifierRest",
 						},
 					},
@@ -18254,20 +18279,20 @@ var g = &grammar{
 		},
 		{
 			name: "SWITCH",
-			pos:  position{line: 2486, col: 1, offset: 76202},
+			pos:  position{line: 2493, col: 1, offset: 76336},
 			expr: &seqExpr{
-				pos: position{line: 2486, col: 14, offset: 76215},
+				pos: position{line: 2493, col: 14, offset: 76349},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2486, col: 14, offset: 76215},
+						pos:        position{line: 2493, col: 14, offset: 76349},
 						val:        "switch",
 						ignoreCase: true,
 						want:       "\"SWITCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2486, col: 33, offset: 76234},
+						pos: position{line: 2493, col: 33, offset: 76368},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2486, col: 34, offset: 76235},
+							pos:  position{line: 2493, col: 34, offset: 76369},
 							name: "IdentifierRest",
 						},
 					},
@@ -18278,20 +18303,20 @@ var g = &grammar{
 		},
 		{
 			name: "TAIL",
-			pos:  position{line: 2487, col: 1, offset: 76250},
+			pos:  position{line: 2494, col: 1, offset: 76384},
 			expr: &seqExpr{
-				pos: position{line: 2487, col: 14, offset: 76263},
+				pos: position{line: 2494, col: 14, offset: 76397},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2487, col: 14, offset: 76263},
+						pos:        position{line: 2494, col: 14, offset: 76397},
 						val:        "tail",
 						ignoreCase: true,
 						want:       "\"TAIL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2487, col: 33, offset: 76282},
+						pos: position{line: 2494, col: 33, offset: 76416},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2487, col: 34, offset: 76283},
+							pos:  position{line: 2494, col: 34, offset: 76417},
 							name: "IdentifierRest",
 						},
 					},
@@ -18302,20 +18327,20 @@ var g = &grammar{
 		},
 		{
 			name: "THEN",
-			pos:  position{line: 2488, col: 1, offset: 76298},
+			pos:  position{line: 2495, col: 1, offset: 76432},
 			expr: &seqExpr{
-				pos: position{line: 2488, col: 14, offset: 76311},
+				pos: position{line: 2495, col: 14, offset: 76445},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2488, col: 14, offset: 76311},
+						pos:        position{line: 2495, col: 14, offset: 76445},
 						val:        "then",
 						ignoreCase: true,
 						want:       "\"THEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2488, col: 33, offset: 76330},
+						pos: position{line: 2495, col: 33, offset: 76464},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2488, col: 34, offset: 76331},
+							pos:  position{line: 2495, col: 34, offset: 76465},
 							name: "IdentifierRest",
 						},
 					},
@@ -18326,23 +18351,23 @@ var g = &grammar{
 		},
 		{
 			name: "TIMESTAMP",
-			pos:  position{line: 2489, col: 1, offset: 76346},
+			pos:  position{line: 2496, col: 1, offset: 76480},
 			expr: &actionExpr{
-				pos: position{line: 2489, col: 14, offset: 76359},
+				pos: position{line: 2496, col: 14, offset: 76493},
 				run: (*parser).callonTIMESTAMP1,
 				expr: &seqExpr{
-					pos: position{line: 2489, col: 14, offset: 76359},
+					pos: position{line: 2496, col: 14, offset: 76493},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2489, col: 14, offset: 76359},
+							pos:        position{line: 2496, col: 14, offset: 76493},
 							val:        "timestamp",
 							ignoreCase: true,
 							want:       "\"TIMESTAMP\"i",
 						},
 						&notExpr{
-							pos: position{line: 2489, col: 33, offset: 76378},
+							pos: position{line: 2496, col: 33, offset: 76512},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2489, col: 34, offset: 76379},
+								pos:  position{line: 2496, col: 34, offset: 76513},
 								name: "IdentifierRest",
 							},
 						},
@@ -18354,20 +18379,20 @@ var g = &grammar{
 		},
 		{
 			name: "TOP",
-			pos:  position{line: 2490, col: 1, offset: 76422},
+			pos:  position{line: 2497, col: 1, offset: 76556},
 			expr: &seqExpr{
-				pos: position{line: 2490, col: 14, offset: 76435},
+				pos: position{line: 2497, col: 14, offset: 76569},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2490, col: 14, offset: 76435},
+						pos:        position{line: 2497, col: 14, offset: 76569},
 						val:        "top",
 						ignoreCase: true,
 						want:       "\"TOP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2490, col: 33, offset: 76454},
+						pos: position{line: 2497, col: 33, offset: 76588},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2490, col: 34, offset: 76455},
+							pos:  position{line: 2497, col: 34, offset: 76589},
 							name: "IdentifierRest",
 						},
 					},
@@ -18378,20 +18403,20 @@ var g = &grammar{
 		},
 		{
 			name: "TRUE",
-			pos:  position{line: 2491, col: 1, offset: 76470},
+			pos:  position{line: 2498, col: 1, offset: 76604},
 			expr: &seqExpr{
-				pos: position{line: 2491, col: 14, offset: 76483},
+				pos: position{line: 2498, col: 14, offset: 76617},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2491, col: 14, offset: 76483},
+						pos:        position{line: 2498, col: 14, offset: 76617},
 						val:        "true",
 						ignoreCase: true,
 						want:       "\"TRUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2491, col: 33, offset: 76502},
+						pos: position{line: 2498, col: 33, offset: 76636},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2491, col: 34, offset: 76503},
+							pos:  position{line: 2498, col: 34, offset: 76637},
 							name: "IdentifierRest",
 						},
 					},
@@ -18402,20 +18427,20 @@ var g = &grammar{
 		},
 		{
 			name: "TYPE",
-			pos:  position{line: 2492, col: 1, offset: 76518},
+			pos:  position{line: 2499, col: 1, offset: 76652},
 			expr: &seqExpr{
-				pos: position{line: 2492, col: 14, offset: 76531},
+				pos: position{line: 2499, col: 14, offset: 76665},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2492, col: 14, offset: 76531},
+						pos:        position{line: 2499, col: 14, offset: 76665},
 						val:        "type",
 						ignoreCase: true,
 						want:       "\"TYPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2492, col: 33, offset: 76550},
+						pos: position{line: 2499, col: 33, offset: 76684},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2492, col: 34, offset: 76551},
+							pos:  position{line: 2499, col: 34, offset: 76685},
 							name: "IdentifierRest",
 						},
 					},
@@ -18426,20 +18451,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNION",
-			pos:  position{line: 2493, col: 1, offset: 76566},
+			pos:  position{line: 2500, col: 1, offset: 76700},
 			expr: &seqExpr{
-				pos: position{line: 2493, col: 14, offset: 76579},
+				pos: position{line: 2500, col: 14, offset: 76713},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2493, col: 14, offset: 76579},
+						pos:        position{line: 2500, col: 14, offset: 76713},
 						val:        "union",
 						ignoreCase: true,
 						want:       "\"UNION\"i",
 					},
 					&notExpr{
-						pos: position{line: 2493, col: 33, offset: 76598},
+						pos: position{line: 2500, col: 33, offset: 76732},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2493, col: 34, offset: 76599},
+							pos:  position{line: 2500, col: 34, offset: 76733},
 							name: "IdentifierRest",
 						},
 					},
@@ -18450,20 +18475,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNIQ",
-			pos:  position{line: 2494, col: 1, offset: 76614},
+			pos:  position{line: 2501, col: 1, offset: 76748},
 			expr: &seqExpr{
-				pos: position{line: 2494, col: 14, offset: 76627},
+				pos: position{line: 2501, col: 14, offset: 76761},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2494, col: 14, offset: 76627},
+						pos:        position{line: 2501, col: 14, offset: 76761},
 						val:        "uniq",
 						ignoreCase: true,
 						want:       "\"UNIQ\"i",
 					},
 					&notExpr{
-						pos: position{line: 2494, col: 33, offset: 76646},
+						pos: position{line: 2501, col: 33, offset: 76780},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2494, col: 34, offset: 76647},
+							pos:  position{line: 2501, col: 34, offset: 76781},
 							name: "IdentifierRest",
 						},
 					},
@@ -18474,20 +18499,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNNEST",
-			pos:  position{line: 2495, col: 1, offset: 76662},
+			pos:  position{line: 2502, col: 1, offset: 76796},
 			expr: &seqExpr{
-				pos: position{line: 2495, col: 14, offset: 76675},
+				pos: position{line: 2502, col: 14, offset: 76809},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2495, col: 14, offset: 76675},
+						pos:        position{line: 2502, col: 14, offset: 76809},
 						val:        "unnest",
 						ignoreCase: true,
 						want:       "\"UNNEST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2495, col: 33, offset: 76694},
+						pos: position{line: 2502, col: 33, offset: 76828},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2495, col: 34, offset: 76695},
+							pos:  position{line: 2502, col: 34, offset: 76829},
 							name: "IdentifierRest",
 						},
 					},
@@ -18498,20 +18523,20 @@ var g = &grammar{
 		},
 		{
 			name: "USING",
-			pos:  position{line: 2496, col: 1, offset: 76710},
+			pos:  position{line: 2503, col: 1, offset: 76844},
 			expr: &seqExpr{
-				pos: position{line: 2496, col: 14, offset: 76723},
+				pos: position{line: 2503, col: 14, offset: 76857},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2496, col: 14, offset: 76723},
+						pos:        position{line: 2503, col: 14, offset: 76857},
 						val:        "using",
 						ignoreCase: true,
 						want:       "\"USING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2496, col: 33, offset: 76742},
+						pos: position{line: 2503, col: 33, offset: 76876},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2496, col: 34, offset: 76743},
+							pos:  position{line: 2503, col: 34, offset: 76877},
 							name: "IdentifierRest",
 						},
 					},
@@ -18522,20 +18547,20 @@ var g = &grammar{
 		},
 		{
 			name: "VALUE",
-			pos:  position{line: 2497, col: 1, offset: 76758},
+			pos:  position{line: 2504, col: 1, offset: 76892},
 			expr: &seqExpr{
-				pos: position{line: 2497, col: 14, offset: 76771},
+				pos: position{line: 2504, col: 14, offset: 76905},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2497, col: 14, offset: 76771},
+						pos:        position{line: 2504, col: 14, offset: 76905},
 						val:        "value",
 						ignoreCase: true,
 						want:       "\"VALUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2497, col: 33, offset: 76790},
+						pos: position{line: 2504, col: 33, offset: 76924},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2497, col: 34, offset: 76791},
+							pos:  position{line: 2504, col: 34, offset: 76925},
 							name: "IdentifierRest",
 						},
 					},
@@ -18546,20 +18571,20 @@ var g = &grammar{
 		},
 		{
 			name: "VALUES",
-			pos:  position{line: 2498, col: 1, offset: 76806},
+			pos:  position{line: 2505, col: 1, offset: 76940},
 			expr: &seqExpr{
-				pos: position{line: 2498, col: 14, offset: 76819},
+				pos: position{line: 2505, col: 14, offset: 76953},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2498, col: 14, offset: 76819},
+						pos:        position{line: 2505, col: 14, offset: 76953},
 						val:        "values",
 						ignoreCase: true,
 						want:       "\"VALUES\"i",
 					},
 					&notExpr{
-						pos: position{line: 2498, col: 33, offset: 76838},
+						pos: position{line: 2505, col: 33, offset: 76972},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2498, col: 34, offset: 76839},
+							pos:  position{line: 2505, col: 34, offset: 76973},
 							name: "IdentifierRest",
 						},
 					},
@@ -18570,20 +18595,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHEN",
-			pos:  position{line: 2499, col: 1, offset: 76854},
+			pos:  position{line: 2506, col: 1, offset: 76988},
 			expr: &seqExpr{
-				pos: position{line: 2499, col: 14, offset: 76867},
+				pos: position{line: 2506, col: 14, offset: 77001},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2499, col: 14, offset: 76867},
+						pos:        position{line: 2506, col: 14, offset: 77001},
 						val:        "when",
 						ignoreCase: true,
 						want:       "\"WHEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2499, col: 33, offset: 76886},
+						pos: position{line: 2506, col: 33, offset: 77020},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2499, col: 34, offset: 76887},
+							pos:  position{line: 2506, col: 34, offset: 77021},
 							name: "IdentifierRest",
 						},
 					},
@@ -18594,20 +18619,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 2500, col: 1, offset: 76902},
+			pos:  position{line: 2507, col: 1, offset: 77036},
 			expr: &seqExpr{
-				pos: position{line: 2500, col: 14, offset: 76915},
+				pos: position{line: 2507, col: 14, offset: 77049},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2500, col: 14, offset: 76915},
+						pos:        position{line: 2507, col: 14, offset: 77049},
 						val:        "where",
 						ignoreCase: true,
 						want:       "\"WHERE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2500, col: 33, offset: 76934},
+						pos: position{line: 2507, col: 33, offset: 77068},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2500, col: 34, offset: 76935},
+							pos:  position{line: 2507, col: 34, offset: 77069},
 							name: "IdentifierRest",
 						},
 					},
@@ -18618,20 +18643,20 @@ var g = &grammar{
 		},
 		{
 			name: "WITH",
-			pos:  position{line: 2501, col: 1, offset: 76950},
+			pos:  position{line: 2508, col: 1, offset: 77084},
 			expr: &seqExpr{
-				pos: position{line: 2501, col: 14, offset: 76963},
+				pos: position{line: 2508, col: 14, offset: 77097},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2501, col: 14, offset: 76963},
+						pos:        position{line: 2508, col: 14, offset: 77097},
 						val:        "with",
 						ignoreCase: true,
 						want:       "\"WITH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2501, col: 33, offset: 76982},
+						pos: position{line: 2508, col: 33, offset: 77116},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2501, col: 34, offset: 76983},
+							pos:  position{line: 2508, col: 34, offset: 77117},
 							name: "IdentifierRest",
 						},
 					},
@@ -19635,18 +19660,33 @@ func (p *parser) callonCallOp1() (any, error) {
 	return p.cur.onCallOp1(stack["name"], stack["args"])
 }
 
-func (c *current) onCountOp1(rec any) (any, error) {
+func (c *current) onCountOp2(rec any) (any, error) {
 	return &ast.CountOp{
 		Kind: "CountOp",
 		Expr: rec.(*ast.RecordExpr),
+		Loc:  loc(c),
 	}, nil
 
 }
 
-func (p *parser) callonCountOp1() (any, error) {
+func (p *parser) callonCountOp2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onCountOp1(stack["rec"])
+	return p.cur.onCountOp2(stack["rec"])
+}
+
+func (c *current) onCountOp8() (any, error) {
+	return &ast.CountOp{
+		Kind: "CountOp",
+		Loc:  loc(c),
+	}, nil
+
+}
+
+func (p *parser) callonCountOp8() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onCountOp8()
 }
 
 func (c *current) onCutOp1(args any) (any, error) {

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -485,6 +485,13 @@ CountOp
       return &ast.CountOp{
         Kind: "CountOp",
         Expr: rec.(*ast.RecordExpr),
+        Loc: loc(c),
+      }, nil
+    }
+  / COUNT &EndOfOp {
+      return &ast.CountOp{
+        Kind: "CountOp",
+        Loc: loc(c),
       }, nil
     }
 

--- a/compiler/semantic/checker.go
+++ b/compiler/semantic/checker.go
@@ -88,12 +88,14 @@ func (c *checker) op(typ super.Type, op sem.Op) super.Type {
 	case *sem.BadOp:
 		return c.unknown
 	case *sem.CountOp:
-		elems := []sem.RecordElem{
-			&sem.FieldElem{Name: op.Alias, Value: &sem.LiteralExpr{Value: "0(uint64)"}},
-		}
+		var elems []sem.RecordElem
 		if op.Expr != nil {
 			elems = append(elems, op.Expr.(*sem.RecordExpr).Elems...)
 		}
+		elems = append(elems, &sem.FieldElem{
+			Name:  op.Alias,
+			Value: &sem.LiteralExpr{Value: "0(uint64)"},
+		})
 		return c.recordElems(typ, elems)
 	case *sem.CutOp:
 		return c.pathsToType(c.assignments(typ, op.Args))

--- a/compiler/sfmt/dag.go
+++ b/compiler/sfmt/dag.go
@@ -411,12 +411,12 @@ func (c *canonDAG) op(p dag.Op) {
 		c.write("combine")
 	case *dag.CountOp:
 		c.next()
-		c.write("count {%s", p.Alias)
+		c.write("count {")
 		if p.Expr != nil {
-			c.write(",")
 			c.recordElems(p.Expr.(*dag.RecordExpr).Elems)
+			c.write(",")
 		}
-		c.write("}")
+		c.write("%s}", p.Alias)
 	case *dag.CutOp:
 		c.next()
 		c.write("cut ")

--- a/compiler/ztests/par-count.yaml
+++ b/compiler/ztests/par-count.yaml
@@ -1,13 +1,13 @@
 # Test ensures that flowgraphs utilizing the count operator
 # are not parallelized.
 script: |
-  SUPER_VAM=1 super compile -C -P 2 'from /dev/null | count {row_number,...this} | aggregate sum(x)'
+  SUPER_VAM=1 super compile -C -P 2 'from /dev/null | count {...this,row_number} | aggregate sum(x)'
 
 outputs:
   - name: stdout
     data: |
       file /dev/null unordered
-      | count {row_number,...this}
+      | count {...this,row_number}
       | aggregate
           sum:=sum(x)
       | values sum

--- a/runtime/sam/op/count/count.go
+++ b/runtime/sam/op/count/count.go
@@ -16,10 +16,10 @@ type Op struct {
 func New(sctx *super.Context, parent sbuf.Puller, alias string, in expr.Evaluator) (*Op, error) {
 	o := &Op{parent: parent, alias: alias}
 	var elems []expr.RecordElem
-	elems = append(elems, expr.RecordElem{Name: alias, Field: evalfunc(o.evalCount)})
 	if in != nil {
 		elems = append(elems, expr.RecordElem{Spread: in})
 	}
+	elems = append(elems, expr.RecordElem{Name: alias, Field: evalfunc(o.evalCount)})
 	var err error
 	o.expr, err = expr.NewRecordExpr(sctx, elems)
 	return o, err

--- a/runtime/vam/op/count.go
+++ b/runtime/vam/op/count.go
@@ -17,10 +17,10 @@ type Count struct {
 func NewCount(sctx *super.Context, parent vector.Puller, alias string, in expr.Evaluator) *Count {
 	o := &Count{parent: parent, alias: alias}
 	var elems []expr.RecordElem
-	elems = append(elems, expr.RecordElem{Name: alias, Expr: evalfunc(o.evalCount)})
 	if in != nil {
 		elems = append(elems, expr.RecordElem{Expr: in})
 	}
+	elems = append(elems, expr.RecordElem{Name: alias, Expr: evalfunc(o.evalCount)})
 	o.expr = expr.NewRecordExpr(sctx, elems)
 	return o
 }

--- a/runtime/ztests/op/count.yaml
+++ b/runtime/ztests/op/count.yaml
@@ -1,45 +1,56 @@
 script: |
+  super -s -c 'values {x:1},{x:2} | count'
+  echo // ===
   super -s -c 'values null,null | count {count}'
   echo // ===
-  super -s -c 'values {x:1},{x:2} | count {row_number,...this}'  
+  super -s -c 'values {x:1},{x:2} | count {...this,row_number}'
   echo // ===
-  super -s -c 'values {x:1,y:1},{x:2,y:2} | count {row_number,x}'  
+  super -s -c 'values {x:1,y:1},{x:2,y:2} | count {x,row_number}'  
   echo // ===
-  super -s -c 'values [1,2],[3,4] | unnest this into ( count {c,val:this} )'
-  ! super -s -c 'values null | count {count} | count := count+"hello"'
+  super -s -c 'values [1,2],[3,4] | unnest this into ( count {val:this,c} )'
+  ! super -s -c 'values null | count | count := count+"hello"'
   >&2 echo // ===
-  ! super -s -c 'values {x:"foo"} | count {row,...this} | x := x+1'
+  ! super -s -c 'values {x:"foo"} | count {...this,row} | x := x+1'
   >&2 echo // ===
   ! super -s -c 'values {x:"foo"} | count {...this}'
+  >&2 echo // ===
+  ! super -s -c 'count {foo:"foo",1}'
 
 vector: true
 
 outputs:
   - name: stdout
     data: |
+      {that:{x:1},count:1::uint64}
+      {that:{x:2},count:2::uint64}
+      // ===
       {count:1::uint64}
       {count:2::uint64}
       // ===
-      {row_number:1::uint64,x:1}
-      {row_number:2::uint64,x:2}
+      {x:1,row_number:1::uint64}
+      {x:2,row_number:2::uint64}
       // ===
-      {row_number:1::uint64,x:1}
-      {row_number:2::uint64,x:2}
+      {x:1,row_number:1::uint64}
+      {x:2,row_number:2::uint64}
       // ===
-      {c:1::uint64,val:1}
-      {c:2::uint64,val:2}
-      {c:1::uint64,val:3}
-      {c:2::uint64,val:4}
+      {val:1,c:1::uint64}
+      {val:2,c:2::uint64}
+      {val:3,c:1::uint64}
+      {val:4,c:2::uint64}
   - name: stderr
     data: |
-      type mismatch at line 1, column 40:
-      values null | count {count} | count := count+"hello"
-                                             ~~~~~~~~~~~~~
+      type mismatch at line 1, column 32:
+      values null | count | count := count+"hello"
+                                     ~~~~~~~~~~~~~
       // ===
       type mismatch at line 1, column 47:
-      values {x:"foo"} | count {row,...this} | x := x+1
+      values {x:"foo"} | count {...this,row} | x := x+1
                                                     ~~~
       // ===
-      first element in record expression for count must be an identifier at line 1, column 26:
+      last element in record expression for count must be an identifier at line 1, column 27:
       values {x:"foo"} | count {...this}
-                               ~~~~~~~~~
+                                ~~~~~~~
+      // ===
+      last element in record expression for count must be an identifier at line 1, column 18:
+      count {foo:"foo",1}
+                       ~


### PR DESCRIPTION
This commit reformats the count operator so the record expression is no longer required and the count alias in the record expression is now the last argument.

Closes #6413