### PR TITLE
cli/inputflags: clean up

### DIFF
--- a/cli/inputflags/flags.go
+++ b/cli/inputflags/flags.go
@@ -1,81 +1,52 @@
 package inputflags
 
 import (
-	"context"
 	"errors"
 	"flag"
-	"fmt"
-	"os"
 
-	"github.com/brimdata/super"
 	"github.com/brimdata/super/cli/auto"
-	"github.com/brimdata/super/pkg/storage"
-	"github.com/brimdata/super/sio"
 	"github.com/brimdata/super/sio/anyio"
 	"github.com/brimdata/super/sio/bsupio"
 )
 
 type Flags struct {
-	anyio.ReaderOpts
-	Dynamic  bool
-	ReadMax  auto.Bytes
-	ReadSize auto.Bytes
-	Threads  int
-}
-
-func (f *Flags) Options() anyio.ReaderOpts {
-	return f.ReaderOpts
+	Dynamic      bool
+	ReaderOpts   anyio.ReaderOpts
+	bsupReadMax  auto.Bytes
+	bsupReadSize auto.Bytes
 }
 
 func (f *Flags) SetFlags(fs *flag.FlagSet, validate bool) {
-	fs.StringVar(&f.Format, "i", "auto", "format of input data [auto,arrows,bsup,csup,csv,json,line,parquet,sup,tsv,zeek,jsup]")
-	f.CSV.Delim = ','
+	f.bsupReadMax = auto.NewBytes(bsupio.MaxSize)
+	fs.Var(&f.bsupReadMax, "bsup.readmax", "maximum Super Binary read buffer size in MiB, MB, etc.")
+	f.bsupReadSize = auto.NewBytes(bsupio.ReadSize)
+	fs.Var(&f.bsupReadSize, "bsup.readsize", "target Super Binary read buffer size in MiB, MB, etc.")
+	opts := &f.ReaderOpts
+	fs.IntVar(&opts.BSUP.Threads, "bsup.threads", 0, "number of Super Binary read threads (0=GOMAXPROCS)")
+	fs.BoolVar(&opts.BSUP.Validate, "bsup.validate", validate, "validate format when reading Super Binary")
+	opts.CSV.Delim = ','
 	fs.Func("csv.delim", `CSV field delimiter (default ",")`, func(s string) error {
 		if len(s) != 1 {
 			return errors.New("CSV field delimiter must be exactly one character")
 		}
-		f.CSV.Delim = rune(s[0])
+		opts.CSV.Delim = rune(s[0])
 		return nil
 
 	})
-	fs.IntVar(&f.BSUP.Threads, "bsup.threads", 0, "number of Super Binary read threads (0=GOMAXPROCS)")
-	fs.BoolVar(&f.BSUP.Validate, "bsup.validate", validate, "validate format when reading Super Binary")
-	f.ReadMax = auto.NewBytes(bsupio.MaxSize)
-	fs.Var(&f.ReadMax, "bsup.readmax", "maximum Super Binary read buffer size in MiB, MB, etc.")
-	f.ReadSize = auto.NewBytes(bsupio.ReadSize)
-	fs.Var(&f.ReadSize, "bsup.readsize", "target Super Binary read buffer size in MiB, MB, etc.")
 	fs.BoolVar(&f.Dynamic, "dynamic", false, "disable static type checking of inputs")
+	fs.StringVar(&opts.Format, "i", "auto", "format of input data [auto,arrows,bsup,csup,csv,json,jsup,line,parquet,sup,tsv,zeek]")
 }
 
 // Init is called after flags have been parsed.
 func (f *Flags) Init() error {
-	f.BSUP.Max = int(f.ReadMax.Bytes)
-	if f.BSUP.Max < 0 {
+	bsup := &f.ReaderOpts.BSUP
+	bsup.Max = int(f.bsupReadMax.Bytes)
+	if bsup.Max < 0 {
 		return errors.New("max read buffer size must be greater than zero")
 	}
-	f.BSUP.Size = int(f.ReadSize.Bytes)
-	if f.BSUP.Size < 0 {
+	bsup.Size = int(f.bsupReadSize.Bytes)
+	if bsup.Size < 0 {
 		return errors.New("target read buffer size must be greater than zero")
 	}
 	return nil
-}
-
-func (f *Flags) Open(ctx context.Context, sctx *super.Context, engine storage.Engine, paths []string, stopOnErr bool) ([]sio.Reader, error) {
-	var readers []sio.Reader
-	for _, path := range paths {
-		if path == "-" {
-			path = "stdio:stdin"
-		}
-		file, err := anyio.Open(ctx, sctx, engine, path, f.ReaderOpts)
-		if err != nil {
-			err = fmt.Errorf("%s: %w", path, err)
-			if stopOnErr {
-				return nil, err
-			}
-			fmt.Fprintln(os.Stderr, err)
-			continue
-		}
-		readers = append(readers, file)
-	}
-	return readers, nil
 }

--- a/cmd/super/root/command.go
+++ b/cmd/super/root/command.go
@@ -149,7 +149,7 @@ func (c *Command) Run(args []string) error {
 	env := exec.NewEnvironment(storage.NewLocalEngine(), nil)
 	env.Dynamic = c.inputFlags.Dynamic
 	env.IgnoreOpenErrors = !c.stopErr
-	env.ReaderOpts = c.inputFlags.Options()
+	env.ReaderOpts = c.inputFlags.ReaderOpts
 	comp := compiler.NewCompilerWithEnv(env)
 	query, err := runtime.CompileQuery(ctx, super.NewContext(), comp, ast, nil)
 	if err != nil {

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -523,5 +523,5 @@ func newInputReader(sctx *super.Context, input string, flags []string) (sio.Read
 	if err != nil {
 		return nil, err
 	}
-	return anyio.NewReaderWithOpts(sctx, r, inflags.Options())
+	return anyio.NewReaderWithOpts(sctx, r, inflags.ReaderOpts)
 }


### PR DESCRIPTION
* Move function Open to cmd/super/db/load as method Command.open.

* Unembed Flag.ReaderOpts for clarity when used in other packages.

* Remove method Flags.Options since it simply returns the value of an exported field.

* Unexport fields Flags.BSUPReadMax and BSUPReadSize.

* Remove unused field Flags.Threads.

* Alphabetize Flags.SetFlags by flag name.