### PR TITLE
runtime/vam/expr: move NewArith and NewCompare op param

### DIFF
--- a/compiler/rungen/vexpr.go
+++ b/compiler/rungen/vexpr.go
@@ -102,9 +102,9 @@ func (b *Builder) compileVamBinary(e *dag.BinaryExpr) (vamexpr.Evaluator, error)
 	case "in":
 		return vamexpr.NewIn(b.sctx(), lhs, rhs), nil
 	case "==", "!=", "<", "<=", ">", ">=":
-		return vamexpr.NewCompare(b.sctx(), lhs, rhs, op), nil
+		return vamexpr.NewCompare(b.sctx(), op, lhs, rhs), nil
 	case "+", "-", "*", "/", "%":
-		return vamexpr.NewArith(b.sctx(), lhs, rhs, op), nil
+		return vamexpr.NewArith(b.sctx(), op, lhs, rhs), nil
 	default:
 		return nil, fmt.Errorf("invalid binary operator %s", op)
 	}

--- a/runtime/vam/expr/arith.go
+++ b/runtime/vam/expr/arith.go
@@ -20,7 +20,7 @@ type Arith struct {
 	rhs    Evaluator
 }
 
-func NewArith(sctx *super.Context, lhs, rhs Evaluator, op string) *Arith {
+func NewArith(sctx *super.Context, op string, lhs, rhs Evaluator) *Arith {
 	return &Arith{sctx, vector.ArithOpFromString(op), lhs, rhs}
 }
 

--- a/runtime/vam/expr/arith_test.go
+++ b/runtime/vam/expr/arith_test.go
@@ -35,7 +35,7 @@ func TestArithOpsAndForms(t *testing.T) {
 	for _, c := range cases {
 		f := func(expected []int64, lhs, rhs vector.Any) {
 			t.Helper()
-			cmp := NewArith(super.NewContext(), &testEval{lhs}, &testEval{rhs}, c.op)
+			cmp := NewArith(super.NewContext(), c.op, &testEval{lhs}, &testEval{rhs})
 			assert.Equal(t, expected, cmp.Eval(nil).(*vector.Int).Values, "op: %s", c.op)
 		}
 
@@ -59,7 +59,7 @@ func TestArithOpsAndForms(t *testing.T) {
 		f(c.expectedForConstLHS, Const, rhsView)
 
 		// Arithmetic on two vector.Consts returns another vector.Const.
-		cmp := NewArith(super.NewContext(), &testEval{Const}, &testEval{Const}, c.op)
+		cmp := NewArith(super.NewContext(), c.op, &testEval{Const}, &testEval{Const})
 		val := cmp.Eval(nil).(*vector.Const)
 		assert.Equal(t, uint32(3), val.Len(), "op: %s", c.op)
 		expected := super.NewInt64(c.expectedForConstLHS[0])

--- a/runtime/vam/expr/compare.go
+++ b/runtime/vam/expr/compare.go
@@ -19,7 +19,7 @@ type Compare struct {
 	rhs    Evaluator
 }
 
-func NewCompare(sctx *super.Context, lhs, rhs Evaluator, op string) *Compare {
+func NewCompare(sctx *super.Context, op string, lhs, rhs Evaluator) *Compare {
 	return &Compare{sctx, vector.CompareOpFromString(op), lhs, rhs}
 }
 

--- a/runtime/vam/expr/compare_test.go
+++ b/runtime/vam/expr/compare_test.go
@@ -43,7 +43,7 @@ func TestCompareOpsAndForms(t *testing.T) {
 	for _, c := range cases {
 		f := func(expected string, lhs, rhs vector.Any) {
 			t.Helper()
-			cmp := NewCompare(super.NewContext(), &testEval{lhs}, &testEval{rhs}, c.op)
+			cmp := NewCompare(super.NewContext(), c.op, &testEval{lhs}, &testEval{rhs})
 			assert.Equal(t, expected, cmp.Eval(nil).(*vector.Bool).Bits.String(), "op: %s", c.op)
 		}
 
@@ -67,11 +67,10 @@ func TestCompareOpsAndForms(t *testing.T) {
 		f(c.expectedForConstLHS, Const, rhsView)
 
 		// Comparing two vector.Consts yields another vector.Const.
-		cmp := NewCompare(super.NewContext(), &testEval{Const}, &testEval{Const}, c.op)
+		cmp := NewCompare(super.NewContext(), c.op, &testEval{Const}, &testEval{Const})
 		val := cmp.Eval(nil).(*vector.Const)
 		assert.Equal(t, uint32(3), val.Len(), "op: %s", c.op)
 		expected := super.NewBool(c.expectedForConstLHS == "111")
 		assert.Equal(t, expected, val.Value(), "op: %s", c.op)
 	}
-
 }

--- a/runtime/vam/expr/logic.go
+++ b/runtime/vam/expr/logic.go
@@ -198,7 +198,7 @@ type In struct {
 }
 
 func NewIn(sctx *super.Context, lhs, rhs Evaluator) *In {
-	return &In{sctx, lhs, rhs, NewPredicateWalk(NewCompare(sctx, nil, nil, "==").eval)}
+	return &In{sctx, lhs, rhs, NewPredicateWalk(NewCompare(sctx, "==", nil, nil).eval)}
 }
 
 func (i *In) Eval(this vector.Any) vector.Any {

--- a/runtime/vam/expr/search.go
+++ b/runtime/vam/expr/search.go
@@ -27,7 +27,7 @@ func NewSearch(s string, val super.Value, e Evaluator) Evaluator {
 	if val.Type().ID() == super.IDNet {
 		net = super.DecodeNet(val.Bytes())
 	}
-	eq := NewCompare(super.NewContext() /* XXX */, nil, nil, "==")
+	eq := NewCompare(super.NewContext() /* XXX */, "==", nil, nil)
 	vectorPred := func(vec vector.Any) vector.Any {
 		if net.IsValid() && vector.KindOf(vec) == vector.KindIP {
 			out := vector.NewFalse(vec.Len())


### PR DESCRIPTION
The op param follows the lhs and rhs params, which feels odd.  Move op ahead of lhs and rhs.