### PR TITLE
runtime/sam/expr: move NewArithmetic op param

### DIFF
--- a/compiler/rungen/expr.go
+++ b/compiler/rungen/expr.go
@@ -125,7 +125,7 @@ func (b *Builder) compileBinary(e *dag.BinaryExpr) (expr.Evaluator, error) {
 	case "<", "<=", ">", ">=":
 		return expr.NewCompareRelative(b.sctx(), lhs, rhs, op)
 	case "+", "-", "*", "/", "%":
-		return expr.NewArithmetic(b.sctx(), lhs, rhs, op)
+		return expr.NewArithmetic(b.sctx(), op, lhs, rhs)
 	default:
 		return nil, fmt.Errorf("invalid binary operator %s", op)
 	}

--- a/runtime/sam/expr/eval.go
+++ b/runtime/sam/expr/eval.go
@@ -428,7 +428,7 @@ var DivideByZero = errors.New("divide by zero")
 
 // NewArithmetic compiles an expression of the form "expr1 op expr2"
 // for the arithmetic operators +, -, *, /
-func NewArithmetic(sctx *super.Context, lhs, rhs Evaluator, op string) (Evaluator, error) {
+func NewArithmetic(sctx *super.Context, op string, lhs, rhs Evaluator) (Evaluator, error) {
 	n := newNumeric(sctx, lhs, rhs)
 	switch op {
 	case "+":


### PR DESCRIPTION
The op param follows the lhs and rhs params, which feels odd.  Move op ahead of lhs and rhs.