### PR TITLE
add -noheader flag to super command

### DIFF
--- a/cli/outputflags/flags.go
+++ b/cli/outputflags/flags.go
@@ -26,6 +26,7 @@ type Flags struct {
 	forceBinary   bool
 	jsonPretty    bool
 	jsonShortcut  bool
+	noHeader      bool
 	outputFile    string
 	pretty        int
 	split         string
@@ -46,6 +47,7 @@ func (f *Flags) setFlags(fs *flag.FlagSet) {
 	fs.IntVar(&f.BSUP.FrameThresh, "bsup.framethresh", bsupio.DefaultFrameThresh,
 		"minimum Super Binary frame size in uncompressed bytes")
 	fs.BoolVar(&f.color, "color", true, "enable/disable color formatting for -S and db text output")
+	fs.BoolVar(&f.CSV.NoHeader, "noheader", false, "omit header for CSV and TSV output")
 	fs.StringVar(&f.supPersist, "persist", "",
 		"regular expression to persist type definitions across the stream")
 	fs.IntVar(&f.pretty, "pretty", 2,

--- a/sio/csvio/ztests/noheader.yaml
+++ b/sio/csvio/ztests/noheader.yaml
@@ -1,0 +1,11 @@
+spq: pass
+
+input: |
+  {a:1,b:2}
+  {a:"one",b:"two"}
+
+output-flags: -f csv -noheader
+
+output: |
+  1,2
+  one,two


### PR DESCRIPTION
When true, it omits the header for CSV and TSV output.

Closes #6381.