### PR TITLE
semantic: simplify keySubst

### DIFF
--- a/compiler/semantic/projection.go
+++ b/compiler/semantic/projection.go
@@ -73,209 +73,131 @@ func (a aggfuncs) tmp() string {
 }
 
 func (a *aggfuncs) subst(e sem.Expr) sem.Expr {
+	return exprWalk(e, func(e sem.Expr) (sem.Expr, bool) {
+		switch e := e.(type) {
+		case *sem.AggFunc:
+			// swap in a temp column for each agg function found, which
+			// will then be referred to by the containing expression.
+			// The agg function is computed into the tmp value with
+			// the generated aggregate operator.
+			tmp := a.tmp()
+			*a = append(*a, namedAgg{name: tmp, agg: e})
+			return sem.NewThis(e, []string{"in", tmp}), true
+		default:
+			return e, false
+		}
+	})
+}
+
+func keySubst(e sem.Expr, exprs []exprloc) (sem.Expr, bool) {
+	ok := true
+	e = exprWalk(e, func(e sem.Expr) (sem.Expr, bool) {
+		if i := exprMatch(e, exprs); i >= 0 {
+			return sem.NewThis(e, []string{"in", fmt.Sprintf("k%d", i)}), true
+		}
+		switch e := e.(type) {
+		case *sem.ThisExpr:
+			ok = false
+		case *sem.AggFunc:
+			// This should't happen.
+			panic(e)
+		}
+		return e, false
+	})
+	return e, ok
+}
+
+type exprVisitor func(e sem.Expr) (sem.Expr, bool)
+
+func exprWalk(e sem.Expr, visit exprVisitor) sem.Expr {
+	var stop bool
+	if e, stop = visit(e); stop {
+		return e
+	}
 	switch e := e.(type) {
 	case nil:
-		return e
 	case *sem.AggFunc:
-		// swap in a temp column for each agg function found, which
-		// will then be referred to by the containing expression.
-		// The agg function is computed into the tmp value with
-		// the generated aggregate operator.
-		tmp := a.tmp()
-		*a = append(*a, namedAgg{name: tmp, agg: e})
-		return sem.NewThis(e, []string{"in", tmp})
+		e.Expr = exprWalk(e, visit)
+		e.Where = exprWalk(e, visit)
 	case *sem.ArrayExpr:
-		e.Elems = a.substArrayElems(e.Elems)
+		e.Elems = exprWalkArrayElems(e.Elems, visit)
 	case *sem.BadExpr:
 	case *sem.BinaryExpr:
-		e.LHS = a.subst(e.LHS)
-		e.RHS = a.subst(e.RHS)
+		e.LHS = exprWalk(e.LHS, visit)
+		e.RHS = exprWalk(e.RHS, visit)
 	case *sem.CallExpr:
-		for k, arg := range e.Args {
-			e.Args[k] = a.subst(arg)
+		var out []sem.Expr
+		for _, arg := range e.Args {
+			out = append(out, exprWalk(arg, visit))
 		}
+		e.Args = out
 	case *sem.CondExpr:
-		e.Cond = a.subst(e.Cond)
-		e.Then = a.subst(e.Then)
-		e.Else = a.subst(e.Else)
+		e.Cond = exprWalk(e.Cond, visit)
+		e.Then = exprWalk(e.Then, visit)
+		e.Else = exprWalk(e.Else, visit)
 	case *sem.DotExpr:
-		e.LHS = a.subst(e.LHS)
+		e.LHS = exprWalk(e.LHS, visit)
 	case *sem.IndexExpr:
-		e.Expr = a.subst(e.Expr)
-		e.Index = a.subst(e.Index)
+		e.Expr = exprWalk(e.Expr, visit)
+		e.Index = exprWalk(e.Index, visit)
 	case *sem.IsNullExpr:
-		e.Expr = a.subst(e.Expr)
+		e.Expr = exprWalk(e.Expr, visit)
 	case *sem.LiteralExpr:
 	case *sem.MapExpr:
 		for _, ent := range e.Entries {
-			ent.Key = a.subst(ent.Key)
-			ent.Value = a.subst(ent.Value)
+			ent.Key = exprWalk(ent.Key, visit)
+			ent.Value = exprWalk(ent.Value, visit)
 		}
 	case *sem.RecordExpr:
-		var elems []sem.RecordElem
+		var out []sem.RecordElem
 		for _, elem := range e.Elems {
 			switch elem := elem.(type) {
 			case *sem.FieldElem:
-				sub := a.subst(elem.Value)
-				elems = append(elems, &sem.FieldElem{Node: elem, Name: elem.Name, Value: sub})
+				e := exprWalk(elem.Value, visit)
+				out = append(out, &sem.FieldElem{Node: elem, Name: elem.Name, Value: e})
 			case *sem.SpreadElem:
-				elems = append(elems, &sem.SpreadElem{Node: elem, Expr: a.subst(elem.Expr)})
+				e := exprWalk(elem.Expr, visit)
+				out = append(out, &sem.SpreadElem{Node: elem, Expr: e})
 			default:
 				panic(elem)
 			}
 		}
-		e.Elems = elems
+		e.Elems = out
 	case *sem.RegexpMatchExpr:
-		e.Expr = a.subst(e.Expr)
+		e.Expr = exprWalk(e.Expr, visit)
 	case *sem.RegexpSearchExpr:
-		e.Expr = a.subst(e.Expr)
+		e.Expr = exprWalk(e.Expr, visit)
 	case *sem.SearchTermExpr:
-		e.Expr = a.subst(e.Expr)
+		e.Expr = exprWalk(e.Expr, visit)
 	case *sem.SetExpr:
-		e.Elems = a.substArrayElems(e.Elems)
+		e.Elems = exprWalkArrayElems(e.Elems, visit)
 	case *sem.SliceExpr:
-		e.Expr = a.subst(e.Expr)
-		e.From = a.subst(e.From)
-		e.To = a.subst(e.To)
+		e.Expr = exprWalk(e.Expr, visit)
+		e.From = exprWalk(e.From, visit)
+		e.To = exprWalk(e.To, visit)
+	case *sem.SubqueryExpr: // XXX This might need to be traversed?
 	case *sem.ThisExpr:
 	case *sem.UnaryExpr:
-		e.Operand = a.subst(e.Operand)
+		e.Operand = exprWalk(e.Operand, visit)
+	default:
+		panic(e)
 	}
 	return e
 }
 
-func (a *aggfuncs) substArrayElems(elems []sem.ArrayElem) []sem.ArrayElem {
-	var out []sem.ArrayElem
-	for _, e := range elems {
-		switch e := e.(type) {
-		case *sem.SpreadElem:
-			out = append(out, &sem.SpreadElem{Node: e, Expr: a.subst(e.Expr)})
-		case *sem.ExprElem:
-			out = append(out, &sem.ExprElem{Node: e, Expr: a.subst(e.Expr)})
-		default:
-			panic(e)
-		}
-	}
-	return out
-}
-
-func keySubst(e sem.Expr, exprs []exprloc) (sem.Expr, bool) {
-	if i := exprMatch(e, exprs); i >= 0 {
-		return sem.NewThis(e, []string{"in", fmt.Sprintf("k%d", i)}), true
-	}
-	ok := true
-	switch e := e.(type) {
-	case nil:
-	case *sem.AggFunc:
-		// This shouldn't happen.
-		panic(e)
-	case *sem.ArrayExpr:
-		e.Elems, ok = keySubstArrayElems(e.Elems, exprs)
-	case *sem.BadExpr:
-	case *sem.BinaryExpr:
-		if e.LHS, ok = keySubst(e.LHS, exprs); ok {
-			e.RHS, ok = keySubst(e.RHS, exprs)
-		}
-	case *sem.CallExpr:
-		var args []sem.Expr
-		for _, arg := range e.Args {
-			if arg, ok = keySubst(arg, exprs); !ok {
-				return nil, false
-			}
-			args = append(args, arg)
-		}
-		e.Args = args
-	case *sem.CondExpr:
-		var ok1, ok2, ok3 bool
-		e.Cond, ok1 = keySubst(e.Cond, exprs)
-		e.Then, ok2 = keySubst(e.Then, exprs)
-		e.Else, ok3 = keySubst(e.Else, exprs)
-		ok = ok1 && ok2 && ok3
-	case *sem.DotExpr:
-		e.LHS, ok = keySubst(e.LHS, exprs)
-	case *sem.IndexExpr:
-		if e.Expr, ok = keySubst(e.Expr, exprs); ok {
-			e.Index, ok = keySubst(e.Index, exprs)
-		}
-	case *sem.IsNullExpr:
-		e.Expr, ok = keySubst(e.Expr, exprs)
-	case *sem.LiteralExpr:
-	case *sem.MapExpr:
-		for _, ent := range e.Entries {
-			if ent.Key, ok = keySubst(ent.Key, exprs); !ok {
-				break
-			}
-			if ent.Value, ok = keySubst(ent.Value, exprs); !ok {
-				break
-			}
-		}
-	case *sem.RecordExpr:
-		var elems []sem.RecordElem
-		for _, elem := range e.Elems {
-			switch elem := elem.(type) {
-			case *sem.FieldElem:
-				e, ok := keySubst(elem.Value, exprs)
-				if !ok {
-					return nil, false
-				}
-				elems = append(elems, &sem.FieldElem{Node: elem, Name: elem.Name, Value: e})
-			case *sem.SpreadElem:
-				e, ok := keySubst(elem.Expr, exprs)
-				if !ok {
-					return nil, false
-				}
-				elems = append(elems, &sem.SpreadElem{Node: elem, Expr: e})
-			default:
-				panic(elem)
-			}
-		}
-		e.Elems = elems
-	case *sem.RegexpMatchExpr:
-		e.Expr, ok = keySubst(e.Expr, exprs)
-	case *sem.RegexpSearchExpr:
-		e.Expr, ok = keySubst(e.Expr, exprs)
-	case *sem.SearchTermExpr:
-		e.Expr, ok = keySubst(e.Expr, exprs)
-	case *sem.SetExpr:
-		e.Elems, ok = keySubstArrayElems(e.Elems, exprs)
-	case *sem.SliceExpr:
-		var ok1, ok2, ok3 bool
-		e.Expr, ok1 = keySubst(e.Expr, exprs)
-		e.From, ok2 = keySubst(e.From, exprs)
-		e.To, ok3 = keySubst(e.To, exprs)
-		ok = ok1 && ok2 && ok3
-	case *sem.SubqueryExpr: // XXX This might need to be traversed?
-	case *sem.ThisExpr:
-		// If we've gotten here it means we have a portion of e that does
-		// not exist in exprs so we are in an error state.
-		return nil, false
-	case *sem.UnaryExpr:
-		e.Operand, ok = keySubst(e.Operand, exprs)
-	default:
-		panic(e)
-	}
-	return e, ok
-}
-
-func keySubstArrayElems(elems []sem.ArrayElem, exprs []exprloc) ([]sem.ArrayElem, bool) {
+func exprWalkArrayElems(elems []sem.ArrayElem, visit exprVisitor) []sem.ArrayElem {
 	var out []sem.ArrayElem
 	for _, elem := range elems {
 		switch elem := elem.(type) {
 		case *sem.SpreadElem:
-			e, ok := keySubst(elem.Expr, exprs)
-			if !ok {
-				return nil, false
-			}
-			out = append(out, &sem.SpreadElem{Node: elem, Expr: e})
+			e := exprWalk(elem.Expr, visit)
+			out = append(out, &sem.SpreadElem{Node: elem.Node, Expr: e})
 		case *sem.ExprElem:
-			e, ok := keySubst(elem.Expr, exprs)
-			if !ok {
-				return nil, false
-			}
-			out = append(out, &sem.ExprElem{Node: elem, Expr: e})
+			e := exprWalk(elem.Expr, visit)
+			out = append(out, &sem.ExprElem{Node: elem.Node, Expr: e})
 		default:
 			panic(elem)
 		}
 	}
-	return out, true
+	return out
 }


### PR DESCRIPTION
Simplify substitution for aggregates and keys by using walkExpr.