### PR TITLE
aggSchema

### DIFF
--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -159,7 +159,7 @@ func (t *translator) fromCTE(node ast.Node, c *ast.SQLCTE) (sem.Seq, schema) {
 		return sem.Seq{badOp()}, badSchema()
 	}
 	t.cteStack = append(t.cteStack, c)
-	seq, sch := t.sqlQueryBody(c.Body, nil)
+	seq, sch := t.sqlQueryBody(c.Body, nil, nil)
 	// Add the CTE name as the alias.  If there is an actual alias, it will
 	// override this.
 	sch = addAlias(sch, c.Name.Name)
@@ -569,7 +569,7 @@ func (t *translator) scopeOp(op *ast.ScopeOp) sem.Seq {
 func (t *translator) semOp(o ast.Op, seq sem.Seq) sem.Seq {
 	switch o := o.(type) {
 	case *ast.SQLOp:
-		seq, sch := t.sqlQueryBody(o.Body, seq)
+		seq, sch := t.sqlQueryBody(o.Body, seq, nil)
 		return unfurl(o, sch, seq)
 	case *ast.FileScan:
 		format := t.env.ReaderOpts.Format

--- a/compiler/semantic/projection.go
+++ b/compiler/semantic/projection.go
@@ -89,7 +89,7 @@ func (a *aggfuncs) subst(e sem.Expr) sem.Expr {
 	})
 }
 
-func keySubst(e sem.Expr, exprs []exprloc) (sem.Expr, bool) {
+func keySubst(e sem.Expr, exprs []sem.Expr) (sem.Expr, bool) {
 	ok := true
 	e = exprWalk(e, func(e sem.Expr) (sem.Expr, bool) {
 		if i := exprMatch(e, exprs); i >= 0 {

--- a/compiler/semantic/schema.go
+++ b/compiler/semantic/schema.go
@@ -26,6 +26,14 @@ type schema interface {
 }
 
 type (
+	aggSchema struct {
+		schema
+		aggs       []sem.Expr
+		aggAliases []string
+		keys       []sem.Expr
+		keyAliases []sem.Expr
+	}
+
 	aliasSchema struct {
 		name string
 		sch  schema
@@ -524,6 +532,10 @@ func (s *subquerySchema) outColumns() ([]string, bool) {
 	return s.outer.outColumns()
 }
 
+func (a *aggSchema) String() string {
+	return fmt.Sprintf("agg: %s", a.schema)
+}
+
 func (a *aliasSchema) String() string {
 	return fmt.Sprintf("alias <%s>", a.name)
 }
@@ -555,7 +567,7 @@ func addAlias(sch schema, alias string) schema {
 			name: alias,
 			sch:  sch.sch,
 		}
-	case *dynamicSchema, *selectSchema, *staticSchema:
+	case *aggSchema, *dynamicSchema, *selectSchema, *staticSchema:
 		return &aliasSchema{
 			name: alias,
 			sch:  sch,

--- a/compiler/ztests/sql/order-by-group-by-agg.yaml
+++ b/compiler/ztests/sql/order-by-group-by-agg.yaml
@@ -1,0 +1,26 @@
+spq: |
+  select a
+  from (values (1,2), (2,1)) as T(a,b)
+  group by a
+  order by sum(b)
+output: |
+  {a:2}
+  {a:1}
+---
+spq: |
+  select count() as c
+  from (values (4)) T(id)
+  group by id
+  order by c
+output: |
+  {c:1::uint64}
+---
+# we got to disable this test in a future pr we'll handle this kind of query.
+# skip: "agg aliases"
+spq: |
+  select count() as c
+  from (values (4)) T(id)
+  group by id
+  order by c+max(id)
+output: |
+  {c:1::uint64}

--- a/compiler/ztests/sql/order-by-group-by-key.yaml
+++ b/compiler/ztests/sql/order-by-group-by-key.yaml
@@ -1,0 +1,32 @@
+spq: |
+  select T.id
+  from (values (1,'yyy'), (2,'aaa')) T(id,foo)
+  inner join (values (1,'zzz'),(2,'aaa')) J(id,bar) on T.id = J.id
+  group by T.id, foo || bar
+  order by T.foo || J.bar
+
+output: |
+  {id:2}
+  {id:1}
+
+---
+spq: |
+  select a+b x
+  from ( values (1,2,3)) T(a,b,c)
+  group by x
+  order by T.a+T.b
+
+output: |
+  {x:3}
+
+---
+spq: |
+  select T.id
+  from (values (1), (2)) T(id)
+  inner join (values (1,'zzz'),(2,'aaa')) J(id,bar) on T.id = J.id
+  group by T.id,bar
+  order by J.bar
+
+output: |
+  {id:2}
+  {id:1}


### PR DESCRIPTION
This commit adjusts the behavior of order by on group by clauses so that order by can sort by aggregation functions and aggregation keys that are not located in the select clause.