### PR TITLE
change count operator output field to int64

### DIFF
--- a/book/src/super-sql/operators/count.md
+++ b/book/src/super-sql/operators/count.md
@@ -35,8 +35,8 @@ count
 {foo:"bar",a:true}
 {foo:"baz",b:false}
 # expected output
-{that:{foo:"bar",a:true},count:1::uint64}
-{that:{foo:"baz",b:false},count:2::uint64}
+{that:{foo:"bar",a:true},count:1}
+{that:{foo:"baz",b:false},count:2}
 ```
 
 ---
@@ -50,9 +50,9 @@ count {c}
 "b"
 "c"
 # expected output
-{c:1::uint64}
-{c:2::uint64}
-{c:3::uint64}
+{c:1}
+{c:2}
+{c:3}
 ```
 
 ---
@@ -65,8 +65,8 @@ count {...this,c}
 {foo:"bar",a:true}
 {foo:"baz",b:false}
 # expected output
-{foo:"bar",a:true,c:1::uint64}
-{foo:"baz",b:false,c:2::uint64}
+{foo:"bar",a:true,c:1}
+{foo:"baz",b:false,c:2}
 ```
 
 ---
@@ -79,6 +79,6 @@ count {third_foo_char:foo[2:3],c}
 {foo:"bar",a:true}
 {foo:"baz",b:false}
 # expected output
-{third_foo_char:"r",c:1::uint64}
-{third_foo_char:"z",c:2::uint64}
+{third_foo_char:"r",c:1}
+{third_foo_char:"z",c:2}
 ```

--- a/runtime/sam/op/count/count.go
+++ b/runtime/sam/op/count/count.go
@@ -10,7 +10,7 @@ type Op struct {
 	parent sbuf.Puller
 	alias  string
 	expr   expr.Evaluator
-	count  uint64
+	count  int64
 }
 
 func New(sctx *super.Context, parent sbuf.Puller, alias string, in expr.Evaluator) (*Op, error) {
@@ -44,5 +44,5 @@ func (e evalfunc) Eval(this super.Value) super.Value { return e(this) }
 
 func (o *Op) evalCount(_ super.Value) super.Value {
 	o.count++
-	return super.NewUint64(o.count)
+	return super.NewInt64(o.count)
 }

--- a/runtime/vam/op/count.go
+++ b/runtime/vam/op/count.go
@@ -11,7 +11,7 @@ type Count struct {
 	parent vector.Puller
 	alias  string
 	expr   expr.Evaluator
-	count  uint64
+	count  int64
 }
 
 func NewCount(sctx *super.Context, parent vector.Puller, alias string, in expr.Evaluator) *Count {
@@ -39,10 +39,10 @@ type evalfunc func(vector.Any) vector.Any
 func (e evalfunc) Eval(this vector.Any) vector.Any { return e(this) }
 
 func (o *Count) evalCount(in vector.Any) vector.Any {
-	counts := make([]uint64, in.Len())
+	counts := make([]int64, in.Len())
 	for i := range in.Len() {
 		o.count++
 		counts[i] = o.count
 	}
-	return vector.NewUint(super.TypeUint64, counts, bitvec.Zero)
+	return vector.NewInt(super.TypeInt64, counts, bitvec.Zero)
 }

--- a/runtime/ztests/op/count.yaml
+++ b/runtime/ztests/op/count.yaml
@@ -21,22 +21,22 @@ vector: true
 outputs:
   - name: stdout
     data: |
-      {that:{x:1},count:1::uint64}
-      {that:{x:2},count:2::uint64}
+      {that:{x:1},count:1}
+      {that:{x:2},count:2}
       // ===
-      {count:1::uint64}
-      {count:2::uint64}
+      {count:1}
+      {count:2}
       // ===
-      {x:1,row_number:1::uint64}
-      {x:2,row_number:2::uint64}
+      {x:1,row_number:1}
+      {x:2,row_number:2}
       // ===
-      {x:1,row_number:1::uint64}
-      {x:2,row_number:2::uint64}
+      {x:1,row_number:1}
+      {x:2,row_number:2}
       // ===
-      {val:1,c:1::uint64}
-      {val:2,c:2::uint64}
-      {val:3,c:1::uint64}
-      {val:4,c:2::uint64}
+      {val:1,c:1}
+      {val:2,c:2}
+      {val:3,c:1}
+      {val:4,c:2}
   - name: stderr
     data: |
       type mismatch at line 1, column 32:


### PR DESCRIPTION
The count operator produces output records containing the count value in a uint64 field.  Change the field's type to int64.

Fixes #6446