### PR TITLE
fix panic in TestSPQ on malformed ztest YAML

### DIFF
--- a/spq_test.go
+++ b/spq_test.go
@@ -73,6 +73,9 @@ func loadZTestInputsAndOutputs(ztestDirs map[string]struct{}) (map[string]string
 			return nil, err
 		}
 		for _, b := range bundles {
+			if b.Test == nil {
+				continue
+			}
 			if i := b.Test.Input; i != nil && isValid(*i) {
 				out[b.FileName+"/input"] = *i
 			}


### PR DESCRIPTION
When ztest.Load encounters a malformed YAML file, it creates a ztest.Bundle with a nil Test field (and non-nil Error field).  Skip these bundles in loadZTestInputsAndOutputs (called from TestSPQ) to avoid dereferencing a nil ztest.