### PR TITLE
change uniq operator count field type to int64

### DIFF
--- a/book/src/super-sql/operators/uniq.md
+++ b/book/src/super-sql/operators/uniq.md
@@ -17,7 +17,7 @@ This operator is most often used with [`cut`](cut.md) and [`sort`](sort.md) to f
 duplicate values.
 
 When run with the `-c` option, each value is output as a record with the
-type signature `{value:any,count:uint64}`, where the `value` field contains the
+type signature `{value:any,count:int64}`, where the `value` field contains the
 unique value and the `count` field indicates the number of consecutive duplicates
 that occurred in the input for that output value.
 
@@ -52,9 +52,9 @@ uniq -c
 2
 3
 # expected output
-{value:1,count:1::uint64}
-{value:2,count:2::uint64}
-{value:3,count:1::uint64}
+{value:1,count:1}
+{value:2,count:2}
+{value:3,count:1}
 ```
 
 ---

--- a/runtime/sam/op/uniq/uniq.go
+++ b/runtime/sam/op/uniq/uniq.go
@@ -14,7 +14,7 @@ type Op struct {
 	parent  sbuf.Puller
 	builder scode.Builder
 	cflag   bool
-	count   uint64
+	count   int64
 	last    *super.Value
 	eos     bool
 }
@@ -31,10 +31,10 @@ func (o *Op) wrap(t *super.Value) super.Value {
 	if o.cflag {
 		o.builder.Reset()
 		o.builder.Append(t.Bytes())
-		o.builder.Append(super.EncodeUint(o.count))
+		o.builder.Append(super.EncodeInt(o.count))
 		typ := o.rctx.Sctx.MustLookupTypeRecord([]super.Field{
 			super.NewField("value", t.Type()),
-			super.NewField("count", super.TypeUint64),
+			super.NewField("count", super.TypeInt64),
 		})
 		return super.NewValue(typ, o.builder.Bytes()).Copy()
 	}

--- a/runtime/ztests/op/uniq.yaml
+++ b/runtime/ztests/op/uniq.yaml
@@ -8,5 +8,5 @@ input: |
   {x:1}
 
 output: |
-  {value:1,count:2::uint64}
-  {value:{x:1},count:1::uint64}
+  {value:1,count:2}
+  {value:{x:1},count:1}


### PR DESCRIPTION
With the -c flag, the uniq operator produces records with a uint64 field named count.  Change the field type to int64.

Closes #6446