### PR TITLE
vector: report const as null if base value is null

### DIFF
--- a/runtime/ztests/expr/arith-divide-by-zero.yaml
+++ b/runtime/ztests/expr/arith-divide-by-zero.yaml
@@ -1,3 +1,4 @@
+# XXX This file should test floats but #6474 needs to be fixed first.
 spq: values a/b, a%b
 
 vector: true
@@ -14,3 +15,17 @@ output: |
   null::uint64
   error("divide by zero")
   error("divide by zero")
+
+---
+
+# Check the divide by zero logic on a const null returns a null.
+spq: |
+  values 
+    1/null::int64,
+    1::uint64/null::uint64
+
+vector: true
+
+output: |
+  null::int64
+  null::uint64

--- a/vector/bool.go
+++ b/vector/bool.go
@@ -81,7 +81,7 @@ func BoolValue(vec Any, slot uint32) (bool, bool) {
 	case *Bool:
 		return vec.Bits.IsSet(slot), vec.Nulls.IsSet(slot)
 	case *Const:
-		return vec.Value().Ptr().AsBool(), vec.Nulls.IsSet(slot)
+		return vec.Value().Ptr().AsBool(), vec.val.IsNull() || vec.Nulls.IsSet(slot)
 	case *Dict:
 		if vec.Nulls.IsSet(slot) {
 			return false, true

--- a/vector/bytes.go
+++ b/vector/bytes.go
@@ -58,7 +58,7 @@ func BytesValue(val Any, slot uint32) ([]byte, bool) {
 			return nil, true
 		}
 		s, _ := val.AsBytes()
-		return s, false
+		return s, val.val.IsNull()
 	case *Dict:
 		if val.Nulls.IsSet(slot) {
 			return nil, true

--- a/vector/float.go
+++ b/vector/float.go
@@ -60,7 +60,7 @@ func FloatValue(vec Any, slot uint32) (float64, bool) {
 	case *Float:
 		return vec.Value(slot), vec.Nulls.IsSet(slot)
 	case *Const:
-		return vec.Value().Ptr().Float(), vec.Nulls.IsSet(slot)
+		return vec.Value().Ptr().Float(), vec.val.IsNull() || vec.Nulls.IsSet(slot)
 	case *Dict:
 		if vec.Nulls.IsSet(slot) {
 			return 0, true

--- a/vector/int.go
+++ b/vector/int.go
@@ -56,7 +56,7 @@ func IntValue(vec Any, slot uint32) (int64, bool) {
 	case *Int:
 		return vec.Value(slot), vec.Nulls.IsSet(slot)
 	case *Const:
-		return vec.val.Int(), vec.Nulls.IsSet(slot)
+		return vec.val.Int(), vec.val.IsNull() || vec.Nulls.IsSet(slot)
 	case *Dict:
 		if vec.Nulls.IsSet(slot) {
 			return 0, true

--- a/vector/ip.go
+++ b/vector/ip.go
@@ -44,7 +44,7 @@ func IPValue(val Any, slot uint32) (netip.Addr, bool) {
 			return netip.Addr{}, true
 		}
 		b, _ := val.AsBytes()
-		return super.DecodeIP(b), false
+		return super.DecodeIP(b), val.val.IsNull()
 	case *Dict:
 		if val.Nulls.IsSet(slot) {
 			return netip.Addr{}, true

--- a/vector/net.go
+++ b/vector/net.go
@@ -44,7 +44,7 @@ func NetValue(val Any, slot uint32) (netip.Prefix, bool) {
 			return netip.Prefix{}, true
 		}
 		s, _ := val.AsBytes()
-		return super.DecodeNet(s), false
+		return super.DecodeNet(s), val.val.IsNull()
 	case *Dict:
 		if val.Nulls.IsSet(slot) {
 			return netip.Prefix{}, true

--- a/vector/string.go
+++ b/vector/string.go
@@ -61,7 +61,7 @@ func StringValue(val Any, slot uint32) (string, bool) {
 			return "", true
 		}
 		s, _ := val.AsString()
-		return s, false
+		return s, val.val.IsNull()
 	case *Dict:
 		if val.Nulls.IsSet(slot) {
 			return "", true

--- a/vector/type.go
+++ b/vector/type.go
@@ -58,7 +58,7 @@ func TypeValueValue(val Any, slot uint32) ([]byte, bool) {
 			return nil, true
 		}
 		s, _ := val.AsBytes()
-		return s, false
+		return s, val.val.IsNull()
 	case *Dict:
 		if val.Nulls.IsSet(slot) {
 			return nil, true

--- a/vector/uint.go
+++ b/vector/uint.go
@@ -56,7 +56,7 @@ func UintValue(vec Any, slot uint32) (uint64, bool) {
 	case *Uint:
 		return vec.Value(slot), vec.Nulls.IsSet(slot)
 	case *Const:
-		return vec.Value().Ptr().Uint(), vec.Nulls.IsSet(slot)
+		return vec.Value().Ptr().Uint(), vec.val.IsNull() || vec.Nulls.IsSet(slot)
 	case *Dict:
 		if vec.Nulls.IsSet(slot) {
 			return 0, true


### PR DESCRIPTION
When getting the value of a primitive const at a given slot, report the value as null if the base value is null.