### PR TITLE
fix: add separator between tables in table output

### DIFF
--- a/sio/tableio/writer.go
+++ b/sio/tableio/writer.go
@@ -43,6 +43,7 @@ func (w *Writer) Write(r super.Value) error {
 	if r.Type() != w.typ {
 		if w.typ != nil {
 			w.flush()
+			w.writer.Write([]byte("---\n"))
 			w.nline = 0
 		}
 		// First time, or new descriptor, print header

--- a/sio/tableio/ztests/multiple-types.yaml
+++ b/sio/tableio/ztests/multiple-types.yaml
@@ -1,0 +1,14 @@
+spq: pass
+
+input: |
+  {s:"foo",val:1}
+  {s:"bar"}
+
+output-flags: -f table
+
+output: |
+  s   val
+  foo 1
+  ---
+  s
+  bar


### PR DESCRIPTION
Fixes #4023

## Changes
- Add `---` separator between tables when record type changes
- Add test for multiple types in table output