### PR TITLE
sio/anyio: don't wrap Parquet reader with sio.ReadCloser

### DIFF
--- a/sio/anyio/lookup.go
+++ b/sio/anyio/lookup.go
@@ -37,11 +37,7 @@ func lookupReader(sctx *super.Context, r io.Reader, opts ReaderOpts) (sio.ReadCl
 	case "json":
 		return sio.NopReadCloser(jsonio.NewReader(sctx, r)), nil
 	case "parquet":
-		zr, err := parquetio.NewReader(sctx, r, opts.Fields)
-		if err != nil {
-			return nil, err
-		}
-		return sio.NopReadCloser(zr), nil
+		return parquetio.NewReader(sctx, r, opts.Fields)
 	case "sup":
 		return sio.NopReadCloser(supio.NewReader(sctx, r)), nil
 	case "tsv":

--- a/sio/anyio/reader.go
+++ b/sio/anyio/reader.go
@@ -41,14 +41,15 @@ func NewReaderWithOpts(sctx *super.Context, r io.Reader, opts ReaderOpts) (sio.R
 	var parquetErr, csupErr error
 	if rs, ok := r.(io.ReadSeeker); ok {
 		if n, err := rs.Seek(0, io.SeekCurrent); err == nil {
-			var zr sio.Reader
-			zr, parquetErr = parquetio.NewReader(sctx, rs, opts.Fields)
+			var rc sio.ReadCloser
+			rc, parquetErr = parquetio.NewReader(sctx, rs, opts.Fields)
 			if parquetErr == nil {
-				return sio.NopReadCloser(zr), nil
+				return rc, nil
 			}
 			if _, err := rs.Seek(n, io.SeekStart); err != nil {
 				return nil, err
 			}
+			var zr sio.Reader
 			zr, csupErr = csupio.NewReader(sctx, rs, opts.Fields)
 			if csupErr == nil {
 				return sio.NopReadCloser(zr), nil


### PR DESCRIPTION
A Parquet reader is an arrowio.Reader, which has a Close method, and wrapping prevents it from being called.  Additionally, wrapping hides the Type method, preventing compiler/semantic.translator.fileType from calling it to determine the file type efficiently.