### PR TITLE
vam: Fix toBool handling of Const with nulls

### DIFF
--- a/runtime/vam/expr/logic.go
+++ b/runtime/vam/expr/logic.go
@@ -167,9 +167,13 @@ func toBool(vec vector.Any) *vector.Bool {
 	case *vector.Const:
 		val := vec.Value()
 		if val.Bool() {
-			out := vector.NewTrue(vec.Len())
-			out.Nulls = vec.Nulls
-			return out
+			var bits bitvec.Bits
+			if vec.Nulls.IsZero() {
+				bits = bitvec.NewTrue(vec.Len())
+			} else {
+				bits = bitvec.Not(vec.Nulls)
+			}
+			return vector.NewBool(bits, vec.Nulls)
 		} else if val.IsNull() {
 			return vector.NewBoolEmpty(vec.Len(), bitvec.NewTrue(vec.Len()))
 		}

--- a/runtime/ztests/expr/logical-or.yaml
+++ b/runtime/ztests/expr/logical-or.yaml
@@ -69,3 +69,13 @@ output: |
   null::bool
   error({message:"not type bool",on:"foo"})
   error({message:"not type bool",on:"foo"})
+
+---
+
+# Issue #6482
+spq: values !(null == null) or false
+
+vector: true
+
+output: |
+  null::bool


### PR DESCRIPTION
When a vector.Const had a true value with nulls set, toBool incorrectly created true bits for null positions. Properly flip true/null values to false/null.

Fixes #6482