### PR TITLE
join(): Fix inconsistency between sam and vam variants

### DIFF
--- a/runtime/sam/expr/function/string.go
+++ b/runtime/sam/expr/function/string.go
@@ -169,6 +169,9 @@ func (j *Join) Call(args []super.Value) super.Value {
 	if !ok || typ.Type.ID() != super.IDString {
 		return j.sctx.WrapError("join: array of string arg required", splitsVal)
 	}
+	if splitsVal.IsNull() {
+		return super.NullString
+	}
 	var separator string
 	if len(args) == 2 {
 		sepVal := args[1]

--- a/runtime/sam/expr/ztests/join.yaml
+++ b/runtime/sam/expr/ztests/join.yaml
@@ -1,8 +1,0 @@
-spq: |
-  cut s1:=join(a1,"."),s2:=join(a1,"."),s3:=join(a3,"."),s4:=join(a4,"."),s5:=join(oo)
-
-input: |
-  {a1:["foo","bar","com"],a2:["foo"],a3:null::[string],a4:[""],oo:["f",".bar.com"]}
-
-output: |
-  {s1:"foo.bar.com",s2:"foo.bar.com",s3:"",s4:"",s5:"f.bar.com"}

--- a/runtime/ztests/expr/function/join.yaml
+++ b/runtime/ztests/expr/function/join.yaml
@@ -1,15 +1,45 @@
-spq: join(s, sep)
+spq: |
+  values join(this, "->")
 
 vector: true
 
 input: |
-  {s:["a","b","c"],sep:", "}
-  {s:"join",sep:","}
-  {s:["a"],sep:["b"]}
-  {s:["a","b",null::string,"c"],sep:""::(int64|string)}
+  ["foo","bar","baz"]
+  ["foo"]
+  null::[string]
+  []::[string]
+  [""]
+  "not an array"
+
 
 output: |
-  "a, b, c"
-  error({message:"join: array of string arg required",on:"join"})
-  error({message:"join: separator must be string",on:["b"]})
-  "abc"
+  "foo->bar->baz"
+  "foo"
+  null::string
+  ""
+  ""
+  error({message:"join: array of string arg required",on:"not an array"})
+
+---
+
+# Single arg
+spq: |
+  join(this)
+
+vector: true
+
+input: |
+  ["f",".bar.com"]
+
+output: |
+  "f.bar.com"
+
+---
+
+# Bad separator arg
+spq: join(["foo","bar"], 1)
+
+vector: true
+
+output: |
+  error({message:"join: separator must be string",on:1})


### PR DESCRIPTION
This commit changes the sam version of join() to return a null string when a null string array is encountered. Also moves the tests to the standard locations and makes the testing more complete.