### PR TITLE
clean up error sentinels in semantic package

### DIFF
--- a/compiler/semantic/analyzer.go
+++ b/compiler/semantic/analyzer.go
@@ -125,13 +125,12 @@ func (e opCycleError) Error() string {
 	return b
 }
 
-func badExpr() sem.Expr {
-	return &sem.BadExpr{}
-}
-
-func badOp() sem.Op {
-	return &sem.BadOp{}
-}
+var (
+	badExpr   = &sem.BadExpr{}
+	badOp     = &sem.BadOp{}
+	badSchema = &dynamicSchema{}
+	badType   = &super.TypeOfNull{}
+)
 
 type reporter struct {
 	*srcfiles.List

--- a/compiler/semantic/resolver.go
+++ b/compiler/semantic/resolver.go
@@ -63,7 +63,7 @@ func (r *resolver) resolveCall(n ast.Node, id string, args []sem.Expr) sem.Expr 
 		// Check argument count here for builtin functions.
 		if _, err := function.New(super.NewContext(), id, len(args)); err != nil {
 			r.t.error(n, err)
-			return badExpr()
+			return badExpr
 		}
 		return sem.NewCall(n, id, args)
 	}
@@ -83,7 +83,7 @@ func (r *resolver) mustResolveCall(n ast.Node, id string, args []sem.Expr) sem.E
 	declParams := d.lambda.Params
 	if len(declParams) != len(args) {
 		r.t.error(n, fmt.Errorf("%q: expected %d params but called with %d", d.name, len(declParams), len(args)))
-		return badExpr()
+		return badExpr
 	}
 	var lambdas []lambda
 	for k, arg := range args {

--- a/compiler/semantic/schema.go
+++ b/compiler/semantic/schema.go
@@ -99,8 +99,6 @@ type (
 	}
 )
 
-var badType = &super.TypeOfNull{}
-
 func newSchemaFromType(typ super.Type) schema {
 	if typ == badType {
 		return badSchema
@@ -133,8 +131,6 @@ func recordOf(typ super.Type) *super.TypeRecord {
 	}
 	return nil
 }
-
-var badSchema = &dynamicSchema{}
 
 func newJoinUsingSchema(j *joinSchema, columns []string) *joinUsingSchema {
 	skip := make(map[string]struct{})

--- a/compiler/semantic/scope.go
+++ b/compiler/semantic/scope.go
@@ -163,13 +163,13 @@ func (s *Scope) resolve(t *translator, n ast.Node, path field.Path) (sem.Expr, e
 	}
 	out, dyn, err := sch.resolveUnqualified(path[0])
 	if err != nil {
-		return badExpr(), err
+		return badExpr, err
 	}
 	if out != nil {
 		if dyn {
 			// Make sure there's not a table with the same name as the column name.
 			if _, tdyn, err := sch.resolveTable(n, path[0], nil); err != nil && tdyn {
-				return badExpr(), fmt.Errorf("cannot use unqualified reference %q when table of same name is in scope (consider qualified reference)", path[0])
+				return badExpr, fmt.Errorf("cannot use unqualified reference %q when table of same name is in scope (consider qualified reference)", path[0])
 			}
 		}
 		return sem.NewThis(n, append(out, path[1:]...)), nil

--- a/compiler/semantic/sql.go
+++ b/compiler/semantic/sql.go
@@ -267,7 +267,7 @@ func (t *translator) selectFrom(loc ast.Loc, exprs []ast.SQLTableExpr, seq sem.S
 	if _, ok := seq[off].(*sem.RobotScan); !ok {
 		if hasParent {
 			t.error(loc, errors.New("SELECT cannot have both an embedded FROM clause and input from parents"))
-			return append(seq, badOp()), badSchema
+			return append(seq, badOp), badSchema
 		}
 	}
 
@@ -429,7 +429,7 @@ func (t *translator) sqlQueryBody(query ast.SQLQueryBody, demand []ast.Expr, seq
 		left, leftSch = leftSch.endScope(query.Left.(ast.Node), left)
 		if leftSch == nil || leftSch == badSchema {
 			// error happened in query body
-			return sem.Seq{badOp()}, badSchema
+			return sem.Seq{badOp}, badSchema
 		}
 		leftCols, lok := leftSch.outColumns()
 		if !lok {
@@ -439,18 +439,18 @@ func (t *translator) sqlQueryBody(query ast.SQLQueryBody, demand []ast.Expr, seq
 		right, rightSch = rightSch.endScope(query.Right.(ast.Node), right)
 		if rightSch == nil || rightSch == badSchema {
 			// error happened in query body
-			return sem.Seq{badOp()}, badSchema
+			return sem.Seq{badOp}, badSchema
 		}
 		rightCols, rok := rightSch.outColumns()
 		if !rok {
 			t.error(query.Right, errors.New("set operations cannot be applied to dynamic sources"))
 		}
 		if !lok || !rok {
-			return sem.Seq{badOp()}, badSchema
+			return sem.Seq{badOp}, badSchema
 		}
 		if len(leftCols) != len(rightCols) {
 			t.error(query, errors.New("set operations can only be applied to sources with the same number of columns"))
-			return sem.Seq{badOp()}, badSchema
+			return sem.Seq{badOp}, badSchema
 		}
 		if !slices.Equal(leftCols, rightCols) {
 			// Rename fields on the right to match the left.
@@ -610,7 +610,7 @@ func (t *translator) sqlJoinCond(cond ast.JoinCond) sem.Expr {
 			exprs = append(exprs, sem.NewBinaryExpr(id, "==", lhs, rhs))
 		}
 		if len(exprs) == 0 {
-			return badExpr()
+			return badExpr
 		}
 		return andUsingExprs(cond, exprs)
 	default:
@@ -698,7 +698,7 @@ func (t *translator) resolveOrdinalOuter(s schema, n ast.Node, prefix string, co
 	case *staticSchema:
 		if col < 1 || col > len(s.columns) {
 			t.error(n, fmt.Errorf("column %d is out of range", col))
-			return badExpr()
+			return badExpr
 		}
 		var path []string
 		if prefix != "" {


### PR DESCRIPTION
This commit cleans up the declarations and use of error elements in the semantic analysis.  Instead of returning new instances of dummy entities from a call (e.g., badExpr(), badOp()) we now just use sentinels.  This means we can use pointer comparison to test for these error conditions.