### PR TITLE
Remove redundant compare() test

### DIFF
--- a/runtime/sam/expr/function/ztests/compare-nullsmax.yaml
+++ b/runtime/sam/expr/function/ztests/compare-nullsmax.yaml
@@ -1,9 +1,0 @@
-spq: values compare(a, b, true), compare(a, b, false), compare(a, b, "error")
-
-input: |
-  {a: null, b: 2}
-
-output: |
-  1
-  -1
-  error({message:"compare: nullsMax arg is not bool",on:"error"})


### PR DESCRIPTION
This test has been moved to runtime/ztests/expr/function/compare.yaml in #6493.