### PR TITLE
vam: union() and collect() agg fixes

### DIFF
--- a/runtime/vam/expr/agg/collect.go
+++ b/runtime/vam/expr/agg/collect.go
@@ -12,6 +12,9 @@ type collect struct {
 }
 
 func (c *collect) Consume(vec vector.Any) {
+	if _, ok := vec.(*vector.Error); ok {
+		return
+	}
 	typ := vec.Type()
 	nulls := vector.NullsOf(vec)
 	var b scode.Builder

--- a/runtime/ztests/op/aggregate/container-partials.yaml
+++ b/runtime/ztests/op/aggregate/container-partials.yaml
@@ -2,8 +2,10 @@
 # with a single-row limit.  We also make sure the partials consumer can handle
 # an empty input by including a record for key "a" with no value field.
 script: |
-  super -s -c "union(x) by key with -limit 1" in.sup > union.sup
-  super -s -c "collect(x) by key with -limit 1" in.sup > collect.sup
+  super -s -c "union(x) by key with -limit 1 | sort key" in.sup > union.sup
+  super -s -c "collect(x) by key with -limit 1 | sort key" in.sup > collect.sup
+
+vector: true
 
 inputs:
   - name: in.sup

--- a/runtime/ztests/op/aggregate/container.yaml
+++ b/runtime/ztests/op/aggregate/container.yaml
@@ -2,6 +2,8 @@ script: |
   super -s -c "union(x)" in.sup > union.sup
   super -s -c "collect(x)" in.sup > collect.sup
 
+vector: true
+
 inputs:
   - name: in.sup
     data: |


### PR DESCRIPTION
This commit fixes a couple issues with the union() and collect()
aggregation functions in vector runtime:
- Ignore error values.
- Fixes panic when a set wrapped in a view is encountered (union()).
- Enable tests for vector runtime.