### PR TITLE
split semantic.schema into relational scope and tables

### DIFF
--- a/compiler/semantic/analyzer.go
+++ b/compiler/semantic/analyzer.go
@@ -126,10 +126,10 @@ func (e opCycleError) Error() string {
 }
 
 var (
-	badExpr   = &sem.BadExpr{}
-	badOp     = &sem.BadOp{}
-	badSchema = &dynamicSchema{}
-	badType   = &super.TypeOfNull{}
+	badExpr  = &sem.BadExpr{}
+	badOp    = &sem.BadOp{}
+	badTable = &staticTable{}
+	badType  = &super.TypeOfNull{}
 )
 
 type reporter struct {

--- a/compiler/ztests/sql/subqueries-select-star.yaml
+++ b/compiler/ztests/sql/subqueries-select-star.yaml
@@ -1,7 +1,7 @@
 script: |
   super -s -c 'select id from ( select * from (values (1)) x(id) )'
   echo // ===
-  # Ensure id can be selected when subquery has select * on a dynamic schema.
+  # Ensure id can be selected when subquery has select * on a dynamic input.
   super -s -c 'select id from ( select * from in.sup )'
 
 inputs:

--- a/compiler/ztests/sql/union-error.yaml
+++ b/compiler/ztests/sql/union-error.yaml
@@ -18,3 +18,6 @@ outputs:
       the all-columns (*) pattern cannot be used for dynamic inputs at line 1, column 8:
       select * from a.sup union all select * from a.sup
              ~
+      the all-columns (*) pattern cannot be used for dynamic inputs at line 1, column 38:
+      select * from a.sup union all select * from a.sup
+                                           ~

--- a/compiler/ztests/tuple.yaml
+++ b/compiler/ztests/tuple.yaml
@@ -1,7 +1,19 @@
-spq: 'values (1,2,(3,4),{x:x*x})'
+spq: 'values (1,2,(3,4))'
 
 input: |
   {x:2}
 
 output: |
-  {c0:1,c1:2,c2:{c0:3,c1:4},c3:{x:4}}
+  {c0:1,c1:2,c2:{c0:3,c1:4}}
+
+---
+
+spq: 'values (1,2,(3,4),{x:x*x})'
+
+input: |
+  {x:2}
+
+error: |
+  SQL VALUES clause currently supports only constant expressions at line 1, column 8:
+  values (1,2,(3,4),{x:x*x})
+         ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This commit refactors the SQL "schema" logic in the semantic package to more cleanly separate relational scopes and tables. Now, staticTable and dynamicTable are tables.  selectScope, joinScope, and subQueryScope (in addition to the tables) are scopes. This further clarifies that sqlPipe returns a table and sqlQueryBody returns a tableScope (i.e., only a selectScope or staticTable).

tableScope.endScope() always returns a staticTable so there is clarity there and no need for the old schema.outColumns()

This refactoring is needed by the upcoming PR that will integrate type checking (and type-to-schema glue) into the translator pass.