### PR TITLE
vam map index: Fix panic on index error("missing")

### DIFF
--- a/runtime/vam/expr/index.go
+++ b/runtime/vam/expr/index.go
@@ -155,6 +155,9 @@ func indexRecord(sctx *super.Context, vec, indexVec vector.Any, base1 bool) vect
 
 func indexMap(sctx *super.Context, vec, indexVec vector.Any) vector.Any {
 	// XXX At some point we'll want to optimize having a const indexVec.
+	if _, ok := indexVec.(*vector.Error); ok {
+		return indexVec
+	}
 	n := vec.Len()
 	var index []uint32
 	if view, ok := vec.(*vector.View); ok {

--- a/runtime/ztests/expr/type-map.yaml
+++ b/runtime/ztests/expr/type-map.yaml
@@ -5,10 +5,12 @@ spq: |
     "conn": conn,
     "dns": dns
   }|
-  fork
-    ( !missing(schemas[_path]) | cut schema:=schemas[_path] )
-    ( missing(schemas[_path]) | put _UNCLASSIFIED:=true )
+  switch missing(schemas[_path]) 
+    case false ( cut schema:=schemas[_path] )
+    case true  ( put _UNCLASSIFIED:=true )
   | sort this
+
+vector: true
 
 input: |
   {_path:"conn",id:{src:"192.168.1.1",dst:"192.168.1.2"},etc:"foo"}


### PR DESCRIPTION
This commit fixes an issue with map index expressions when the input index value is an error. Previously this would cause the runtime to panic.