### PR TITLE
has_error: null error values return false

### DIFF
--- a/runtime/sam/expr/function/types.go
+++ b/runtime/sam/expr/function/types.go
@@ -100,10 +100,6 @@ func (h *HasError) Call(args []super.Value) super.Value {
 }
 
 func (h *HasError) hasError(t super.Type, b scode.Bytes) (bool, bool) {
-	typ := super.TypeUnder(t)
-	if _, ok := typ.(*super.TypeError); ok {
-		return true, false
-	}
 	// If a value is null we can skip since an null error is not an error.
 	if b == nil {
 		return false, false
@@ -113,7 +109,7 @@ func (h *HasError) hasError(t super.Type, b scode.Bytes) (bool, bool) {
 	}
 	var hasErr bool
 	canCache := true
-	switch typ := typ.(type) {
+	switch typ := super.TypeUnder(t).(type) {
 	case *super.TypeRecord:
 		it := b.Iter()
 		for _, f := range typ.Fields {
@@ -148,6 +144,8 @@ func (h *HasError) hasError(t super.Type, b scode.Bytes) (bool, bool) {
 			hasErr, cc = h.hasError(typ, b)
 			canCache = !canCache || cc
 		}
+	case *super.TypeError:
+		hasErr = true
 	}
 	// We cannot cache a type if the type or one of its children has a union
 	// with an error member.

--- a/runtime/sam/expr/ztests/has_error.yaml
+++ b/runtime/sam/expr/ztests/has_error.yaml
@@ -6,6 +6,10 @@ input: |
   {f1:127.0.0.1,f2:error("error")}
   [1,2]::[int64|error(string)]
   |{"key":error(0)::(int64|error(int64))}|
+  <error(int64)>
+  <{x:error(int64)}>
+  null::error(int64)
+  null::{x:error(string)}
 
 output: |
   false
@@ -13,3 +17,7 @@ output: |
   true
   false
   true
+  false
+  false
+  false
+  false


### PR DESCRIPTION
This commit fixes has_error so that null error values return false for having an error.