### PR TITLE
Remove cache for HasError function

### DIFF
--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -186,8 +186,7 @@ func (t *translator) fromFString(entity *ast.FromEval, args []ast.OpArg, seq sem
 }
 
 func hasError(val super.Value) bool {
-	has := function.NewHasError()
-	result := has.Call([]super.Value{val})
+	result := function.HasError{}.Call([]super.Value{val})
 	return result.AsBool()
 }
 

--- a/runtime/sam/expr/function/function.go
+++ b/runtime/sam/expr/function/function.go
@@ -72,7 +72,7 @@ func New(sctx *super.Context, name string, narg int) (expr.Function, error) {
 		argmax = -1
 		f = &Has{}
 	case "has_error":
-		f = NewHasError()
+		f = HasError{}
 	case "hex":
 		f = &Hex{sctx: sctx}
 	case "is":

--- a/runtime/sam/expr/ztests/has_error.yaml
+++ b/runtime/sam/expr/ztests/has_error.yaml
@@ -5,10 +5,13 @@ input: |
   error(0)
   {f1:127.0.0.1,f2:error("error")}
   [1,2]::[int64|error(string)]
-  |{"key":error(0)::(int64|error(int64))}|
+  [1,2,error(0)]
+  |[1,2,error(0)]|
+  |{"k2":1,"k1":error(0)}|
   <error(int64)>
   <{x:error(int64)}>
   null::error(int64)
+  null::(int64|error(int64))
   null::{x:error(string)}
 
 output: |
@@ -17,6 +20,9 @@ output: |
   true
   false
   true
+  true
+  true
+  false
   false
   false
   false


### PR DESCRIPTION
This commit removes the caching logic from the sequential runtime implementation of the HasError function. There was a bug in the current implementation where unions values that had an error type but were not errors themselves would report the entire union type as a cacheable non-error then subsequent error values of that union would get false reported as not having an error. This caching behavior could be fixed with additional logic but since we are not so interested in performance in the sequential runtime remove the caching and simplify the logic.

Fixes #6199 