### PR TITLE
Add notes in docs for not-yet-supported items

### DIFF
--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -379,6 +379,10 @@ whereas pipe operators can emit any data type desired in a varying fashion, and
 * [sum types](super-sql/types/union.md) are integral to piped data allowing mix-typed data processing
 and results that need not fit in a uniform table.
 
+> [!NOTE]
+> Case insensitive column names in SQL clauses are not yet supported.
+> ([super#6066](https://github.com/brimdata/super/issues/6066))
+
 With this approach, SuperSQL can be adopted and used for existing use cases
 based on legacy SQL while incrementally expanding and embracing
 the pipe model tied to super-structured data.

--- a/book/src/super-sql/expressions/subqueries.md
+++ b/book/src/super-sql/expressions/subqueries.md
@@ -79,8 +79,10 @@ may reach a scope that is outside of the subquery.
 In this case, the subquery is a
 [correlated subquery](https://en.wikipedia.org/wiki/Correlated_subquery).
 
-Correlated subqueries are not yet supported.  They are detected and a
-compile-time error is reported when encountered.
+> [!NOTE]
+> Correlated subqueries are not yet supported.  They are detected and a
+> compile-time error is reported when encountered.
+> ([super#6549](https://github.com/brimdata/super/issues/6549))
 
 A correlated subquery can always be rewritten as a pipe subquery using
 [unnest](../operators/unnest.md) using this pattern:


### PR DESCRIPTION
This adds a couple "Note" admonitions for functionality that we don't expect to be implemented before our planned GA release but we still want mentioned in the docs.

One other I've been tracking that's not included in these changes is #6143. Since it's a bug regarding an argument of an operator it seems minor enough that it doesn't quite justify a "Note", plus I'm holding out hope someone may fix it soon since panics usually get treated with priority.