### PR TITLE
fix bug handling expression args in from and http option headers

### DIFF
--- a/book/src/super-sql/operators/from.md
+++ b/book/src/super-sql/operators/from.md
@@ -135,6 +135,9 @@ to be included as the body of the HTTP request.
 
 Currently, the headers expression must evaluate to a compile-time constant though this
 may change to allow dynamic computation in a future version of SuperSQL.
+Each field of this record must either be a string or (to specify a
+header option appearing multiple times with different values)
+an array or set of strings.
 
 #### Expression
 


### PR DESCRIPTION
This commit fixes a bug where expression opArgs were incorrectly asserted to the wrong type and also a problem with how HTTP option headers were parsed so that we now allow either single-arg strings multi-arg arrays of strings.

We don't have a good way in ztest for spinning up a server to test reading from a URL so we are leaving that for for future test coverage.

Closes #6143