### PR TITLE
Use v6 of GoReleaser Action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
     - run: make test-unit
     - run: make test-system
     - run: make test-heavy
-    - uses: goreleaser/goreleaser-action@v5
+    - uses: goreleaser/goreleaser-action@v6
       with:
         args: release --clean
       env:


### PR DESCRIPTION
In preparation for tagging a GA release of SuperDB this Friday, I tested out our release workflow in personal repos just to get ahead of any bit rot. The only snag I hit is that we need to use a newer version of the GoReleaser Action than in the past, so I adjust that here.

## How I Tested

1. Installed a prerelease `super` via the Cask in my personal Homebrew tap via `brew install --cask philrz/tap/super`
2. Created a personal fork of the super repo at https://github.com/philrz/super, then in it:
   * Enabled Actions
   * Set a `PAT_TOKEN` Actions Secret similar to the one that already exists in the production super repo
   * Changed the `homebrew_casks.repository` property in the GoReleaser config to point to my personal homebrew tap repo
   * Updated to `goreleaser/goreleaser-action@v6` instead of `@v5` in the `release.yaml` Workflow (as done in this PR)
4. Ran `git tag -a -m v0.1.0 v0.1.0 && git push origin v0.1.0` to trigger the release job in the personal fork of the super repo
5. Confirmed the tagged release binaries showed up in https://github.com/philrz/super/releases
6. Did a `brew update && brew upgrade` and confirmed the newer binary it downloaded from the Cask in my personal Homebrew tap now showed `v0.1.0` when running `super -version`
