### PR TITLE
Mention sqllogictests in SQL docs intro page

### DIFF
--- a/book/src/super-sql/sql/intro.md
+++ b/book/src/super-sql/sql/intro.md
@@ -319,3 +319,29 @@ values 1, 'foo', {x:1}
 {that:"foo"}
 {that:{x:1}}
 ```
+
+## Testing Backward Compatibility
+
+In addition to tests found within the
+[SuperDB GitHub repository](https://github.com/brimdata/super), backward
+compatibility relative to PostgreSQL is tested using
+[sqllogictest](https://sqlite.org/sqllogictest/doc/trunk/about.wiki) queries
+from [SQLite](https://sqlite.org/).
+
+As of the first GA release of SuperDB, 3,615,296 of 3,619,718 eligible queries
+(99.88% success rate) from the SQLite set produce the same result as
+PostgreSQL when run via `super`. The following open issues are known to be a
+cause of one or more of the 0.12% remaining unsuccessful queries and will be
+addressed in future SuperDB releases.
+
+|**Issue**|**Description**|
+|---------|----------------|
+|[super#6549](https://github.com/brimdata/super/issues/6549)|SQL: Correlated subqueries|
+|[super#6033](https://github.com/brimdata/super/issues/6033)|SQL: INTERSECT and EXCEPT|
+|[super#6074](https://github.com/brimdata/super/issues/6074)|SQL: Large cartesian product causes very long query runtime|
+|[super#5984](https://github.com/brimdata/super/issues/5984)|SQL: NULL values absent from JOIN output|
+|[super#6536](https://github.com/brimdata/super/issues/6536)|SQL: Signed zero|
+|[super#6517](https://github.com/brimdata/super/issues/6517)|SQL: Promoting return types to common type of arguments|
+
+Additional details on how the tests are assembled and executed can be found in
+the [sqllogic-ztests repo](https://github.com/brimdata/sqllogic-ztests).


### PR DESCRIPTION
Here I've added a summary of our current success rate on the sqllogictests and a list of open issues known to contribute to the remaining failures.

To keep the docs tidy, I've linked off to the https://github.com/brimdata/sqllogic-ztests repo for further details if readers want to dig more into which of the queries we're using, how to run the tests themselves, etc. In the interest of time, up to this point, I've been doing the sqllogictest stuff as a "one person show" so I've not sought formal review of the READMEs in that repo. However, if the way I'm now proposing linking to them increases interest in their content, check out the [top-level README](https://github.com/brimdata/sqllogic-ztests/blob/main/README.md) and the [README with more details about the SQLite queries](https://github.com/brimdata/sqllogic-ztests/blob/main/ztests/sqlite/README.md). Feel free to open PRs on that repo if you'd like to propose changes, or ping me with questions.