### PR TITLE
Fix broken links to Database docs

### DIFF
--- a/book/src/command/db-init.md
+++ b/book/src/command/db-init.md
@@ -17,7 +17,7 @@ Additional options of the [db sub-command](db.md#options)
 ### Description
 
 A new database is created and initialized with the `init` command.  The `path` argument
-is a [storage path](../database/intro.md#storage-layer)
+is a storage path
 and is optional.  If not present, the path
 is [determined automatically](db.md#database-connection).
 

--- a/book/src/command/db-load.md
+++ b/book/src/command/db-load.md
@@ -70,7 +70,7 @@ Data added to a pool can arrive in any order with respect to its sort key.
 While each object is sorted before it is written,
 the collection of objects is generally not sorted.
 
-Each load operation creates a single [commit](../database/intro.md#commit-objects),
+Each load operation creates a single commit,
 which includes:
 * an author and message string,
 * a timestamp computed by the server, and
@@ -94,7 +94,7 @@ with the user obtained from the session and a message that is descriptive
 of the action.
 
 The `date` field here is used by the database for
-[time travel](../database/intro.md#time-travel)
+time travel
 through the branch and pool history, allowing you to see the state of
 branches at any time in their commit history.
 

--- a/book/src/command/db-log.md
+++ b/book/src/command/db-log.md
@@ -15,7 +15,7 @@ Additional options of the [db sub-command](db.md#options)
 ### Description
 
 The `log` command, like `git log`, displays a history of the
-[commits](../database/intro.md#commit-objects)
+commits
 starting from any commit, expressed as a [commitish](db.md#commitish).  If no argument is
 given, the tip of the working branch is used.
 
@@ -38,7 +38,7 @@ A commit object includes
 an optional author and message, along with a required timestamp,
 that is stored in the commit journal for reference.  These values may
 be specified as options to the [`load`](db-load.md) command, and are also available in the
-database [API](../database/api.md) for automation.
+database API for automation.
 
 >[!NOTE]
 > The branchlog meta-query source is not yet implemented.

--- a/book/src/command/db-serve.md
+++ b/book/src/command/db-serve.md
@@ -32,9 +32,9 @@ Additional options of the [db sub-command](db.md#options)
 TODO: get rid of personality metaphor?
 
 The `serve` command implements the
-[server personality](../database/intro.md#command-personalities) to service requests
+server personality to service requests
 from instances of the client personality.
-It listens for [API](../database/api.md) requests on the interface and port
+It listens for API requests on the interface and port
 specified by the `-l` option, executes the requests, and returns results.
 
 The `-log.level` option controls log verbosity.  Available levels, ordered

--- a/book/src/dev/integrations/grafana.md
+++ b/book/src/dev/integrations/grafana.md
@@ -2,6 +2,6 @@
 
 A [data source plugin](https://grafana.com/grafana/plugins/?type=datasource)
 for [Grafana](https://grafana.com/) is available that enables plotting of
-time-series data that's stored in a [SuperDB database](../../database/intro.md). See the
+time-series data that's stored in a [SuperDB database](../../command/db.md). See the
 README in the [grafana-zed-datasource repository](https://github.com/brimdata/grafana-zed-datasource)
 for details.

--- a/book/src/getting-started/intro.md
+++ b/book/src/getting-started/intro.md
@@ -17,7 +17,7 @@ SuperDB's disaggregation of compute and storage is reflected into the
 design of its command hierarchy: running the top-level `super` command
 runs the compute engine only on inputs like files and URLs, while
 the [`db`](../command/db.md) subcommands of `super` operate upon
-a [persistent database](../database/intro.md).
+a persistent database.
 
 To get online help, run the `super` command or any sub-command with `-h`,
 e.g.,

--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -23,7 +23,7 @@ for super-structured data with the introduction of:
 * several super-structured serialization [formats](formats/intro.md),
 * a SQL-compatible [query language](super-sql/intro.md) adapted for super-structured data,
 * a super-structured [query engine](https://github.com/brimdata/super/tree/main/runtime/vam), and
-* a super-structured [database format](database/format.md) compatible with
+* a super-structured database format compatible with
   cloud object stores.
 
 To achieve high performance for the dynamically typed data that lies at the heart of
@@ -93,7 +93,7 @@ a runtime system that
 * runs directly on any data inputs like files, streams, or APIs, or
 * manipulates and queries data in a persistent
 storage layer &mdash; the
-[SuperDB database](database/intro.md) &mdash; that rhymes in design with the emergent
+[SuperDB database](command/db.md) &mdash; that rhymes in design with the emergent
 [lakehouse pattern](https://www.cidrdb.org/cidr2021/papers/cidr2021_paper17.pdf)
 but is based on super-structured data.
 
@@ -103,7 +103,7 @@ the [db](command/db.md) subcommand and specify an optional query with `-c`:
 super -c "SELECT 'hello, world'"
 ```
 To interact with a SuperDB database, invoke the [db](command/db.md) subcommands
-of `super` and/or program against the [database API](database/api.md).
+of `super` and/or program against the database API.
 
 >[!NOTE]
 > The persistent database layer is still under development and not yet

--- a/book/src/super-sql/intro.md
+++ b/book/src/super-sql/intro.md
@@ -159,7 +159,7 @@ results in
 When running on the local file system,
 `from` may refer to a file or an HTTP URL
 indicating an API endpoint.
-When connected to a [SuperDB database](../database/intro.md),
+When connected to a [SuperDB database](../command/db.md),
 `from` typically
 refers to a collection of super-structured data called a _pool_ and
 is referenced using the pool's name similar to SQL referencing

--- a/book/src/super-sql/operators/from.md
+++ b/book/src/super-sql/operators/from.md
@@ -135,8 +135,7 @@ The only allowed option for a pool is the commit argument having the form
 ```
 commit <commitsh>
 ```
-where `<commitish>` is a
-[commitish](../../database/intro.md#commitish) that specifies a specific
+where `<commitish>` specifies a specific
 commit in the pool's log thereby allowing time travel.
 
 The the commit argument may be abbreviated by appending to the pool name

--- a/book/src/super-sql/operators/load.md
+++ b/book/src/super-sql/operators/load.md
@@ -20,7 +20,7 @@ receives as input. Much like how [`super db load`](../../command/db-load.md)
 is used at the command line to populate a pool with data from files, streams,
 and URIs, the `load` operator is used to save query results from your SuperSQL
 query to a pool in the same database. `<pool>` is a string indicating the
-[name or ID](../../database/intro.md#data-pools) of the destination pool.
+name or ID of the destination pool.
 If the optional `@<branch>` string is included then the data will be committed
 to an existing branch of that name, otherwise the `main` branch is assumed.
 The `author`, `message`, and `meta` strings may also be provided to further


### PR DESCRIPTION
This fixes some broken links due to the Database docs having been commented out in #6578, similar to how #6576 fixed broken links from having commented out the Tutorials docs in #6574.

Where appropriate I replaced with links to the `super db` command doc page on the assumption that'll be sticking around in some form. That way curious readers can learn still learn _some_ stuff about the database there. For more specific topics like the API doc or details about the storage format, I'm proposing just not linking at all. That's not ideal, but since in the docs there's already "Note" admonitions that set expectations that the database is not ready for prime time, this may be ok.
