### PR TITLE
replace terminal command help descriptions with links to book

### DIFF
--- a/book/src/command/db.md
+++ b/book/src/command/db.md
@@ -287,10 +287,17 @@ Likewise, you can delete a branch with `-d`:
 ```
 super db branch -d staging
 ```
-and list the branches as follows:
+No data is
+deleted by this operation and the deleted branch can be easily recreated by
+running the branch command again with the commit ID desired.
+
+You can list the branches as follows:
 ```
 super db branch
 ```
+
+If no branch is currently checked out, then "-use pool@base" can be
+supplied to specify the desired pool for the new branch.
 
 ### super db compact
 
@@ -671,39 +678,6 @@ data loaded in a reverted commit remains in the database but no longer
 appears in the branch. The new commit may recursively be reverted by an
 additional revert operation.
 
-### super db use
-
-```
-super db use [ <commitish> ]
-```
-* [Global](options.md#global)
-* [Database](options.md#database)
-
-The `use` command sets the working branch to the indicated commitish.
-When run with no argument, it displays the working branch and
-[database connection](#database-connection).
-
-For example,
-```
-super db use logs
-```
-provides a "pool-only" commitish that sets the working branch to `logs@main`.
-
-If a `@branch` or commit ID are given without a pool prefix, then the pool of
-the commitish previously in use is presumed.  For example, if you are on
-`logs@main` then run this command:
-```
-super db use @test
-```
-then the working branch is set to `logs@test`.
-
-To specify a branch in another pool, simply prepend
-the pool name to the desired branch:
-```
-super db use otherpool@otherbranch
-```
-This command stores the working branch in `$HOME/.super_head`.
-
 ### super db serve
 
 ```
@@ -739,6 +713,65 @@ is recommended.
 
 The `-manage` option enables the running of the same maintenance tasks
 normally performed via the [manage](#super-db-manage) sub-command.
+
+### super db use
+
+```
+super db use [ <commitish> ]
+```
+* [Global](options.md#global)
+* [Database](options.md#database)
+
+The `use` command sets the working branch to the indicated commitish.
+When run with no argument, it displays the working branch and
+[database connection](#database-connection).
+
+Setting these values allows commands like load, rebase, merge, etc. to function without
+having to specify the working branch.  The branch specifier may also be
+a commit ID, in which case you enter a headless state and commands
+like load that require a branch will report an error.
+
+The use command is like "git checkout" but there is no local copy of
+the database.  Rather, the local HEAD state influences commands as
+they access the database.
+
+The pool must be the name or ID of an existing pool.  The branch must be
+the name of an existing branch or a commit ID.
+
+Any command that relies upon HEAD can also be run with the `-use` option
+to refer to a different HEAD without executing an explicit `use` command.
+While the use of HEAD is convenient for interactive CLI sessions,
+automation and orchestration tools are better off hard-wiring the
+HEAD references in each database command via `-use`.
+
+The `use` command merely checks that the branch exists and updates the
+file ~/.super_head.  This file simply contains a pointer to the HEAD branch
+and thus provides the default for the `-use` option.  This way, multiple working
+directories can contain different HEAD pointers (along with your local files)
+and you can easily switch between windows without having to continually
+re-specify a new HEAD.  Unlike Git, all the committed pool data remains
+in the database and is not copied to this local directory.
+
+For example,
+```
+super db use logs
+```
+provides a "pool-only" commitish that sets the working branch to `logs@main`.
+
+If an `@branch` or commit ID are given without a pool prefix, then the pool of
+the commitish previously in use is presumed.  For example, if you are on
+`logs@main` then run this command:
+```
+super db use @test
+```
+then the working branch is set to `logs@test`.
+
+To specify a branch in another pool, simply prepend
+the pool name to the desired branch:
+```
+super db use otherpool@otherbranch
+```
+This command stores the working branch in `$HOME/.super_head`.
 
 ### super db vacate
 

--- a/cmd/super/compile/command.go
+++ b/cmd/super/compile/command.go
@@ -12,21 +12,7 @@ var spec = &charm.Spec{
 	Usage: "compile [ options ] query [file ...]",
 	Short: "compile a SuperSQL query for inspection and debugging",
 	Long: `
-This command parses a query and emits the resulting abstract syntax
-tree (AST) or runtime directed acyclic graph (DAG) in the output format desired.
-Use "-dag" to specify the DAG form; otherwise, the AST form is assumed.
-
-The "-C" option causes the output to be shown as query language source
-instead of the AST.  This is particularly helpful to see how SuperSQL queries
-in their abbreviated form are translated into the exanded, pedantic form.
-The DAG can also be formatted as query-style text
-but the resulting text is informational only and does not conform to
-any query syntax.  When "-C" is specified, the result is sent to stdout
-and the "-o" option has no effect.
-
-This command is often used for dev and test but
-is also useful to advanced users for understanding how SuperSQL syntax is
-parsed into an AST or compiled into a runtime DAG.
+See https://superdb.org/command/compile.html
 `,
 	New: New,
 }

--- a/cmd/super/db/auth/command.go
+++ b/cmd/super/db/auth/command.go
@@ -11,8 +11,10 @@ var spec = &charm.Spec{
 	Name:  "auth",
 	Usage: "auth [subcommand]",
 	Short: "authentication and authorization commands",
-	Long:  ``,
-	New:   New,
+	Long: `
+See https://superdb.org/command/db.html#super-db-auth
+`,
+	New: New,
 }
 
 func init() {

--- a/cmd/super/db/auth/login.go
+++ b/cmd/super/db/auth/login.go
@@ -15,8 +15,10 @@ var Login = &charm.Spec{
 	Name:  "login",
 	Usage: "auth login",
 	Short: "log in to a database service and save credentials",
-	Long:  ``,
-	New:   NewLoginCommand,
+	Long: `
+See https://superdb.org/command/db.html#super-db-auth
+`,
+	New: NewLoginCommand,
 }
 
 type LoginCommand struct {

--- a/cmd/super/db/auth/logout.go
+++ b/cmd/super/db/auth/logout.go
@@ -12,8 +12,10 @@ var Logout = &charm.Spec{
 	Name:  "logout",
 	Usage: "auth logout",
 	Short: "remove saved credentials for a database service",
-	Long:  ``,
-	New:   NewLogoutCommand,
+	Long: `
+See https://superdb.org/command/db.html#super-db-auth
+`,
+	New: NewLogoutCommand,
 }
 
 type LogoutCommand struct {

--- a/cmd/super/db/auth/method.go
+++ b/cmd/super/db/auth/method.go
@@ -13,8 +13,10 @@ var Method = &charm.Spec{
 	Name:  "method",
 	Usage: "auth method",
 	Short: "display authentication method supported by database service",
-	Long:  ``,
-	New:   NewMethod,
+	Long: `
+See https://superdb.org/command/db.html#super-db-auth
+`,
+	New: NewMethod,
 }
 
 type MethodCommand struct {

--- a/cmd/super/db/auth/store.go
+++ b/cmd/super/db/auth/store.go
@@ -10,10 +10,12 @@ import (
 )
 
 var Store = &charm.Spec{
-	Name:   "store",
-	Usage:  "auth store",
-	Short:  "store raw tokens",
-	Long:   ``,
+	Name:  "store",
+	Usage: "auth store",
+	Short: "store raw tokens",
+	Long: `
+See https://superdb.org/command/db.html#super-db-auth
+`,
 	New:    NewStore,
 	Hidden: true,
 }

--- a/cmd/super/db/auth/verify.go
+++ b/cmd/super/db/auth/verify.go
@@ -13,8 +13,10 @@ var Verify = &charm.Spec{
 	Name:  "verify",
 	Usage: "auth verify",
 	Short: "verify authentication credentials",
-	Long:  ``,
-	New:   NewVerify,
+	Long: `
+See https://superdb.org/command/db.html#super-db-auth
+`,
+	New: NewVerify,
 }
 
 type VerifyCommand struct {

--- a/cmd/super/db/branch/command.go
+++ b/cmd/super/db/branch/command.go
@@ -22,18 +22,7 @@ var spec = &charm.Spec{
 	Usage: "branch new-branch [base]",
 	Short: "create a new branch",
 	Long: `
-The db branch command creates a new branch with the indicated name.
-If specified, base is either an existing branch name or a commit ID
-and provides the new branch's base.  If not specified, then HEAD is assumed.
-
-The branch command does not check out the new branch.
-
-If the -d option is specified, then the branch is deleted.  No data is
-deleted by this operation and the deleted branch can be easily recreated by
-running the branch command again with the commit ID desired.
-
-If no branch is currently checked out, then "-use pool@base" can be
-supplied to specify the desired pool for the new branch.
+See https://superdb.org/command/db.html#super-db-branch
 `,
 	New: New,
 }

--- a/cmd/super/db/command.go
+++ b/cmd/super/db/command.go
@@ -22,8 +22,8 @@ var Spec = &charm.Spec{
 	Usage: "db <sub-command> [options] [arguments...]",
 	Short: "run database commands",
 	Long: `
-db is a command-line tool for creating, configuring, ingesting into,
-querying, and orchestrating databases.`,
+See https://superdb.org/command/db.html
+`,
 	New:          New,
 	InternalLeaf: true,
 }

--- a/cmd/super/db/compact/command.go
+++ b/cmd/super/db/compact/command.go
@@ -16,9 +16,8 @@ var spec = &charm.Spec{
 	Usage: "compact id id [id ...]",
 	Short: "compact data objects on a pool branch",
 	Long: `
-The compact command takes a list of data object IDs, writes the values
-in those objects to a sequence of new, non-overlapping objects, and creates
-a commit on HEAD replacing the old objects with the new ones.`,
+See https://superdb.org/command/db.html#super-db-compact
+`,
 	New: New,
 }
 

--- a/cmd/super/db/create/command.go
+++ b/cmd/super/db/create/command.go
@@ -18,19 +18,7 @@ var spec = &charm.Spec{
 	Usage: "create [-orderby key[:asc|:desc]] name",
 	Short: "create a new data pool",
 	Long: `
-The db create command creates new pools.  A pool key may be specified
-as the sort key of the data stored in the pool. The prefix ":asc" or ":desc"
-appearing after the specified key indicates the sort order.  If no sort
-order is given, ascending is assumed.
-
-The single argument specifies the name for the pool.
-
-The db query command can efficiently perform
-range scans with respect to the pool key using the
-"range" parameter to the "from" operator as the data is laid out
-naturally for such scans.
-
-By default, a branch called "main" is initialized in the newly created pool.
+See https://superdb.org/command/db.html#super-db-create
 `,
 	HiddenFlags: "seekstride",
 	New:         New,

--- a/cmd/super/db/delete/command.go
+++ b/cmd/super/db/delete/command.go
@@ -21,22 +21,7 @@ var spec = &charm.Spec{
 	Usage: "delete id [id ...]",
 	Short: "delete data objects from a pool branch",
 	Long: `
-The delete command takes a list of data object IDs and
-deletes references to those object from HEAD by commiting a new
-delete operation to HEAD.
-Once the delete operation completes, the deleted data is no longer seen
-when read data from the pool.
-
-If the -where flag is specified, delete will remove all values for which the
-provided filter expression is true. The value provided to where must be a
-single filter expression, e.g.:
-
-super db delete -where 'ts > 2022-10-05T17:20:00Z and ts < 2022-10-05T17:21:00Z'
-
-No data is actually removed from the database.  Instead, a delete
-operation is an action in the pool's commit journal.  Any delete
-can be "undone" by adding the commits back to the log using
-"super db revert".
+See https://superdb.org/command/db.html#super-db-delete
 `,
 	New: New,
 }

--- a/cmd/super/db/drop/command.go
+++ b/cmd/super/db/drop/command.go
@@ -15,11 +15,7 @@ var spec = &charm.Spec{
 	Usage: "drop pool",
 	Short: "delete a data pool from a database",
 	Long: `
-The drop command removes the named pool from the database.
-
-DANGER ZONE.
-When deleting an entire pool, the drop command prompts for confirmation.
-Once the pool is deleted, its data is gone so use this command carefully.
+See https://superdb.org/command/db.html#super-db-drop
 `,
 	New: New,
 }

--- a/cmd/super/db/init/command.go
+++ b/cmd/super/db/init/command.go
@@ -17,7 +17,7 @@ var spec = &charm.Spec{
 	Usage: "create and initialize a new, empty database",
 	Short: "init [ path ]",
 	Long: `
-"super db init" ...
+See https://superdb.org/command/db.html#super-db-init
 `,
 	New: New,
 }

--- a/cmd/super/db/load/command.go
+++ b/cmd/super/db/load/command.go
@@ -32,7 +32,7 @@ var spec = &charm.Spec{
 	Usage: "load [options] file|S3-object|- ...",
 	Short: "add and commit data to a branch",
 	Long: `
-The load command adds data to a pool and commits it to a branch.
+See https://superdb.org/command/db.html#super-db-load
 `,
 	New: New,
 }

--- a/cmd/super/db/log/command.go
+++ b/cmd/super/db/log/command.go
@@ -18,10 +18,7 @@ var spec = &charm.Spec{
 	Usage: "log [options]",
 	Short: "display the commit log history starting at any commit",
 	Long: `
-The log command outputs a commit history of any branch or unnamed commit object
-from a data pool in the format desired.
-By default, the output is in the human-readable "db" format
-but BSUP can be used to easily be pipe a log to super or other tooling for analysis.
+See https://superdb.org/command/db.html#super-db-log
 `,
 	New: New,
 }

--- a/cmd/super/db/ls/command.go
+++ b/cmd/super/db/ls/command.go
@@ -20,13 +20,7 @@ var spec = &charm.Spec{
 	Usage: "ls [options] [pool]",
 	Short: "list pools in a database or branches in a pool",
 	Long: `
-"super db ls" lists pools in a database or branches in a pool.
-
-By default, all pools in the database are listed along with each pool's unique ID
-and pool key configuration.
-
-If a pool name or pool ID is given, then the pool's branches are listed along
-with the ID of their commit object, which points at the tip of each branch.
+See https://superdb.org/command/db.html#super-db-ls
 `,
 	New: New,
 }

--- a/cmd/super/db/manage/command.go
+++ b/cmd/super/db/manage/command.go
@@ -19,27 +19,7 @@ var spec = &charm.Spec{
 	Usage: "manage",
 	Short: "run compaction and other maintenance tasks on a database",
 	Long: `
-The manage command performs maintenance tasks on a database.
-
-Currently the only supported task is compaction, which reduces
-fragmentation by reading data objects in a pool and writing their
-contents back to large, non-overlapping objects.
-
-If the -monitor option is specified and the database is located via network
-connection, super db manage will run continuously and perform updates as
-needed. By default a check is performed once per minute to determine if
-updates are necessary. The -interval option may be used to specify an
-alternate check frequency in duration format.
-
-If -monitor is not specified, a single maintenance pass is performed on
-the database.
-
-The output from manage provides a per-pool summary of the maintenance
-performed, including a count of objects_compacted.
-
-As an alternative to running manage as a separate command, the -manage
-option is also available on the "super db serve" command to have maintenance
-tasks run at the specified interval by the service process.
+See https://superdb.org/command/db.html#super-db-manage
 `,
 	New: New,
 }

--- a/cmd/super/db/merge/command.go
+++ b/cmd/super/db/merge/command.go
@@ -17,6 +17,7 @@ var spec = &charm.Spec{
 	Usage: "merge branch",
 	Short: "merge current branch into another",
 	Long: `
+See https://superdb.org/command/db.html#super-db-merge
 `,
 	New: New,
 }

--- a/cmd/super/db/rename/command.go
+++ b/cmd/super/db/rename/command.go
@@ -14,8 +14,7 @@ var spec = &charm.Spec{
 	Usage: "rename old-name new-name",
 	Short: "rename a data pool",
 	Long: `
-The rename command changes the name of the pool given by the -p option to the
-new name provided.
+See https://superdb.org/command/db.html#super-db-rename
 `,
 	New: New,
 }

--- a/cmd/super/db/revert/command.go
+++ b/cmd/super/db/revert/command.go
@@ -18,10 +18,7 @@ var spec = &charm.Spec{
 	Usage: "revert commit",
 	Short: "revert reverses an old commit",
 	Long: `
-The revert command reverses the actions in a commit by applying the inverse
-steps in a new commit to the tip of the indicated branch.  Any data loaded
-in a reverted commit remains in the database but no longer appears in the branch.
-The new commit may recursively be reverted by an additional revert operation.
+See https://superdb.org/command/db.html#super-db-revert
 `,
 	New: New,
 }

--- a/cmd/super/db/serve/command.go
+++ b/cmd/super/db/serve/command.go
@@ -30,19 +30,7 @@ var spec = &charm.Spec{
 	Usage: "serve [options]",
 	Short: "service requests to a database",
 	Long: `
-The serve command implements SuperDB's server personality to service
-requests from instances of SuperDB's client personality. It listens
-for database API requests on the interface and port specified by
-the -l option, executes the requests, and returns results.
-
-The -log.level option controls log verbosity. Available levels,
-ordered from most to least verbose, are debug, info (the default),
-warn, error, dpanic, panic, and fatal. If the volume of logging
-output at the default info level seems too excessive for
-production use, warn level is recommended.
-
-The -manage option enables the running of the same maintenance tasks
-normally performed via the separate "super db manage" command.
+See https://superdb.org/command/db.html#super-db-serve
 `,
 	HiddenFlags: "brimfd,portfile",
 	New:         New,

--- a/cmd/super/db/use/command.go
+++ b/cmd/super/db/use/command.go
@@ -18,44 +18,7 @@ var spec = &charm.Spec{
 	Usage: "use [pool][@branch]",
 	Short: "use a branch or print current branch and database",
 	Long: `
-The use command prints or sets the working pool and branch.  Setting these
-values allows commands like load, rebase, merge, etc. to function without
-having to specify the working branch.  The branch specifier may also be
-a commit ID, in which case you enter a headless state and commands
-like load that require a branch will report an error.
-
-The use command is like "git checkout" but there is no local copy of
-the database.  Rather, the local HEAD state influences commands as
-they access the database.
-
-With no argument, use prints the working pool and branch as well as the
-location of the current database.
-
-With an argument of the form "pool", use sets the working pool as indicated
-and the working branch to "main".
-
-With an argument of the form "pool@branch", use sets the working pool and
-branch as indicated.
-
-With an argument of the form "@branch", use sets only the working branch.
-The working pool must already be set.
-
-The pool must be the name or ID of an existing pool.  The branch must be
-the name of an existing branch or a commit ID.
-
-Any command that relies upon HEAD can also be run with the -use option
-to refer to a different HEAD without executing an explicit "use" command.
-While the use of HEAD is convenient for interactive CLI sessions,
-automation and orchestration tools are better off hard-wiring the
-HEAD references in each database command via -use.
-
-The use command merely checks that the branch exists and updates the
-file ~/.super_head.  This file simply contains a pointer to the HEAD branch
-and thus provides the default for the -use option.  This way, multiple working
-directories can contain different HEAD pointers (along with your local files)
-and you can easily switch between windows without having to continually
-re-specify a new HEAD.  Unlike Git, all the committed pool data remains
-in the database and is not copied to this local directory.
+See https://superdb.org/command/db.html#super-db-use
 `,
 	New: New,
 }

--- a/cmd/super/db/vacate/command.go
+++ b/cmd/super/db/vacate/command.go
@@ -13,18 +13,7 @@ var spec = &charm.Spec{
 	Usage: "vacate [options] commit",
 	Short: "compact a pool's commit history by squashing old commit objects",
 	Long: `
-The vacate command compacts the commit history by squashing all of the commit
-objects in the history up to the indicated commit and removing the old commits.
-No other commit objects in the pool may point at any of the squashed commits.
-In particular, no branch may point to any commit that would be deleted.
-
-The branch history may contain pointers to old commit objects, but any attempt
-to access them will fail as the underlying commit history will be no longer available.
-
-DANGER ZONE.
-There is no prompting or second chances here so use carefully.
-Once the pool's commit history has been squashed and old commits is deleted,
-they cannot be recovered.
+See https://superdb.org/command/db.html#super-db-vacate
 `,
 	New: New,
 }

--- a/cmd/super/db/vacuum/command.go
+++ b/cmd/super/db/vacuum/command.go
@@ -17,12 +17,7 @@ var spec = &charm.Spec{
 	Usage: "vacuum [options]",
 	Short: "clear space by removing unreferenced objects",
 	Long: `
-"super db vacuum" clears up space in a pool by removing objects that are not visible 
-from a pool's branch or commit.
-
-DANGER ZONE:
-Running this command will permanently delete objects referenced in 
-previous commits causing missing data when time traveling to those commits.
+See https://superdb.org/command/db.html#super-db-vacuum
 `,
 	New: New,
 }

--- a/cmd/super/root/command.go
+++ b/cmd/super/root/command.go
@@ -30,65 +30,7 @@ var Super = &charm.Spec{
 	Short:       "process data with SuperSQL queries",
 	HiddenFlags: "cpuprofile,memprofile,trace",
 	Long: `
-The "super" command provides a way to process data in diverse input formats,
-providing search, analytics, and extensive transformations using
-the SuperSQL query language.
-A query typically applies Boolean logic or keyword search to filter
-the input and then transforms or analyzes the filtered stream.
-Output is written to one or more files or to standard output.
-
-A query is comprised of one or more operators interconnected
-into a pipeline using the pipe symbol "|" or the alternate "|>".
-See https://superdb.org
-for details.  The "select" and "from" operators provide backward
-compatibility with SQL. In fact, you can use SQL exclusively and
-avoid pipeline operators altogether if you prefer.
-
-Supported file formats include Arrow, CSV, JSON, Parquet,
-Super JSON, Super Binary, Super Columnar, and Zeek TSV.
-
-Input files may be file system paths;
-"-" for standard input; or HTTP, HTTPS, or S3 URLs.
-For most types of data, the input format is automatically detected.
-If multiple files are specified, each file format is determined independently
-so you can mix and match input types.  If multiple files are concatenated
-into a stream and presented as standard input, the files must all be of the
-same type as the beginning of the stream will determine the format.
-
-If no input file is specified, the default of a single null input value will be
-fed to the query.  This is analogous to SQL's default input of a single
-empty input row.
-
-Output is sent to standard output unless an output file is specified with -o.
-Some output formats like Parquet are based on schemas and require all
-data in the output to conform to the same schema.  To handle this, you can
-either fuse the data into a union of all the record types present
-(presuming all the output values are records) or you can specify the -split
-flag to indicate a destination directory for separate output files for each
-output type.  This flag may be used in combination with -o, which
-provides the prefix for the file path, e.g.,
-
-  super -f parquet -split out -o example-output input.bsup
-
-When writing to stdout and stdout is a terminal, the default output format is Super JSON.
-Otherwise, the default format is Super Binary.  In either case, the default
-may be overridden with -f, -s, or -S.
-
-The query text is comprised of text specified by -c and source files
-specified by -I.  Both -c and -I may appear multiple times and the
-query text is concatenated in left-to-right order with intervening newlines.
-Any error messages are properly collated to the included file
-in which they occurred.
-
-The runtime processes input natively as super-structured data so if you intend to run
-many queries over the same data, you will see substantial performance gains
-by converting your data to the Super Binary format, e.g.,
-
-  super -f bsup input.any > fast.bsup
-
-  super -c <query> fast.bsup
-
-Please see https://github.com/brimdata/super for more information.
+See https://superdb.org/command/super.html
 `,
 	New:          New,
 	InternalLeaf: true,


### PR DESCRIPTION
This commit simplifies the command docs by having just one copy that describes each command and including a URL to superdb.org in the terminal help text.  We moved some text that was in the terminal help to the book and swapped the order of "super db serve" and "super db use" because they were out of order.  We didn't update "super dev" because it's not documented in the book yet.
