### PR TITLE
fix bug with type checking case/cond branches

### DIFF
--- a/compiler/semantic/ztests/checker-case.yaml
+++ b/compiler/semantic/ztests/checker-case.yaml
@@ -1,0 +1,42 @@
+script: |
+  super -s -I walk.spq in.sup
+  ! super -s -I fail.spq in.sup
+
+inputs:
+  - name: walk.spq
+    data: |
+      fn walk(node, visit):
+        case kind(node)
+        when "array" then
+          [unnest node | walk(this, visit)]
+        when "record" then
+          unflatten([unnest flatten(node) | {key,value:walk(value, visit)}])
+        when "union" then
+          walk(under(node), visit)
+        else visit(node)
+        end
+      fn addOne(node): case typeof(node) when <int64> then node+1 else node end
+      values walk(this, &addOne)
+  - name: fail.spq
+    data: |
+      values
+        case typeof(this)
+        when <string> then this+1
+        else this+2
+        end
+  - name: in.sup
+    data: |
+      {n:1}
+
+outputs:
+  - name: stdout
+    data: |
+      {n:2}
+  - name: stderr
+    data: |
+      type mismatch: {n:int64} + int64 in fail.spq at line 4, column 8:
+        else this+2
+             ~~~~~~
+      type mismatch: {n:int64} + int64 in fail.spq at line 3, column 22:
+        when <string> then this+1
+                           ~~~~~~

--- a/compiler/semantic/ztests/checker-cond-fail.yaml
+++ b/compiler/semantic/ztests/checker-cond-fail.yaml
@@ -1,0 +1,17 @@
+script: |
+  ! super -s -c "values has(n) ? this+1 : this+2" in.sup
+
+inputs:
+  - name: in.sup
+    data: |
+      {n:1}
+
+outputs:
+  - name: stderr
+    data: |
+      type mismatch: {n:int64} + int64 at line 1, column 17:
+      values has(n) ? this+1 : this+2
+                      ~~~~~~
+      type mismatch: {n:int64} + int64 at line 1, column 26:
+      values has(n) ? this+1 : this+2
+                               ~~~~~~


### PR DESCRIPTION
This commit fixes a type checking problem where the type checker was too aggresive in checking all branches of conditional expressions. Instead, we require that just one branch is clean.  If all the branches have errors, then we report the errors and the query fails to compile.

We will later add a strict-mode of type checking that requires type assertions when needed and all the branches must pass, similar to the relational model.

Fixes #6563