### PR TITLE
Re-initialize changelog for SuperDB release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - 2026-01-30
 
 ### Added
-- Initial release (see https://superdb.org/intro.html)
+- Initial release (see the [project documentation](https://superdb.org/intro.html))


### PR DESCRIPTION
This is apparently how all the cool kids start changelogs nowdays. Some apparently also include a bullet list of major features, but like @mccanne did with the command help it felt appropriate to link off to the docs rather than create another redundant summary.