### PR TITLE
docs: Update signature for bucket()

### DIFF
--- a/book/src/super-sql/functions/time/bucket.md
+++ b/book/src/super-sql/functions/time/bucket.md
@@ -5,16 +5,15 @@ quantize a time or duration value into buckets of equal time spans
 ## Synopsis
 
 ```
-bucket(val: time, span: duration|number) -> time
-bucket(val: duration, span: duration|number) -> duration
+bucket(val: time, span: duration) -> time
+bucket(val: duration, span: duration) -> duration
 ```
 
 ## Description
 
 The `bucket` function quantizes a time or duration `val`
-(or value that can be coerced to time) into buckets that
-are equally spaced as specified by `span` where the bucket boundary
-aligns with 0.
+into buckets that are equally spaced as specified by `span`
+where the bucket boundary aligns with 0.
 
 ## Examples
 


### PR DESCRIPTION
Update the docs for the bucket function to reflect that the second argument must be a duration (number values are no longer allowed).