### PR TITLE
In intro doc, adjust ClickHouse command line and expected error

### DIFF
--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -238,8 +238,8 @@ ClickHouse provides a secondary type function `dynamicType()`
 to get at the underlying type,
 but we can't use that function on the top-level value
 ```sh
-$ clickhouse -q "SELECT dynamicType(*) FROM 'example.json'"
-Code: 43. DB::Exception: First argument for function dynamicType must be Dynamic, got Array(Dynamic) instead: In scope SELECT toTypeName(*), dynamicType(*) FROM `example.json`. (ILLEGAL_TYPE_OF_ARGUMENT)
+$ clickhouse -q "SELECT dynamicType(a) FROM 'example.json'"
+Code: 43. DB::Exception: First argument for function dynamicType must be Dynamic, got Array(Dynamic) instead: In scope SELECT dynamicType(a) FROM `example.json`. (ILLEGAL_TYPE_OF_ARGUMENT)
 ```
 Instead we must ask for the type of the array element
 ```sh


### PR DESCRIPTION
While repeating some examples from the intro doc, I spotted that the error message we were showing as returned by ClickHouse included a reference to having called `toTypeName` that didn't match with the query in the command line, so I trimmed that. That also led me to notice the command was referring to `*` while the example commands both above and below it in the doc referenced field `a` by name, so I made that adjustment as well.
