### PR TITLE
Drop quotes in DuckDB string output

### DIFF
--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -155,12 +155,12 @@ relational column called `a` is an array &mdash; but leaves the contents
 of the array as the non-inferred type JSON:
 ```sh
 $ duckdb -c "SELECT * FROM 'example.json'"
-┌──────────────┐
-│      a       │
-│    json[]    │
-├──────────────┤
-│ [1, '"foo"'] │
-└──────────────┘
+┌────────────┐
+│     a      │
+│   json[]   │
+├────────────┤
+│ [1, "foo"] │
+└────────────┘
 ```
 DataFusion simply fails with an error:
 ```sh


### PR DESCRIPTION
While I'm not certain which version of DuckDB @mccanne was using when he captured the DuckDB output shown in the "intro" doc, it does seem like they've recently made a change to drop single quotes here, so I've updated the text to match.

```
$ duckdb-v1.3.2 -c "SELECT * FROM 'example.json'"
┌──────────────┐
│      a       │
│    json[]    │
├──────────────┤
│ [1, '"foo"'] │
└──────────────┘

$ duckdb-v1.4.4 -c "SELECT * FROM 'example.json'"
┌────────────┐
│     a      │
│   json[]   │
├────────────┤
│ [1, "foo"] │
└────────────┘
```