### PR TITLE
Remove uses of SUPER_VAM=1

### DIFF
--- a/book/src/tutorials/performance.md
+++ b/book/src/tutorials/performance.md
@@ -532,7 +532,7 @@ Benchmark 1: super -s -I /mnt/tmpdir/tmp.pDeSZCTa2V
 
 About to execute
 ================
-SUPER_VAM=1 super -s -I /mnt/tmpdir/tmp.AYZIh6yi2s
+super -s -I /mnt/tmpdir/tmp.AYZIh6yi2s
 
 With query
 ==========
@@ -540,8 +540,8 @@ SELECT count()
 FROM '/mnt/gha.parquet'
 WHERE grep('in case you have any feedback 😊', payload.pull_request.body)
 
-+ hyperfine --show-output --warmup 1 --runs 1 --time-unit second 'SUPER_VAM=1 super -s -I /mnt/tmpdir/tmp.AYZIh6yi2s'
-Benchmark 1: SUPER_VAM=1 super -s -I /mnt/tmpdir/tmp.AYZIh6yi2s
++ hyperfine --show-output --warmup 1 --runs 1 --time-unit second 'super -s -I /mnt/tmpdir/tmp.AYZIh6yi2s'
+Benchmark 1: super -s -I /mnt/tmpdir/tmp.AYZIh6yi2s
 {count:2}
   Time (abs ≡):        40.838 s               [User: 292.674 s, System: 18.797 s]
 ```
@@ -678,7 +678,7 @@ Benchmark 1: super -s -I /mnt/tmpdir/tmp.jJSibCjp8r
 
 About to execute
 ================
-SUPER_VAM=1 super -s -I /mnt/tmpdir/tmp.evXq1mxkI0
+super -s -I /mnt/tmpdir/tmp.evXq1mxkI0
 
 With query
 ==========
@@ -686,8 +686,8 @@ SELECT count()
 FROM '/mnt/gha.parquet'
 WHERE grep('in case you have any feedback 😊')
 
-+ hyperfine --show-output --warmup 1 --runs 1 --time-unit second 'SUPER_VAM=1 super -s -I /mnt/tmpdir/tmp.evXq1mxkI0'
-Benchmark 1: SUPER_VAM=1 super -s -I /mnt/tmpdir/tmp.evXq1mxkI0
++ hyperfine --show-output --warmup 1 --runs 1 --time-unit second 'super -s -I /mnt/tmpdir/tmp.evXq1mxkI0'
+Benchmark 1: super -s -I /mnt/tmpdir/tmp.evXq1mxkI0
 {count:3}
   Time (abs ≡):        55.081 s               [User: 408.337 s, System: 18.597 s]
 ```
@@ -805,7 +805,7 @@ Benchmark 1: super -s -I /mnt/tmpdir/tmp.AbeKpBbYW8
 
 About to execute
 ================
-SUPER_VAM=1 super -s -I /mnt/tmpdir/tmp.5xTnB02WgG
+super -s -I /mnt/tmpdir/tmp.5xTnB02WgG
 
 With query
 ==========
@@ -813,8 +813,8 @@ SELECT count()
 FROM '/mnt/gha.parquet'
 WHERE actor.login='johnbieren'
 
-+ hyperfine --show-output --warmup 1 --runs 1 --time-unit second 'SUPER_VAM=1 super -s -I /mnt/tmpdir/tmp.5xTnB02WgG'
-Benchmark 1: SUPER_VAM=1 super -s -I /mnt/tmpdir/tmp.5xTnB02WgG
++ hyperfine --show-output --warmup 1 --runs 1 --time-unit second 'super -s -I /mnt/tmpdir/tmp.5xTnB02WgG'
+Benchmark 1: super -s -I /mnt/tmpdir/tmp.5xTnB02WgG
 {count:879}
   Time (abs ≡):         0.303 s               [User: 0.792 s, System: 0.240 s]
 ```
@@ -981,7 +981,7 @@ Benchmark 1: super -s -I /mnt/tmpdir/tmp.QMhaBvUi2y
 
 About to execute
 ================
-SUPER_VAM=1 super -s -I /mnt/tmpdir/tmp.yfAdMeskPR
+super -s -I /mnt/tmpdir/tmp.yfAdMeskPR
 
 With query
 ==========
@@ -990,8 +990,8 @@ FROM '/mnt/gha.parquet'
 WHERE repo.name='duckdb/duckdb'
 GROUP BY type
 
-+ hyperfine --show-output --warmup 1 --runs 1 --time-unit second 'SUPER_VAM=1 super -s -I /mnt/tmpdir/tmp.yfAdMeskPR'
-Benchmark 1: SUPER_VAM=1 super -s -I /mnt/tmpdir/tmp.yfAdMeskPR
++ hyperfine --show-output --warmup 1 --runs 1 --time-unit second 'super -s -I /mnt/tmpdir/tmp.yfAdMeskPR'
+Benchmark 1: super -s -I /mnt/tmpdir/tmp.yfAdMeskPR
 {type:"PushEvent",count:15}
 {type:"IssuesEvent",count:9}
 {type:"WatchEvent",count:29}
@@ -1166,7 +1166,7 @@ Benchmark 1: super -s -I /mnt/tmpdir/tmp.JzRx6IABuv
 
 About to execute
 ================
-SUPER_VAM=1 super -s -I /mnt/tmpdir/tmp.djiUKncZ0T
+super -s -I /mnt/tmpdir/tmp.djiUKncZ0T
 
 With query
 ==========
@@ -1177,8 +1177,8 @@ FROM '/mnt/gha.parquet'
 | ORDER BY count DESC
 | LIMIT 5
 
-+ hyperfine --show-output --warmup 1 --runs 1 --time-unit second 'SUPER_VAM=1 super -s -I /mnt/tmpdir/tmp.djiUKncZ0T'
-Benchmark 1: SUPER_VAM=1 super -s -I /mnt/tmpdir/tmp.djiUKncZ0T
++ hyperfine --show-output --warmup 1 --runs 1 --time-unit second 'super -s -I /mnt/tmpdir/tmp.djiUKncZ0T'
+Benchmark 1: super -s -I /mnt/tmpdir/tmp.djiUKncZ0T
 {assignee:"poad",count:1966}
 {assignee:"vinayakkulkarni",count:508}
 {assignee:"tmtmtmtm",count:356}

--- a/compiler/ztests/par-aggregate-func.yaml
+++ b/compiler/ztests/par-aggregate-func.yaml
@@ -4,7 +4,7 @@ script: |
   super db create -q -orderby s:asc test
   super db compile -P 2 -C "from test | union(s) by n:=len(s)" | sed -e 's/pool .*/.../'
   echo ===
-  SUPER_VAM=1 super compile -C -P 2 -dynamic 'from test.csup | summarize count(a) by b'
+  super compile -C -P 2 -dynamic 'from test.csup | summarize count(a) by b'
 
 outputs:
   - name: stdout

--- a/compiler/ztests/par-concurrency.yaml
+++ b/compiler/ztests/par-concurrency.yaml
@@ -1,5 +1,4 @@
 script: |
-  export SUPER_VAM=1
   echo === -P 2
   super compile -C -P 2 -dynamic 'fork ( from a.csup | sort b ) ( from c.csup | sort d )'
   echo === -P 5

--- a/compiler/ztests/par-count.yaml
+++ b/compiler/ztests/par-count.yaml
@@ -1,7 +1,7 @@
 # Test ensures that flowgraphs utilizing the count operator
 # are not parallelized.
 script: |
-  SUPER_VAM=1 super compile -C -P 2 'from /dev/null | count {...this,row_number} | aggregate sum(x)'
+  super compile -vam -C -P 2 'from /dev/null | count {...this,row_number} | aggregate sum(x)'
 
 outputs:
   - name: stdout

--- a/compiler/ztests/par-sort.yaml
+++ b/compiler/ztests/par-sort.yaml
@@ -1,5 +1,5 @@
 script: |
-  SUPER_VAM=1 super compile -C -P 2 -dynamic 'from test.csup | sort a, b desc nulls last | values c'
+  super compile -C -P 2 -dynamic 'from test.csup | sort a, b desc nulls last | values c'
 
 outputs:
   - name: stdout

--- a/compiler/ztests/par-top.yaml
+++ b/compiler/ztests/par-top.yaml
@@ -8,7 +8,7 @@ script: |
   echo ===
   super db compile -C -P 2 'from test | top 3 b desc' | sed -e 's/pool .*/.../'
   echo ===
-  SUPER_VAM=1 super compile -C -P 2 -dynamic 'from test.csup | top 3 a, b desc nulls last | values c'
+  super compile -C -P 2 -dynamic 'from test.csup | top 3 a, b desc nulls last | values c'
 
 outputs:
   - name: stdout

--- a/compiler/ztests/pruner-in.yaml
+++ b/compiler/ztests/pruner-in.yaml
@@ -1,5 +1,4 @@
 script: |
-  export SUPER_VAM=1
   super compile -C -O -dynamic 'from test.csup | x in ["foo","bar"]'
   echo // ===
   # Test that we still optimize for a tuple which gets translated into a record.

--- a/compiler/ztests/pruner-regexp.yaml
+++ b/compiler/ztests/pruner-regexp.yaml
@@ -1,5 +1,4 @@
 script: |
-  export SUPER_VAM=1
   super compile -C -O -dynamic 'from test.csup | where x LIKE "cslab%"'
   echo // ===
   super compile -C -O -dynamic 'from test.csup | where grep("^csla[bB].*", x)'

--- a/runtime/vam/op/ztests/agg-count-by-string.yaml
+++ b/runtime/vam/op/ztests/agg-count-by-string.yaml
@@ -7,7 +7,6 @@ script: |
     seq -f '{x: "0", y: "1", z: "%.0f"}' 257
     seq -f '{x: "0", y: "2", z: "%.0f"}' 257
   } | super -o t.csup -f csup -
-  export SUPER_VAM=1
   super -s -c 'from t.csup | count() by x'
   super -s -c 'from t.csup | count() by y | sort y'
   super -s -c 'from t.csup | count(distinct x) by y | sort y'

--- a/runtime/vam/op/ztests/agg-sum.yaml
+++ b/runtime/vam/op/ztests/agg-sum.yaml
@@ -7,7 +7,6 @@ script: |
     seq -f '{x: 0, y: %.0f}' 257
     seq -f '{x: 1, y: %.0f}' 257
   } | super -o t.csup -f csup -
-  export SUPER_VAM=1
   super -s -c 'from t.csup | sum(x)'
   super -s -c 'from t.csup | sum(y)'
 

--- a/runtime/vam/op/ztests/arith.yaml
+++ b/runtime/vam/op/ztests/arith.yaml
@@ -2,7 +2,7 @@
 
 script: |
   super -o t.csup -f csup -
-  SUPER_VAM=1 super -s -c "from t.csup | values this,a+a,a+b,b+a,b+b"
+  super -s -c "from t.csup | values this,a+a,a+b,b+a,b+b"
 
 inputs:
   - name: stdin

--- a/runtime/vam/op/ztests/values.yaml
+++ b/runtime/vam/op/ztests/values.yaml
@@ -1,6 +1,6 @@
 script: |
   super -o t.csup -f csup -
-  SUPER_VAM=1 super -s -c "from t.csup | values a >= 1, a >= b, a >= 1 or a >= b"
+  super -s -c "from t.csup | values a >= 1, a >= b, a >= 1 or a >= b"
 
 inputs:
   - name: stdin

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -355,7 +355,7 @@ func (z *ZTest) RunScript(ctx context.Context, shellPath, testDir string, tempDi
 	if serr != nil {
 		serr = fmt.Errorf("=== sequence ===\n%w", serr)
 	}
-	verr := runsh(ctx, shellPath, testDir, tempDir(), z, "SUPER_VAM=1")
+	verr := runsh(ctx, shellPath, testDir, tempDir(), z, "SUPER_RUNTIME=vam")
 	if verr != nil {
 		verr = fmt.Errorf("=== vector ===\n%w", verr)
 	}


### PR DESCRIPTION
A previous commit got rid of the environment variable SUPER_VAM to activate the vector runtime. Since vector runtime is now automatically enabled for CSUP and Parquet remove the environment variable where those files are used in tests and use SUPER_RUNTIME=vam elsewhere.