### PR TITLE
vam.regexp: Only shorten nulls if nulls is non-zero

### DIFF
--- a/runtime/vam/expr/function/regexp.go
+++ b/runtime/vam/expr/function/regexp.go
@@ -56,7 +56,9 @@ func (r *Regexp) Call(args ...vector.Any) vector.Any {
 		}
 		out.Offsets = append(out.Offsets, inner.Len())
 	}
-	out.Nulls.Shorten(out.Len())
+	if !out.Nulls.IsZero() {
+		out.Nulls.Shorten(out.Len())
+	}
 	if len(errs) > 0 {
 		return vector.Combine(out, errs, vector.NewVecWrappedError(r.sctx, errMsg, vector.Pick(regVec, errs)))
 	}


### PR DESCRIPTION
This was causing panics on inputs that have no nulls. Testing on this will occur once we enable vector runtime on mdtest (forthcoming).