### PR TITLE
Makefile: give accurate error message if go not in PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ VERSION = $(shell git describe --tags --dirty --always)
 LDFLAGS = -s -X github.com/brimdata/super/cli.version=$(VERSION)
 BUILD_COMMANDS = ./cmd/super
 
+ifeq ($(GO),$(shell command -v go 2>/dev/null))
+  $(error Go is not installed or not in PATH)
+endif
+
 ifeq "$(filter-out 386 arm mips mipsle, $(shell go env GOARCH))" ""
 $(error 32-bit architectures are unsupported; see https://github.com/brimdata/super/issues/4044)
 endif


### PR DESCRIPTION
Tried building for the first time in eons and was surprised by the "32-bit unsupported" error (I didn't have Go installed on this instance).