### PR TITLE
vam.Cast: Fix casting to a named primitive

### DIFF
--- a/runtime/vam/expr/cast/cast.go
+++ b/runtime/vam/expr/cast/cast.go
@@ -8,6 +8,9 @@ import (
 )
 
 func To(sctx *super.Context, vec vector.Any, typ super.Type) vector.Any {
+	if named, ok := typ.(*super.TypeNamed); ok {
+		return castNamed(sctx, vec, named)
+	}
 	vec = vector.Under(vec)
 	switch vec.Kind() {
 	case vector.KindNull:
@@ -85,6 +88,16 @@ func castConst(sctx *super.Context, vec *vector.Const, typ super.Type) vector.An
 		return errCastFailed(sctx, vec, typ, "")
 	}
 	return vector.NewConst(val, vec.Len())
+}
+
+func castNamed(sctx *super.Context, vec vector.Any, named *super.TypeNamed) vector.Any {
+	return vector.Apply(false, func(vecs ...vector.Any) vector.Any {
+		vec := vecs[0]
+		if vec.Kind() == vector.KindError {
+			return vec
+		}
+		return vector.NewNamed(named, vec)
+	}, To(sctx, vec, named.Type))
 }
 
 func errCastFailed(sctx *super.Context, vec vector.Any, typ super.Type, msgSuffix string) vector.Any {

--- a/runtime/ztests/expr/cast/named.yaml
+++ b/runtime/ztests/expr/cast/named.yaml
@@ -21,3 +21,20 @@ output: |
   null::=named
   error("missing")
   error("foo")
+
+---
+
+# Test casting to a named type keeps the named type.
+spq: |
+  type foo=string
+  values {str:cast(this, "foo"), named:cast(this, foo)}
+
+vector: true
+
+input: |
+  1
+  2
+
+output: |
+  {str:1::=foo,named:"1"::=foo}
+  {str:2::=foo,named:"2"::=foo}


### PR DESCRIPTION
This commit fixes an issue with cast in vector runtime where casting to a named primitive would lose the named type.