### PR TITLE
vam.rename: update type of nested records

### DIFF
--- a/runtime/vam/expr/renamer.go
+++ b/runtime/vam/expr/renamer.go
@@ -1,6 +1,8 @@
 package expr
 
 import (
+	"slices"
+
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/runtime/sam/expr"
 	"github.com/brimdata/super/vector"
@@ -31,5 +33,15 @@ func (r *Renamer) eval(vecs ...vector.Any) vector.Any {
 	if err != nil {
 		return vector.NewWrappedError(r.sctx, err.Error(), vec)
 	}
-	return vector.NewRecord(val.Type().(*super.TypeRecord), recVec.Fields, recVec.Len(), recVec.Nulls)
+	return changeRecordType(recVec, val.Type().(*super.TypeRecord))
+}
+
+func changeRecordType(vec *vector.Record, typ *super.TypeRecord) *vector.Record {
+	fields := slices.Clone(vec.Fields)
+	for i, f := range typ.Fields {
+		if rtyp, ok := f.Type.(*super.TypeRecord); ok {
+			fields[i] = changeRecordType(vec.Fields[i].(*vector.Record), rtyp)
+		}
+	}
+	return vector.NewRecord(typ, fields, vec.Len(), vec.Nulls)
 }

--- a/runtime/ztests/op/rename-nested.yaml
+++ b/runtime/ztests/op/rename-nested.yaml
@@ -11,3 +11,16 @@ output: |
   {net:{src:10.164.94.120,orig_p:39681::(port=uint16),dst:10.47.3.155,resp_p:3389::port}}
   {net:{src:10.164.94.121,orig_p:39681::(port=uint16),dst:10.47.3.155,resp_p:3390::port}}
   {net:{orig_p:39681::(port=uint16),resp_p:3389::port}}
+
+---
+
+# Test nested renamed records in vector runtime are deeply renamed.
+spq: rename x.x:=x.y | values x
+
+vector: true
+
+input: |
+  {x:{y:1}}
+
+output: |
+  {x:1}


### PR DESCRIPTION
This commit fixes an issue in the vector runtime version of the rename operator where nested records were not getting assigned updated types.