### PR TITLE
Include @main in "go get" example shown in docs

### DIFF
--- a/book/src/dev/libraries/go.md
+++ b/book/src/dev/libraries/go.md
@@ -20,7 +20,7 @@ Some of the key packages are:
 
 To install in your local Go project, simply run:
 ```
-go get github.com/brimdata/super
+go get github.com/brimdata/super@main
 ```
 
 ## Examples
@@ -68,6 +68,7 @@ cd example
 go mod init example
 cat > main.go
 # [paste from above]
+go get github.com/brimdata/super@main
 go mod tidy
 ```
 To run type:


### PR DESCRIPTION
The Go module ecosystem unfortunately does not play well with our having used the `v0.1.0` tag for our recent first GA release of SuperDB, as it was used once years ago for the release of a different tool in this same repo. Since SuperDB is still pre-`v1.0`, for now we can just advise Go developers to use `@main` when doing `go get` to avoid the problem. We have ideas for how we might resolve the tag collision in the future.