### PR TITLE
vam.Dequiet: Do not rip unions on record fields

### DIFF
--- a/runtime/vam/expr/quiet.go
+++ b/runtime/vam/expr/quiet.go
@@ -57,7 +57,7 @@ func (d *Dequiet) rec(vec vector.Any) vector.Any {
 		}
 		vecs = append(vecs, d.dequiet(vec))
 	}
-	return vector.Apply(true, func(vecs ...vector.Any) vector.Any {
+	return vector.Apply(false, func(vecs ...vector.Any) vector.Any {
 		var fields []super.Field
 		var vals []vector.Any
 		for i, vec := range vecs {

--- a/runtime/ztests/op/cut-quiet.yaml
+++ b/runtime/ztests/op/cut-quiet.yaml
@@ -55,3 +55,16 @@ input: |
 output: |
   {ports:{orig_p:1::(port=uint16),resp_p:2::port},resp_p:2::port}
   {ports:[3::(port=uint16),4::port]}
+
+---
+
+# Test dequiet keeps unions.
+spq: cut x,quiet(y)
+
+vector: true
+
+input: |
+  {x:1::(int64|null)}
+
+output: |
+  {x:1::(int64|null)}


### PR DESCRIPTION
This commit fixes an issue with vam.Dequiet where record fields would get deunioned causing a mismatch between the record type and field types.