### PR TITLE
runtime/vam/expre: preserve unspread union in array expression

### DIFF
--- a/runtime/vam/expr/arrayexpr.go
+++ b/runtime/vam/expr/arrayexpr.go
@@ -64,7 +64,7 @@ func buildList(sctx *super.Context, elems []ListElem, in []vector.Any) ([]uint32
 			}
 		}
 		vecTags = append(vecTags, uint32(len(vecs)))
-		if union, ok := vec.(*vector.Union); ok {
+		if union, ok := vec.(*vector.Union); ok && elem.Spread != nil {
 			vecs = append(vecs, union.Values...)
 			unionTags[i] = union.Tags
 		} else {

--- a/runtime/ztests/expr/array-expr.yaml
+++ b/runtime/ztests/expr/array-expr.yaml
@@ -11,6 +11,7 @@ input: |
   // heterogenous
   {a:"foo",b:1,c:127.0.0.1}
   {a:"bar",b:2,c:127.0.0.2}
+  {a:0,b:"1"::(int64|string),c:null::(int64|string|null)}
 
 output: |
   [error("missing"),error("quiet"),null]
@@ -20,6 +21,7 @@ output: |
   [|{"key":"k1"}|,null,|{"key":"k3"}|]
   ["foo",1,127.0.0.1]
   ["bar",2,127.0.0.2]
+  [0,"1"::(int64|string),null::(int64|string|null)]
 
 ---
 


### PR DESCRIPTION
In the array expression "[...x, y]", union values in x should be unwrapped but a union value in y should be preserved as a union.  The vector runtime incorrectly unwraps it.  Fix that.