### PR TITLE
sup: omit decoration for self-describing error values

### DIFF
--- a/runtime/sam/expr/expr_test.go
+++ b/runtime/sam/expr/expr_test.go
@@ -526,7 +526,7 @@ func TestCasts(t *testing.T) {
 	testSuccessful(t, `("foo")::uint32`, "", `error({message:"cannot cast to uint32",on:"foo"})`)
 
 	// Test cast to int64
-	testSuccessful(t, "(this)::int64", "10000000000000000000::uint64", `error({message:"cannot cast to int64",on:10000000000000000000::uint64})::error({message:string,on:uint64})`)
+	testSuccessful(t, "(this)::int64", "10000000000000000000::uint64", `error({message:"cannot cast to int64",on:10000000000000000000::uint64})`)
 	testSuccessful(t, "(this)::int64", "1e+19", `error({message:"cannot cast to int64",on:1e+19})`)
 	testSuccessful(t, `("10000000000000000000")::int64`, "", `error({message:"cannot cast to int64",on:"10000000000000000000"})`)
 

--- a/runtime/ztests/expr/cast/int.yaml
+++ b/runtime/ztests/expr/cast/int.yaml
@@ -33,10 +33,10 @@ output: |
   1::int16
   1::int32
   1
-  error({message:"cannot cast to int8",on:10000000000000000000::uint64})::error({message:string,on:uint64})
-  error({message:"cannot cast to int16",on:10000000000000000000::uint64})::error({message:string,on:uint64})
-  error({message:"cannot cast to int32",on:10000000000000000000::uint64})::error({message:string,on:uint64})
-  error({message:"cannot cast to int64",on:10000000000000000000::uint64})::error({message:string,on:uint64})
+  error({message:"cannot cast to int8",on:10000000000000000000::uint64})
+  error({message:"cannot cast to int16",on:10000000000000000000::uint64})
+  error({message:"cannot cast to int32",on:10000000000000000000::uint64})
+  error({message:"cannot cast to int64",on:10000000000000000000::uint64})
   -1::int8
   -1::int16
   -1::int32

--- a/runtime/ztests/expr/function/quiet.yaml
+++ b/runtime/ztests/expr/function/quiet.yaml
@@ -17,7 +17,7 @@ output: |
   1
   [3,2,1,0]
   error("missing")::=foo
-  error("missing")::error(bar=string)
+  error("missing"::=bar)
   null
   error(null)
   error({x:"missing"})

--- a/runtime/ztests/expr/index.yaml
+++ b/runtime/ztests/expr/index.yaml
@@ -44,7 +44,7 @@ output: |
   error("missing")
   error({message:"index is not an integer",on:null})
   error({message:"index is not an integer",on:"hi"})
-  error({message:"cannot cast to int64",on:9223372036854775808::uint64})::error({message:string,on:uint64})
+  error({message:"cannot cast to int64",on:9223372036854775808::uint64})
   "foo"
   2
   1

--- a/runtime/ztests/expr/shape-cast-from-union.yaml
+++ b/runtime/ztests/expr/shape-cast-from-union.yaml
@@ -22,11 +22,11 @@ output: |
   error({message:"cannot cast to string",on:null})
   "1"
   "1"
-  error({message:"cannot cast to int64|string",on:1::int8::(int8|string)})::error({message:string,on:int8|string})
-  error({message:"cannot cast to int8|string",on:1::(int64|string)})::error({message:string,on:int64|string})
+  error({message:"cannot cast to int64|string",on:1::int8::(int8|string)})
+  error({message:"cannot cast to int8|string",on:1::(int64|string)})
   "one"
   ["1","one"]
-  [error({message:"cannot cast to int8|string",on:1::(int64|string)})::error({message:string,on:int64|string}),"one"::(int8|string)]
-  [error({message:"cannot cast to int8|int16",on:1::(int64|string)})::error({message:string,on:int64|string}),error({message:"cannot cast to int8|int16",on:"one"::(int64|string)})::error({message:string,on:int64|string})]
+  [error({message:"cannot cast to int8|string",on:1::(int64|string)}),"one"::(int8|string)]
+  [error({message:"cannot cast to int8|int16",on:1::(int64|string)}),error({message:"cannot cast to int8|int16",on:"one"::(int64|string)})]
   {a:["1","one"]}
-  {a:[error({message:"cannot cast to int8|string",on:1::(int64|string)})::error({message:string,on:int64|string}),"one"::(int8|string)]}
+  {a:[error({message:"cannot cast to int8|string",on:1::(int64|string)}),"one"::(int8|string)]}

--- a/runtime/ztests/expr/unary-minus.yaml
+++ b/runtime/ztests/expr/unary-minus.yaml
@@ -35,15 +35,15 @@ output: |
   -1::int8
   1::int8
   -1::int8
-  error({message:"unary '-' underflow",on:-128::int8})::error({message:string,on:int8})
+  error({message:"unary '-' underflow",on:-128::int8})
   -1::int16
   1::int16
   -1::int16
-  error({message:"unary '-' underflow",on:-32768::int16})::error({message:string,on:int16})
+  error({message:"unary '-' underflow",on:-32768::int16})
   -1::int32
   1::int32
   -1::int32
-  error({message:"unary '-' underflow",on:-2147483648::int32})::error({message:string,on:int32})
+  error({message:"unary '-' underflow",on:-2147483648::int32})
   -1
   1
   -1

--- a/runtime/ztests/op/fuse-basic.yaml
+++ b/runtime/ztests/op/fuse-basic.yaml
@@ -84,5 +84,5 @@ input: |
   error("s")
 
 output: |
-  error(1)::error(int64|string)
-  error("s")::error(int64|string)
+  error(1::(int64|string))
+  error("s"::(int64|string))

--- a/sup/formatter.go
+++ b/sup/formatter.go
@@ -164,7 +164,7 @@ func (f *Formatter) formatValue(indent int, typ super.Type, bytes scode.Bytes, p
 		f.build("error")
 		f.endColor()
 		f.build("(")
-		f.formatValue(indent, t.Type, bytes, known, parentImplied, false)
+		f.formatValue(indent, t.Type, bytes, known, parentImplied, true)
 		f.build(")")
 	case *super.TypeOfType:
 		f.startColor(color.Gray(200))

--- a/sup/sup.go
+++ b/sup/sup.go
@@ -49,7 +49,7 @@ func SelfDescribing(typ super.Type) bool {
 		return true
 	}
 	switch typ := typ.(type) {
-	case *super.TypeRecord, *super.TypeArray, *super.TypeSet, *super.TypeMap:
+	case *super.TypeRecord, *super.TypeArray, *super.TypeSet, *super.TypeMap, *super.TypeError:
 		return true
 	case *super.TypeNamed:
 		return SelfDescribing(typ.Type)

--- a/sup/ztests/error.yaml
+++ b/sup/ztests/error.yaml
@@ -1,0 +1,11 @@
+spq: pass
+
+input: &input |
+  error(null)
+  error({})
+  error(1::(int64|string))
+  error(2::=named)
+  error(3)::=named
+  error({a:1::=named,b:2::named})
+
+output: *input


### PR DESCRIPTION
The SUP formatter omits decoration for most self-describing values (i.e., whose type can be derived entirely from the value's SUP representation) but not for errors.  Omit decoration for errors too.