### PR TITLE
change BSUP union tag to uvarint in implementation

### DIFF
--- a/compiler/semantic/sem/expr.go
+++ b/compiler/semantic/sem/expr.go
@@ -530,13 +530,8 @@ func setToExpr(loc ast.Node, typ *super.TypeSet, bytes scode.Bytes) Expr {
 }
 
 func unionToExpr(loc ast.Node, typ *super.TypeUnion, bytes scode.Bytes) Expr {
-	it := bytes.Iter()
-	tag := super.DecodeInt(it.Next())
-	inner, err := typ.Type(int(tag))
-	if err != nil {
-		panic(err)
-	}
-	return NewCast(loc, valueToExpr(loc, inner, it.Next()), typ)
+	innerType, innerBytes := typ.Untag(bytes)
+	return NewCast(loc, valueToExpr(loc, innerType, innerBytes), typ)
 }
 
 func mapToExpr(loc ast.Node, typ *super.TypeMap, bytes scode.Bytes) Expr {

--- a/complex.go
+++ b/complex.go
@@ -332,7 +332,7 @@ func (t *TypeUnion) TagOf(typ Type) int {
 // type from the union.  Untag panics if the tag is invalid.
 func (t *TypeUnion) Untag(bytes scode.Bytes) (Type, scode.Bytes) {
 	it := bytes.Iter()
-	tag := DecodeInt(it.Next())
+	tag := DecodeUint(it.Next())
 	inner, err := t.Type(int(tag))
 	if err != nil {
 		panic(err)
@@ -353,5 +353,5 @@ func BuildUnion(b *scode.Builder, tag int, val scode.Bytes) {
 
 func BeginUnion(b *scode.Builder, tag int) {
 	b.BeginContainer()
-	b.Append(EncodeInt(int64(tag)))
+	b.Append(EncodeUint(uint64(tag)))
 }

--- a/fuzz/fuzz.go
+++ b/fuzz/fuzz.go
@@ -252,8 +252,7 @@ func GenValue(b *bytes.Reader, context *super.Context, typ super.Type, builder *
 			builder.EndContainer()
 		case *super.TypeUnion:
 			tag := binary.LittleEndian.Uint64(GenBytes(b, 8)) % uint64(len(typ.Types))
-			builder.BeginContainer()
-			builder.Append(super.EncodeInt(int64(tag)))
+			super.BeginUnion(builder, int(tag))
 			GenValue(b, context, typ.Types[tag], builder)
 			builder.EndContainer()
 		default:

--- a/runtime/sam/expr/function/flatten.go
+++ b/runtime/sam/expr/function/flatten.go
@@ -74,16 +74,15 @@ func (n *Flatten) encode(fields []super.Field, inner super.Type, base field.Path
 			continue
 		}
 		typ := n.entryTypes[f.Type]
-		union, _ := inner.(*super.TypeUnion)
-		if union != nil {
-			n.BeginContainer()
-			n.Append(super.EncodeInt(int64(union.TagOf(typ))))
+		union, ok := inner.(*super.TypeUnion)
+		if ok {
+			super.BeginUnion(&n.Builder, union.TagOf(typ))
 		}
 		n.BeginContainer()
 		n.encodeKey(key)
 		n.Append(val)
 		n.EndContainer()
-		if union != nil {
+		if ok {
 			n.EndContainer()
 		}
 	}

--- a/sio/arrowio/writer.go
+++ b/sio/arrowio/writer.go
@@ -438,7 +438,7 @@ func (w *Writer) buildArrowValue(b array.Builder, typ super.Type, bytes scode.By
 		}
 	case *array.DenseUnionBuilder:
 		it := bytes.Iter()
-		tag := super.DecodeInt(it.Next())
+		tag := super.DecodeUint(it.Next())
 		typeCode := w.unionTagMappings[typ][tag]
 		b.Append(arrow.UnionTypeCode(typeCode))
 		w.buildArrowValue(b.Child(typeCode), typ.(*super.TypeUnion).Types[tag], it.Next())

--- a/sio/jsupio/reader.go
+++ b/sio/jsupio/reader.go
@@ -185,8 +185,7 @@ func (r *Reader) decodeUnion(builder *scode.Builder, typ *super.TypeUnion, body 
 	if err != nil {
 		return fmt.Errorf("bad tag for JSUP union value: %w", err)
 	}
-	builder.BeginContainer()
-	builder.Append(super.EncodeInt(int64(tag)))
+	super.BeginUnion(builder, tag)
 	if err := r.decodeValue(builder, inner, tuple[1]); err != nil {
 		return err
 	}

--- a/sup/builder.go
+++ b/sup/builder.go
@@ -216,16 +216,11 @@ func buildMap(b *scode.Builder, m *Map) error {
 }
 
 func buildUnion(b *scode.Builder, union *Union) error {
-	if tag := union.Tag; tag >= 0 {
-		b.BeginContainer()
-		b.Append(super.EncodeInt(int64(tag)))
-		if err := buildValue(b, union.Value); err != nil {
-			return err
-		}
-		b.EndContainer()
-	} else {
-		b.Append(nil)
+	super.BeginUnion(b, union.Tag)
+	if err := buildValue(b, union.Value); err != nil {
+		return err
 	}
+	b.EndContainer()
 	return nil
 }
 

--- a/vector/union.go
+++ b/vector/union.go
@@ -25,9 +25,8 @@ func (u *Union) Type() super.Type {
 }
 
 func (u *Union) Serialize(b *scode.Builder, slot uint32) {
-	b.BeginContainer()
 	tag := u.Typ.TagOf(u.TypeOf(slot))
-	b.Append(super.EncodeInt(int64(tag)))
+	super.BeginUnion(b, tag)
 	u.Dynamic.Serialize(b, slot)
 	b.EndContainer()
 }

--- a/walk.go
+++ b/walk.go
@@ -72,7 +72,7 @@ func walkUnion(typ *TypeUnion, body scode.Bytes, visit Visitor) error {
 		return errors.New("union has empty body")
 	}
 	it := body.Iter()
-	tag := DecodeInt(it.Next())
+	tag := DecodeUint(it.Next())
 	inner, err := typ.Type(int(tag))
 	if err != nil {
 		return err


### PR DESCRIPTION
The BSUP specification states that a union tag is encoded as a uvarint but the implementation encodes it as a varint.  Change the implementation to uvarint.

This is a backward-incompatible change.