### PR TITLE
allow SPQ cast of null to any type

### DIFF
--- a/context.go
+++ b/context.go
@@ -593,12 +593,12 @@ func (c *Context) WrapError(msg string, val Value) Value {
 	return NewValue(errType, b.Bytes())
 }
 
-func (c *Context) Nullable(typ Type) Type {
+func (c *Context) Nullable(typ Type) *TypeUnion {
 	var types []Type
 	if union, ok := TypeUnder(typ).(*TypeUnion); ok {
 		for _, t := range union.Types {
 			if t == TypeNull {
-				return typ
+				return union
 			}
 		}
 		types = slices.Clone(union.Types)

--- a/runtime/sam/expr/function/cast.go
+++ b/runtime/sam/expr/function/cast.go
@@ -50,6 +50,11 @@ func (c *cast) Cast(from super.Value, to super.Type) super.Value {
 		return from
 	case fromType.ID() == to.ID():
 		return super.NewValue(to, from.Bytes())
+	case fromType == super.TypeNull:
+		union := c.sctx.Nullable(to)
+		var b scode.Builder
+		super.BuildUnion(&b, union.TagOf(super.TypeNull), nil)
+		return super.NewValue(union, b.Bytes().Body())
 	}
 	switch to := to.(type) {
 	case *super.TypeRecord:

--- a/runtime/vam/expr/cast/cast.go
+++ b/runtime/vam/expr/cast/cast.go
@@ -14,7 +14,15 @@ func To(sctx *super.Context, vec vector.Any, typ super.Type) vector.Any {
 	vec = vector.Under(vec)
 	switch vec.Kind() {
 	case vector.KindNull:
-		return errCastFailed(sctx, vec, typ, "")
+		union := sctx.Nullable(typ)
+		tag := union.TagOf(super.TypeNull)
+		tags := make([]uint32, vec.Len())
+		for i := range vec.Len() {
+			tags[i] = uint32(tag)
+		}
+		vecs := make([]vector.Any, len(union.Types))
+		vecs[tag] = vector.NewConst(super.Null, vec.Len())
+		return vector.NewUnion(union, tags, vecs)
 	case vector.KindError:
 		return vec
 	}

--- a/runtime/ztests/expr/cast-array.yaml
+++ b/runtime/ztests/expr/cast-array.yaml
@@ -11,9 +11,9 @@ input: |
   |[1,2]|
 
 output: |
-  error({message:"cannot cast to [string]",on:null})
-  [error({message:"cannot cast to string",on:null})]
-  [error({message:"cannot cast to string",on:null})]
+  null::(null|[string])
+  [null]::[string|null]
+  [null]::[string|null]
   ["1","2"]
   ["1","2"]
   ["1","2"]

--- a/runtime/ztests/expr/cast/bool.yaml
+++ b/runtime/ztests/expr/cast/bool.yaml
@@ -38,7 +38,7 @@ output: |
   false
   false
   error({message:"cannot cast to bool",on:"blah"})
-  error({message:"cannot cast to bool",on:null})
+  null::(bool|null)
   true
   error("bad")
   error({message:"cannot cast to bool",on:{x:1}})

--- a/runtime/ztests/expr/cast/bytes.yaml
+++ b/runtime/ztests/expr/cast/bytes.yaml
@@ -16,6 +16,6 @@ output: |
   0x666f6f
   0x626172
   0x
-  error({message:"cannot cast to bytes",on:null})
+  null::(bytes|null)
   error({message:"cannot cast to bytes",on:{x:"foo"}})
   error("bad")

--- a/runtime/ztests/expr/cast/duration.yaml
+++ b/runtime/ztests/expr/cast/duration.yaml
@@ -25,7 +25,7 @@ output: |
   -25m
   1ns
   error({message:"cannot cast to duration",on:1e+19})
-  error({message:"cannot cast to duration",on:null})
+  null::(duration|null)
   error("bad")
   error({message:"cannot cast to duration",on:{x:1}})
   error({message:"cannot cast to duration",on:[1,2]})

--- a/runtime/ztests/expr/cast/enum.yaml
+++ b/runtime/ztests/expr/cast/enum.yaml
@@ -13,5 +13,5 @@ output: |
   "e2"::enum(e1,e2)
   error({message:"no such symbol in enum(e1,e2)",on:"e3"})
   error({message:"cannot cast to enum",on:0})
-  error({message:"cannot cast to enum",on:null})
+  null::(null|enum(e1,e2))
   error("bad")

--- a/runtime/ztests/expr/cast/float.yaml
+++ b/runtime/ztests/expr/cast/float.yaml
@@ -11,6 +11,7 @@ input: |
   2::=named
   false
   true
+  null
 
 output: |
   1.5::float16
@@ -37,6 +38,9 @@ output: |
   1.::float16
   1.::float32
   1.
+  null::(float16|null)
+  null::(float32|null)
+  null::(float64|null)
 
 ---
 
@@ -45,7 +49,6 @@ spq: cast(this, <float64>)
 vector: true
 
 input: |
-  null
   error("bad")
   {x:1}
   [1,2]
@@ -53,7 +56,6 @@ input: |
   |{"x":1}|
 
 output: |
-  error({message:"cannot cast to float64",on:null})
   error("bad")
   error({message:"cannot cast to float64",on:{x:1}})
   error({message:"cannot cast to float64",on:[1,2]})

--- a/runtime/ztests/expr/cast/int.yaml
+++ b/runtime/ztests/expr/cast/int.yaml
@@ -6,7 +6,6 @@ vector: true
 input: |
   "-1"
   "65535"
-  null
   1::uint64
   10000000000000000000::uint64
   -1.
@@ -14,6 +13,7 @@ input: |
   1e8
   false
   true
+  null
 
 output: |
   -1::int8
@@ -24,10 +24,6 @@ output: |
   error({message:"cannot cast to int16",on:"65535"})
   65535::int32
   65535
-  error({message:"cannot cast to int8",on:null})
-  error({message:"cannot cast to int16",on:null})
-  error({message:"cannot cast to int32",on:null})
-  error({message:"cannot cast to int64",on:null})
   1::int8
   1::int16
   1::int32
@@ -56,6 +52,10 @@ output: |
   1::int16
   1::int32
   1
+  null::(int8|null)
+  null::(int16|null)
+  null::(int32|null)
+  null::(int64|null)
 
 ---
 
@@ -64,7 +64,6 @@ spq: cast(this, <int64>)
 vector: true
 
 input: |
-  null
   error("bad")
   {x:1}
   [1,2]
@@ -72,7 +71,6 @@ input: |
   |{"x":1}|
 
 output: |
-  error({message:"cannot cast to int64",on:null})
   error("bad")
   error({message:"cannot cast to int64",on:{x:1}})
   error({message:"cannot cast to int64",on:[1,2]})

--- a/runtime/ztests/expr/cast/ip.yaml
+++ b/runtime/ztests/expr/cast/ip.yaml
@@ -17,7 +17,7 @@ output: |
   error({message:"cannot cast to ip",on:"foo"})
   127.0.0.1
   2001:0:130f::9c0:876a:130b
-  error({message:"cannot cast to ip",on:null})
+  null::(ip|null)
   1.1.1.1
   1.1.1.2
   error({message:"cannot cast to ip",on:34})

--- a/runtime/ztests/expr/cast/map.yaml
+++ b/runtime/ztests/expr/cast/map.yaml
@@ -13,6 +13,6 @@ input: |
 output: |
   |{}|
   |{1:|{"2":3,"4":5}|,7:error({message:"cannot cast to |{string:int64}|",on:8}),9:|{"10":error({message:"cannot cast to int64",on:[]::[null]}),"[]":11,error({message:"cannot cast to string",on:null}):error({message:"cannot cast to int64",on:null})}|}|
-  error({message:"cannot cast to |{int64:|{string:int64}|}|",on:null})
+  null::(null||{int64:|{string:int64}|}|)
   error({message:"cannot cast to |{int64:|{string:int64}|}|",on:1})
   error("bad")

--- a/runtime/ztests/expr/cast/net.yaml
+++ b/runtime/ztests/expr/cast/net.yaml
@@ -15,7 +15,7 @@ input: |
 output: |
   192.168.1.0/24
   2001:db8::/32
-  error({message:"cannot cast to net",on:null})
+  null::(net|null)
   10.0.0.0/8
   10.0.0.0/8
   error({message:"cannot cast to net",on:-35})

--- a/runtime/ztests/expr/cast/record.yaml
+++ b/runtime/ztests/expr/cast/record.yaml
@@ -18,7 +18,7 @@ output: |
   {a:1,b:"{}",c:error("missing"),d:error("missing")}
   {a:error("missing"),b:"1",c:error({message:"cannot cast to {}",on:2}),d:error("missing")}
   {a:1,b:"2",c:{},d:[{e:"4",f:5},{e:"7",f:6},error({message:"cannot cast to {e:string,f:int64}",on:8})]}
-  {a:7,b:"6",c:error({message:"cannot cast to {}",on:null}),d:[{e:"1",f:2},{e:"4",f:3},error({message:"cannot cast to {e:string,f:int64}",on:5})]}
-  error({message:"cannot cast to {a:int64,b:string,c:{},d:[{e:string,f:int64}]}",on:null})
+  {a:7,b:"6",c:null::(null|{}),d:[{e:"1",f:2},{e:"4",f:3},error({message:"cannot cast to {e:string,f:int64}",on:5})]}
+  null::(null|{a:int64,b:string,c:{},d:[{e:string,f:int64}]})
   error({message:"cannot cast to {a:int64,b:string,c:{},d:[{e:string,f:int64}]}",on:1})
   error("bad")

--- a/runtime/ztests/expr/cast/string.yaml
+++ b/runtime/ztests/expr/cast/string.yaml
@@ -34,7 +34,7 @@ output: |
   "1"
   "2"
   "3"
-  error({message:"cannot cast to string",on:null})
+  null::(string|null)
   "1"
   "2"
   "3.5"

--- a/runtime/ztests/expr/cast/time.yaml
+++ b/runtime/ztests/expr/cast/time.yaml
@@ -30,7 +30,7 @@ output: |
   error({message:"cannot cast to time",on:"foo"})
   1969-12-31T23:59:59Z
   1970-01-01T00:00:00.000000001Z
-  error({message:"cannot cast to time",on:null})
+  null::(time|null)
   error({message:"cannot cast to time",on:1e+200})
   error("bad")
   error({message:"cannot cast to time",on:{x:1}})

--- a/runtime/ztests/expr/cast/type.yaml
+++ b/runtime/ztests/expr/cast/type.yaml
@@ -19,5 +19,5 @@ output: |
   error({message:"cannot cast to type",on:"{x:\"foo\"}"})
   error({message:"cannot cast to type",on:"<int>"})
   error({message:"cannot cast to type",on:1})
-  error({message:"cannot cast to type",on:null})
+  null::(type|null)
   error("bad")

--- a/runtime/ztests/expr/cast/uint.yaml
+++ b/runtime/ztests/expr/cast/uint.yaml
@@ -23,10 +23,10 @@ output: |
   error({message:"cannot cast to uint16",on:-1})
   error({message:"cannot cast to uint32",on:-1})
   error({message:"cannot cast to uint64",on:-1})
-  error({message:"cannot cast to uint8",on:null})
-  error({message:"cannot cast to uint16",on:null})
-  error({message:"cannot cast to uint32",on:null})
-  error({message:"cannot cast to uint64",on:null})
+  null::(uint8|null)
+  null::(uint16|null)
+  null::(uint32|null)
+  null::(uint64|null)
   error("bad")
   error("bad")
   error("bad")
@@ -39,7 +39,6 @@ spq: cast(this, <uint64>)
 vector: true
 
 input: |
-  null
   error("bad")
   {x:1}
   [1,2]
@@ -47,7 +46,6 @@ input: |
   |{"x":1}|
 
 output: |
-  error({message:"cannot cast to uint64",on:null})
   error("bad")
   error({message:"cannot cast to uint64",on:{x:1}})
   error({message:"cannot cast to uint64",on:[1,2]})

--- a/runtime/ztests/expr/shape-cast-array-to-set.yaml
+++ b/runtime/ztests/expr/shape-cast-array-to-set.yaml
@@ -12,5 +12,5 @@ input: |
 output: |
   {a:|[]|::|[ip]|,b:|[]|::|[{b:ip}]|}
   {a:|[1.1.1.1,2.2.2.2]|,b:|[{b:1.1.1.1},{b:2.2.2.2}]|}
-  {a:|[1.1.1.1]|,b:|[{b:2.2.2.2},{b:error({message:"cannot cast to ip",on:null})}]|}
-  {a:|[1.1.1.1,error({message:"cannot cast to ip",on:"2"})]|,b:|[{b:1.1.1.1},{b:error({message:"cannot cast to ip",on:null})},{b:error({message:"cannot cast to ip",on:"2"})}]|}
+  {a:|[1.1.1.1]|,b:|[{b:2.2.2.2},{b:null::(ip|null)}]|}
+  {a:|[1.1.1.1,error({message:"cannot cast to ip",on:"2"})]|,b:|[{b:1.1.1.1},{b:null::(ip|null)},{b:error({message:"cannot cast to ip",on:"2"})}]|}

--- a/runtime/ztests/expr/shape-cast-arrays.yaml
+++ b/runtime/ztests/expr/shape-cast-arrays.yaml
@@ -12,5 +12,5 @@ input: |
 output: |
   {a:[]::[ip],b:[]::[{b:ip}]}
   {a:[1.1.1.1,2.2.2.2],b:[{b:1.1.1.1},{b:2.2.2.2}]}
-  {a:[1.1.1.1],b:[{b:error({message:"cannot cast to ip",on:null})},{b:2.2.2.2}]}
-  {a:[error({message:"cannot cast to ip",on:null}),1.1.1.1,error({message:"cannot cast to ip",on:"2"})],b:[{b:error({message:"cannot cast to ip",on:null})},{b:1.1.1.1},{b:error({message:"cannot cast to ip",on:"2"})}]}
+  {a:[1.1.1.1],b:[{b:null::(ip|null)},{b:2.2.2.2}]}
+  {a:[error({message:"cannot cast to ip",on:null}),1.1.1.1,error({message:"cannot cast to ip",on:"2"})],b:[{b:null::(ip|null)},{b:1.1.1.1},{b:error({message:"cannot cast to ip",on:"2"})}]}

--- a/runtime/ztests/expr/shape-cast-set-to-array.yaml
+++ b/runtime/ztests/expr/shape-cast-set-to-array.yaml
@@ -11,8 +11,8 @@ input: |
   {a:|[null,"1.1.1.1","2"]|,b:|[{b:null},{b:"1.1.1.1"},{b:"2"}]|}
 
 output: |
-  {a:error({message:"cannot cast to [ip]",on:null}),b:error({message:"cannot cast to [{b:ip}]",on:null})}
+  {a:null::(null|[ip]),b:null::(null|[{b:ip}])}
   {a:[]::[ip],b:[]::[{b:ip}]}
   {a:[1.1.1.1,2.2.2.2],b:[{b:1.1.1.1},{b:2.2.2.2}]}
-  {a:[1.1.1.1],b:[{b:error({message:"cannot cast to ip",on:null})},{b:2.2.2.2}]}
-  {a:[error({message:"cannot cast to ip",on:"2"}),error({message:"cannot cast to ip",on:null}),1.1.1.1],b:[{b:error({message:"cannot cast to ip",on:"2"})},{b:error({message:"cannot cast to ip",on:null})},{b:1.1.1.1}]}
+  {a:[1.1.1.1],b:[{b:null::(ip|null)},{b:2.2.2.2}]}
+  {a:[error({message:"cannot cast to ip",on:"2"}),error({message:"cannot cast to ip",on:null}),1.1.1.1],b:[{b:error({message:"cannot cast to ip",on:"2"})},{b:null::(ip|null)},{b:1.1.1.1}]}

--- a/runtime/ztests/expr/shape-cast-sets.yaml
+++ b/runtime/ztests/expr/shape-cast-sets.yaml
@@ -11,8 +11,8 @@ input: |
   {a:|[null,"1.1.1.1","2"]|,b:|[null,{b:null},{b:"1.1.1.1"},{b:"2"}]|}
 
 output: |
-  {a:error({message:"cannot cast to |[ip]|",on:null}),b:error({message:"cannot cast to |[{b:ip}]|",on:null})}
+  {a:null::(null||[ip]|),b:null::(null||[{b:ip}]|)}
   {a:|[]|::|[ip]|,b:|[]|::|[{b:ip}]|}
   {a:|[1.1.1.1,2.2.2.2]|,b:|[{b:1.1.1.1},{b:2.2.2.2}]|}
-  {a:|[1.1.1.1,error({message:"cannot cast to ip",on:null})]|,b:|[{b:2.2.2.2},{b:error({message:"cannot cast to ip",on:null})},error({message:"cannot cast to {b:ip}",on:null})]|}
-  {a:|[1.1.1.1,error({message:"cannot cast to ip",on:null}),error({message:"cannot cast to ip",on:"2"})]|,b:|[{b:1.1.1.1},{b:error({message:"cannot cast to ip",on:null})},{b:error({message:"cannot cast to ip",on:"2"})},error({message:"cannot cast to {b:ip}",on:null})]|}
+  {a:|[1.1.1.1,error({message:"cannot cast to ip",on:null})]|,b:|[{b:2.2.2.2},{b:null::(ip|null)},error({message:"cannot cast to {b:ip}",on:null})]|}
+  {a:|[1.1.1.1,error({message:"cannot cast to ip",on:null}),error({message:"cannot cast to ip",on:"2"})]|,b:|[{b:1.1.1.1},{b:null::(ip|null)},{b:error({message:"cannot cast to ip",on:"2"})},error({message:"cannot cast to {b:ip}",on:null})]|}

--- a/runtime/ztests/expr/shape-cast-to-union.yaml
+++ b/runtime/ztests/expr/shape-cast-to-union.yaml
@@ -12,7 +12,7 @@ input: |
   {a:"goodbye"::=string_named}
 
 output: |
-  {a:error({message:"cannot cast to int64|string|string_named=string",on:null})}
+  {a:null::(int64|string|(string_named=string)|null)}
   {a:1::(union=int64|string|(string_named=string))}
   {a:"hello"::(union=int64|string|(string_named=string))}
   {a:"goodbye"::=string_named::(union=int64|string|string_named)}

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -409,7 +409,9 @@ func (z *ZTest) Run(t *testing.T, path, filename string) {
 		err = z.RunInternal(t.Context())
 	}
 	if err != nil {
-		t.Fatalf("%s:%d: %s", filename, z.Line, err)
+		// Lead with newline so line-numbered errors are
+		// navigable in editors.
+		t.Fatalf("\n%s:%d: %s", filename, z.Line, err)
 	}
 }
 


### PR DESCRIPTION
Since removal of typed nulls in #6633, a cast in SPQ of null to any type other than null or a nullable union (i.e., a union containing null) results in an error.  Since SQL allows a cast of null to any type, do likewise in SPQ with the result of a cast to a non-null type being a nullable union containing the null value.  For example, the result of `null::int64` is `null::(int64|null)`.

Note that SUP retains the restriction that null can be cast only to null or a nullable union.

Fixes #6658.