### PR TITLE
fix vam cast of union to named type

### DIFF
--- a/runtime/vam/expr/cast.go
+++ b/runtime/vam/expr/cast.go
@@ -9,13 +9,7 @@ import (
 	"github.com/brimdata/super/vector"
 )
 
-type literalCast struct {
-	caster Evaluator
-	expr   Evaluator
-}
-
 func NewLiteralCast(sctx *super.Context, expr Evaluator, literal *Literal) (Evaluator, error) {
-	var c Evaluator
 	typeVal := literal.val
 	switch typeVal.Type().ID() {
 	case super.IDType:
@@ -26,48 +20,49 @@ func NewLiteralCast(sctx *super.Context, expr Evaluator, literal *Literal) (Eval
 		if typ.ID() >= super.IDTypeComplex {
 			return nil, fmt.Errorf("cast: casting to type %s not currently supported in vector runtime", sup.FormatType(typ))
 		}
-		c = &casterPrimitive{sctx, typ}
+		return &casterPrimitive{sctx, expr, typ}, nil
 	case super.IDString:
 		name := super.DecodeString(typeVal.Bytes())
 		if _, err := super.NewContext().LookupTypeNamed(name, super.TypeNull); err != nil {
 			return nil, err
 		}
-		c = &casterNamedType{sctx, name}
+		return &casterNamedType{sctx, expr, name}, nil
 	default:
 		return nil, fmt.Errorf("cast type argument is not a type: %s", sup.FormatValue(typeVal))
 	}
-	return &literalCast{c, expr}, nil
-}
-
-func (p *literalCast) Eval(vec vector.Any) vector.Any {
-	return vector.Apply(true, func(vecs ...vector.Any) vector.Any {
-		return p.caster.Eval(vecs[0])
-	}, p.expr.Eval(vec))
 }
 
 type casterPrimitive struct {
 	sctx *super.Context
+	expr Evaluator
 	typ  super.Type
 }
 
 func (c *casterPrimitive) Eval(this vector.Any) vector.Any {
-	return cast.To(c.sctx, this, c.typ)
+	return vector.Apply(true, func(vecs ...vector.Any) vector.Any {
+		return cast.To(c.sctx, vecs[0], c.typ)
+	}, c.expr.Eval(this))
 }
 
 type casterNamedType struct {
 	sctx *super.Context
+	expr Evaluator
 	name string
 }
 
 func (c *casterNamedType) Eval(this vector.Any) vector.Any {
-	this = vector.Under(this)
-	typ := this.Type()
-	if typ.Kind() == super.ErrorKind {
-		return this
+	return vector.Apply(false, c.eval, c.expr.Eval(this))
+}
+
+func (c *casterNamedType) eval(vecs ...vector.Any) vector.Any {
+	vec := vecs[0]
+	if vec.Kind() == vector.KindError {
+		return vec
 	}
-	named, err := c.sctx.LookupTypeNamed(c.name, typ)
+	vec = vector.Under(vec)
+	named, err := c.sctx.LookupTypeNamed(c.name, vec.Type())
 	if err != nil {
-		return vector.NewStringError(c.sctx, err.Error(), this.Len())
+		return vector.NewStringError(c.sctx, err.Error(), vec.Len())
 	}
-	return vector.NewNamed(named, this)
+	return vector.NewNamed(named, vec)
 }

--- a/runtime/ztests/expr/cast/named.yaml
+++ b/runtime/ztests/expr/cast/named.yaml
@@ -8,6 +8,7 @@ input: |
   "foo"
   "bar"
   "baz"::=a
+  1::(int64|null)
   null
   error("missing")
   error("foo")
@@ -18,6 +19,7 @@ output: |
   "foo"::=named
   "bar"::=named
   "baz"::=named
+  1::(named=int64|null)
   null::=named
   error("missing")
   error("foo")


### PR DESCRIPTION
In the vector runtime, a cast of a union to a named type discards the union.  Fix that.