### PR TITLE
runtime/sam: ignore null partial in fuse()

### DIFF
--- a/runtime/sam/expr/agg/fuse.go
+++ b/runtime/sam/expr/agg/fuse.go
@@ -48,6 +48,9 @@ func (f *fuse) Result(sctx *super.Context) super.Value {
 }
 
 func (f *fuse) ConsumeAsPartial(partial super.Value) {
+	if partial.IsNull() {
+		return
+	}
 	if partial.Type() != super.TypeType {
 		panic("fuse: partial not a type value")
 	}


### PR DESCRIPTION
fuse.ResultAsPartial can return super.Null so fuse.ConsumeAsPartial must ignore it.