### PR TITLE
runtime/sam: remove inaccurate comment in Collect.ConsumeAsPartial

### DIFF
--- a/runtime/sam/expr/agg/collect.go
+++ b/runtime/sam/expr/agg/collect.go
@@ -63,8 +63,7 @@ func newArray(sctx *super.Context, vals []super.Value) super.Value {
 }
 
 func (c *Collect) ConsumeAsPartial(val super.Value) {
-	//XXX These should not be passed in here. See issue #3175
-	if len(val.Bytes()) == 0 {
+	if val.IsNull() {
 		return
 	}
 	arrayType, ok := val.Type().(*super.TypeArray)


### PR DESCRIPTION
Collect.ResultAsPartial can return super.Null so
Collect.ConsumeAsPartial must ignore it.

Closes ##3175 (because null is expected in ConsumeAsPartial).