### PR TITLE
sio/arrowio, sio/parquetio: update some names

### DIFF
--- a/sio/arrowio/writer.go
+++ b/sio/arrowio/writer.go
@@ -44,7 +44,7 @@ type Writer struct {
 }
 
 type WriteCloser interface {
-	Write(rec arrow.Record) error
+	Write(arrow.RecordBatch) error
 	Close() error
 }
 
@@ -109,10 +109,10 @@ func (w *Writer) flush(min int) error {
 	if w.builder.Field(0).Len() < min {
 		return nil
 	}
-	rec := w.builder.NewRecord()
-	defer rec.Release()
+	batch := w.builder.NewRecordBatch()
+	defer batch.Release()
 	w.builder.Reserve(recordBatchSize)
-	return w.writer.Write(rec)
+	return w.writer.Write(batch)
 }
 
 func (w *Writer) newArrowDataType(typ super.Type) (arrow.DataType, error) {

--- a/sio/parquetio/vectorreader.go
+++ b/sio/parquetio/vectorreader.go
@@ -138,7 +138,7 @@ func (p *VectorReader) ConcurrentPull(done bool, id int) (vector.Any, error) {
 			}
 			p.rrs[id] = rr
 		}
-		rec, err := p.rrs[id].Read()
+		batch, err := p.rrs[id].Read()
 		if err != nil {
 			if err == io.EOF {
 				p.rrs[id] = nil
@@ -146,7 +146,7 @@ func (p *VectorReader) ConcurrentPull(done bool, id int) (vector.Any, error) {
 			}
 			return nil, err
 		}
-		return p.vbs[id].build(array.RecordToStructArray(rec), false)
+		return p.vbs[id].build(array.RecordToStructArray(batch), false)
 	}
 }
 


### PR DESCRIPTION
The new names reflect terminology changes in github.com/apache/arrow-go.