### PR TITLE
csup: fix Object.ProjectMetadata bug

### DIFF
--- a/csup/metadata.go
+++ b/csup/metadata.go
@@ -277,7 +277,6 @@ func metadataValue(cctx *Context, sctx *super.Context, b *scode.Builder, id ID, 
 
 func metadataLeaf(sctx *super.Context, b *scode.Builder, min, max super.Value) super.Type {
 	b.BeginContainer()
-	b.Append(nil) // no optional fields here
 	b.Append(min.Bytes())
 	b.Append(max.Bytes())
 	b.EndContainer()

--- a/csup/object_test.go
+++ b/csup/object_test.go
@@ -1,0 +1,36 @@
+package csup_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/brimdata/super"
+	"github.com/brimdata/super/csup"
+	"github.com/brimdata/super/pkg/field"
+	"github.com/brimdata/super/sio"
+	"github.com/brimdata/super/sup"
+	"github.com/stretchr/testify/require"
+)
+
+func TestObjectProjectMetadata(t *testing.T) {
+	var b bytes.Buffer
+	w := csup.NewWriter(sio.NopCloser(&b))
+	sctx := super.NewContext()
+	supValues := []string{
+		"{a:1,b:{c:4,d:0.7}}",
+		"{a:2,b:{c:5,d:0.8}}",
+		"{a:3,b:{c:6,d:0.9}}",
+	}
+	for _, s := range supValues {
+		require.NoError(t, w.Write(sup.MustParseValue(sctx, s)))
+	}
+	require.NoError(t, w.Close())
+	csupBytes := b.Bytes()
+
+	o, err := csup.NewObject(bytes.NewReader(csupBytes))
+	require.NoError(t, err)
+	p := field.NewProjection(field.DottedList("b.d,a"))
+	values := o.ProjectMetadata(super.NewContext(), p)
+	require.Len(t, values, 1)
+	require.Equal(t, "{b:{d:{min:0.7,max:0.9}},a:{min:1,max:3}}", sup.FormatValue(values[0]))
+}


### PR DESCRIPTION
metadataLeaf incorrectly adds an extra empty value to the scode of the record that it constructs.  Remove that.