### PR TITLE
Have GoReleaser sign and notarize macOS builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,3 +25,8 @@ jobs:
         args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+        MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
+        MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
+        MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
+        MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+        MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,6 +15,19 @@ builds:
       - linux
       - windows
       - darwin
+notarize:
+  macos:
+    - enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
+      ids:
+        - super
+      sign:
+        certificate: "{{ .Env.MACOS_SIGN_P12 }}"
+        password: "{{ .Env.MACOS_SIGN_PASSWORD }}"
+      notarize:
+        issuer_id: "{{ .Env.MACOS_NOTARY_ISSUER_ID }}"
+        key_id: "{{ .Env.MACOS_NOTARY_KEY_ID }}"
+        key: "{{ .Env.MACOS_NOTARY_KEY }}"
+        wait: true
 archives:
   - name_template: "{{ .ProjectName }}-{{ .Tag }}.{{ .Os }}-{{ .Arch }}"
     format_overrides:


### PR DESCRIPTION
## What's Changing

The changes here along with Actions Secrets I've added for the repo will make it such that our macOS `super` release binaries going forward will be signed and notarized.

## Why

In looking toward submitting a Cask for `super` to the core Homebrew set, the very first thing they caution under [reasons for rejection](https://docs.brew.sh/Acceptable-Casks#rejected-casks) is:

> App fails with GateKeeper enabled on Homebrew supported macOS versions and platforms (e.g. unsigned apps will not launch on Apple Silicon Macs).

Even beyond Homebrew, I've since learned that not having the `super` binary signed/notarized creates potential problems for regular users that may download our releases from GitHub via browser.

## Details

On my Intel Mac for instance, if I download the most recent SuperDB [release v0.2.0](https://github.com/brimdata/super/releases/tag/v0.2.0) via Chrome, unpack, and run `./super`, I get a pop-up like this:

<img width="251" height="232" alt="image" src="https://github.com/user-attachments/assets/c0f884cb-20fb-4b8c-a3ab-cb1fe5839acf" />

The same happens if I install via `brew install --cask brimdata/tap/super` per our [docs](https://superdb.org/getting-started/install.html). Experienced users know they can get around this by clicking through an exception in **Settings > Privacy & Security**. But as we seek to make SuperDB accessible to wider audiences, this is definitely a bad look.

In addition to adding them as Repository Secrets here in the repo, I've also saved the values of the secrets in our AWS Secrets Manager under `super_repo_build_secrets`.

## Testing

I've tested out the signing and notarizing in a personal fork repo and have made scratch releases [v0.3.0](https://github.com/philrz/super/releases/tag/v0.3.0) (which represents a baseline repro of the problem) and [v0.6.0](https://github.com/philrz/super/releases/tag/v0.6.0) (which is signed and notarized and shows the fix). To verify, in addition to the presence/absence of the pop-up I showed above, with the scratch `v0.3.0` artifact we see:

```
$ spctl -a -vvv --type install ./super
./super: rejected
source=no usable signature
```

And with the scratch `v0.6.0` artifact:

```
$ spctl -a -vvv --type install ./super
./super: accepted
source=Notarized Developer ID
origin=Developer ID Application: Brim Data, Inc. (2DBXHXV7KJ)
```
