### PR TITLE
Add support for zed vacate command (#6706)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -37,7 +37,7 @@ jobs:
       - run: go build -o dist ./cmd/...
       - run: go test -v ./mdtest
   output-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/markdown-lint.yaml
+++ b/.github/workflows/markdown-lint.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   markdown-link:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Lint

--- a/.github/workflows/notify-docs-update.yaml
+++ b/.github/workflows/notify-docs-update.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Send dispatch event
       run: |

--- a/.github/workflows/notify-downstream-merge.yaml
+++ b/.github/workflows/notify-downstream-merge.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         repo: [brimcap, zui]

--- a/.github/workflows/notify-main-failure.yaml
+++ b/.github/workflows/notify-main-failure.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   slackNotify:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Notify Brim HQ of failure on main
         uses: tiloio/slack-webhook-action@v1.1.2

--- a/.github/workflows/perf-compare.yaml
+++ b/.github/workflows/perf-compare.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   perf-compare:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
       - v*
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,4 @@
+version: 2
 builds:
   - main: ./cmd/zed
     id: zed
@@ -70,5 +71,3 @@ checksum:
   name_template: 'zed-checksums.txt'
 snapshot:
   name_template: "{{ incpatch .Version }}-{{ .ShortCommit }}"
-changelog:
-  skip: true

--- a/api/api.go
+++ b/api/api.go
@@ -124,6 +124,10 @@ type QueryWarning struct {
 	Warning string `json:"warning" zed:"warning"`
 }
 
+type VacateResponse struct {
+	CommitIDs []ksuid.KSUID `super:"commit_ids"`
+}
+
 type VacuumResponse struct {
 	ObjectIDs []ksuid.KSUID `zed:"object_ids"`
 }

--- a/api/client/connection.go
+++ b/api/client/connection.go
@@ -20,6 +20,7 @@ import (
 	"github.com/brimdata/zed/lake"
 	"github.com/brimdata/zed/lake/branches"
 	"github.com/brimdata/zed/lakeparse"
+	"github.com/brimdata/zed/pkg/nano"
 	"github.com/brimdata/zed/runtime/exec"
 	"github.com/brimdata/zed/zio/zngio"
 	"github.com/brimdata/zed/zson"
@@ -375,6 +376,20 @@ func (c *Connection) delete(ctx context.Context, poolID ksuid.KSUID, branchName 
 	var commit api.CommitResponse
 	err := c.doAndUnmarshal(req, &commit)
 	return commit, err
+}
+
+func (c *Connection) Vacate(ctx context.Context, pool string, ts nano.Ts, dryrun bool) (api.VacateResponse, error) {
+	path := urlPath("pool", pool, "vacate")
+	vals := make(url.Values)
+	vals.Add("ts", ts.Time().Format(time.RFC3339Nano))
+	if dryrun {
+		vals.Add("dryrun", "true")
+	}
+	path += "?" + vals.Encode()
+	req := c.NewRequest(ctx, http.MethodPost, path, nil)
+	var res api.VacateResponse
+	err := c.doAndUnmarshal(req, &res)
+	return res, err
 }
 
 func (c *Connection) Vacuum(ctx context.Context, pool, revision string, dryrun bool) (api.VacuumResponse, error) {

--- a/cmd/zed/vacate/command.go
+++ b/cmd/zed/vacate/command.go
@@ -1,42 +1,106 @@
 package vacate
 
 import (
+	"context"
 	"errors"
 	"flag"
+	"fmt"
+	"strings"
 
+	"github.com/brimdata/zed/cli/poolflags"
 	"github.com/brimdata/zed/cmd/zed/root"
+	"github.com/brimdata/zed/lake/api"
+	"github.com/brimdata/zed/lakeparse"
 	"github.com/brimdata/zed/pkg/charm"
+	"github.com/brimdata/zed/pkg/nano"
+	"github.com/brimdata/zed/pkg/plural"
 )
 
 var Cmd = &charm.Spec{
 	Name:  "vacate",
-	Usage: "vacate [options] commit",
-	Short: "compact a pool's commit history by squashing old commit objects",
+	Usage: "vacate [options] [timestamp]",
+	Short: "compact a pool's commit history by removing old commit objects",
 	Long: `
-The vacate command compacts the commit history by squashing all of the commit
-objects in the history up to the indicated commit and removing the old commits.
-No other commit objects in the pool may point at any of the squashed commits.
-In particular, no branch may point to any commit that would be deleted.
-
-The branch history may contain pointers to old commit objects, but any attempt
-to access them will fail as the underlying commit history will be no longer available.
-
-DANGER ZONE.
-There is no prompting or second chances here so use carefully.
-Once the pool's commit history has been squashed and old commits is deleted,
-they cannot be recovered.
+See https://superdb.org/command/db.html#super-db-vacate
 `,
 	New: New,
 }
 
 type Command struct {
 	*root.Command
+	poolFlags poolflags.Flags
+	dryrun    bool
+	force     bool
 }
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
-	return &Command{Command: parent.(*root.Command)}, nil
+	c := &Command{Command: parent.(*root.Command)}
+	c.poolFlags.SetFlags(f)
+	f.BoolVar(&c.dryrun, "dryrun", false, "view the number of commits to be deleted")
+	f.BoolVar(&c.force, "f", false, "do not prompt for confirmation")
+	return c, nil
 }
 
 func (c *Command) Run(args []string) error {
-	return errors.New("issue #2545")
+	ctx, cleanup, err := c.Init()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	db, err := c.LakeFlags.Open(ctx)
+	if err != nil {
+		return err
+	}
+	at, err := c.poolFlags.HEAD()
+	if err != nil {
+		return err
+	}
+	var ts nano.Ts
+	if len(args) > 0 {
+		ts, err = nano.ParseRFC3339Nano([]byte(args[0]))
+	} else {
+		ts, err = c.getTsFromCommitish(ctx, db, at)
+	}
+	if err != nil {
+		return err
+	}
+	verb := "would vacate"
+	if !c.dryrun {
+		verb = "vacated"
+		if err := c.confirm(ctx, ts); err != nil {
+			return err
+		}
+	}
+	cids, err := db.Vacate(ctx, at.Pool, ts, c.dryrun)
+	if err != nil {
+		return err
+	}
+	if !c.LakeFlags.Quiet {
+		fmt.Printf("%s %d commit%s\n", verb, len(cids), plural.Slice(cids, "s"))
+	}
+	return nil
+}
+
+func (c *Command) getTsFromCommitish(ctx context.Context, db api.Interface, at *lakeparse.Commitish) (nano.Ts, error) {
+	commit, err := api.GetCommit(ctx, db, at.Pool, at.Branch)
+	if err != nil {
+		return 0, err
+	}
+	return commit.Date, nil
+}
+
+func (c *Command) confirm(ctx context.Context, ts nano.Ts) error {
+	if c.force {
+		return nil
+	}
+	fmt.Printf("Are you sure you want to vacate history order than %s? There is no going back... [y|n]\n", ts)
+	var input string
+	if _, err := fmt.Scanln(&input); err != nil {
+		return err
+	}
+	input = strings.ToLower(input)
+	if input == "y" || input == "yes" {
+		return nil
+	}
+	return errors.New("operation canceled")
 }

--- a/lake/api/api.go
+++ b/lake/api/api.go
@@ -10,9 +10,11 @@ import (
 	"github.com/brimdata/zed/api"
 	"github.com/brimdata/zed/api/client"
 	"github.com/brimdata/zed/lake"
+	"github.com/brimdata/zed/lake/commits"
 	"github.com/brimdata/zed/lake/pools"
 	"github.com/brimdata/zed/lakeparse"
 	"github.com/brimdata/zed/order"
+	"github.com/brimdata/zed/pkg/nano"
 	"github.com/brimdata/zed/zbuf"
 	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zson"
@@ -38,6 +40,7 @@ type Interface interface {
 	Revert(ctx context.Context, poolID ksuid.KSUID, branch string, commitID ksuid.KSUID, commit api.CommitMessage) (ksuid.KSUID, error)
 	AddVectors(ctx context.Context, pool, revision string, objects []ksuid.KSUID, message api.CommitMessage) (ksuid.KSUID, error)
 	DeleteVectors(ctx context.Context, pool, revision string, objects []ksuid.KSUID, message api.CommitMessage) (ksuid.KSUID, error)
+	Vacate(ctx context.Context, pool string, time nano.Ts, dryrun bool) ([]ksuid.KSUID, error)
 	Vacuum(ctx context.Context, pool, revision string, dryrun bool) ([]ksuid.KSUID, error)
 }
 
@@ -166,6 +169,42 @@ func LookupBranchByID(ctx context.Context, api Interface, id ksuid.KSUID) (*lake
 		return branch, nil
 	default:
 		return nil, fmt.Errorf("internal error: multiple branches found with same id: %s", id)
+	}
+}
+
+func GetCommit(ctx context.Context, api Interface, pool, revision string) (*commits.Commit, error) {
+	poolID, err := api.PoolID(ctx, pool)
+	if err != nil {
+		return nil, err
+	}
+	commit, err := lakeparse.ParseID(revision)
+	if err != nil {
+		// LookupBranchByName(ctx
+		if commit, err = api.CommitObject(ctx, poolID, revision); err != nil {
+			return nil, err
+		}
+	}
+	b := newBuffer(commits.Commit{})
+	query := fmt.Sprintf("from %q:log | where id == 0x%s", poolID, idToHex(commit))
+	q, err := api.Query(ctx, nil, query)
+	if err != nil {
+		return nil, err
+	}
+	defer q.Pull(true)
+	if err := zbuf.CopyPuller(b, q); err != nil {
+		return nil, err
+	}
+	switch len(b.results) {
+	case 0:
+		return nil, fmt.Errorf("%s: commit not found", commit)
+	case 1:
+		commit, ok := b.results[0].(*commits.Commit)
+		if !ok {
+			return nil, fmt.Errorf("internal error: branch record has wrong type: %T", b.results[0])
+		}
+		return commit, nil
+	default:
+		return nil, fmt.Errorf("internal error: multiple commits found with same id: %s", commit)
 	}
 }
 

--- a/lake/api/local.go
+++ b/lake/api/local.go
@@ -11,6 +11,7 @@ import (
 	"github.com/brimdata/zed/lake"
 	"github.com/brimdata/zed/lakeparse"
 	"github.com/brimdata/zed/order"
+	"github.com/brimdata/zed/pkg/nano"
 	"github.com/brimdata/zed/pkg/storage"
 	"github.com/brimdata/zed/runtime"
 	"github.com/brimdata/zed/runtime/exec"
@@ -207,6 +208,18 @@ func (l *local) DeleteVectors(ctx context.Context, pool, revision string, ids []
 		return ksuid.Nil, err
 	}
 	return branch.DeleteVectors(ctx, ids, message.Author, message.Body)
+}
+
+func (l *local) Vacate(ctx context.Context, pool string, ts nano.Ts, dryrun bool) ([]ksuid.KSUID, error) {
+	poolID, err := l.PoolID(ctx, pool)
+	if err != nil {
+		return nil, err
+	}
+	p, err := l.root.OpenPool(ctx, poolID)
+	if err != nil {
+		return nil, err
+	}
+	return p.Vacate(ctx, ts, dryrun)
 }
 
 func (l *local) Vacuum(ctx context.Context, pool, revision string, dryrun bool) ([]ksuid.KSUID, error) {

--- a/lake/api/remote.go
+++ b/lake/api/remote.go
@@ -13,6 +13,7 @@ import (
 	"github.com/brimdata/zed/lakeparse"
 	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/pkg/field"
+	"github.com/brimdata/zed/pkg/nano"
 	"github.com/brimdata/zed/zbuf"
 	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zio/zngio"
@@ -145,6 +146,11 @@ func (r *remote) AddVectors(ctx context.Context, pool, revision string, objects 
 func (r *remote) DeleteVectors(ctx context.Context, pool, revision string, ids []ksuid.KSUID, message api.CommitMessage) (ksuid.KSUID, error) {
 	res, err := r.conn.DeleteVectors(ctx, pool, revision, ids, message)
 	return res.Commit, err
+}
+
+func (r *remote) Vacate(ctx context.Context, pool string, ts nano.Ts, dryrun bool) ([]ksuid.KSUID, error) {
+	res, err := r.conn.Vacate(ctx, pool, ts, dryrun)
+	return res.CommitIDs, err
 }
 
 func (r *remote) Vacuum(ctx context.Context, pool, revision string, dryrun bool) ([]ksuid.KSUID, error) {

--- a/lake/branches/store.go
+++ b/lake/branches/store.go
@@ -92,3 +92,23 @@ func (s *Store) Remove(ctx context.Context, config Config) error {
 	}
 	return nil
 }
+
+func (s *Store) TruncateHistory(ctx context.Context, at journal.ID) error {
+	return s.store.MoveTail(ctx, at)
+}
+
+// EntryWhere returns the ID of the first journal entry satisfying f(entry), or
+// Nil if none do.
+func (s *Store) EntryWhere(ctx context.Context, f func(*Config) bool) (journal.ID, error) {
+	var at journal.ID
+	err := s.store.WalkEntries(ctx, func(id journal.ID, entries []journal.Entry) bool {
+		at = id
+		for _, e := range entries {
+			if f(e.(*Config)) {
+				return true
+			}
+		}
+		return false
+	})
+	return at, err
+}

--- a/lake/commits/reader.go
+++ b/lake/commits/reader.go
@@ -2,6 +2,8 @@ package commits
 
 import (
 	"context"
+	"errors"
+	"io/fs"
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/zio"
@@ -37,6 +39,10 @@ func (r *LogReader) Read() (*zed.Value, error) {
 	}
 	_, commitObject, err := r.store.GetBytes(r.ctx, r.cursor)
 	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			r.cursor = ksuid.Nil
+			err = nil
+		}
 		return nil, err
 	}
 	next := commitObject.Parent

--- a/lake/commits/store.go
+++ b/lake/commits/store.go
@@ -7,10 +7,12 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"runtime"
 	"sync"
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/lake/data"
+	"github.com/brimdata/zed/pkg/nano"
 	"github.com/brimdata/zed/pkg/storage"
 	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zio/zngio"
@@ -18,6 +20,7 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/segmentio/ksuid"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 )
 
 var (
@@ -108,6 +111,18 @@ func (s *Store) Snapshot(ctx context.Context, leaf ksuid.KSUID) (*Snapshot, erro
 		s.snapshots.Add(leaf, snap)
 		return snap, nil
 	}
+	snap, err := s.buildSnapshot(ctx, leaf)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.putSnapshot(ctx, leaf, snap); err != nil {
+		s.logger.Error("Storing snapshot", zap.Error(err))
+	}
+	s.snapshots.Add(leaf, snap)
+	return snap, nil
+}
+
+func (s *Store) buildSnapshot(ctx context.Context, leaf ksuid.KSUID) (*Snapshot, error) {
 	var objects []*Object
 	var base *Snapshot
 	for at := leaf; at != ksuid.Nil; {
@@ -135,6 +150,17 @@ func (s *Store) Snapshot(ctx context.Context, leaf ksuid.KSUID) (*Snapshot, erro
 		// No snapshot found, so wait for data object.
 		wg.Wait()
 		if oErr != nil {
+			if errors.Is(oErr, fs.ErrNotExist) {
+				// If object get error is not exists then perhaps commits have
+				// been vacated at this point, check if previous is a base
+				// commit.
+				snap, err := s.getBase(ctx, at)
+				if err != nil {
+					return nil, fmt.Errorf("system error: error fetching base: %w", err)
+				}
+				base = snap
+				break
+			}
 			return nil, oErr
 		}
 		objects = append(objects, o)
@@ -153,10 +179,6 @@ func (s *Store) Snapshot(ctx context.Context, leaf ksuid.KSUID) (*Snapshot, erro
 			}
 		}
 	}
-	if err := s.putSnapshot(ctx, leaf, snap); err != nil {
-		s.logger.Error("Storing snapshot", zap.Error(err))
-	}
-	s.snapshots.Add(leaf, snap)
 	return snap, nil
 }
 
@@ -179,6 +201,27 @@ func (s *Store) putSnapshot(ctx context.Context, commit ksuid.KSUID, snap *Snaps
 
 func (s *Store) snapshotPathOf(commit ksuid.KSUID) *storage.URI {
 	return s.path.JoinPath(commit.String() + ".snap.zng")
+}
+
+func (s *Store) getBase(ctx context.Context, commit ksuid.KSUID) (*Snapshot, error) {
+	r, err := s.engine.Get(ctx, s.basePathOf(commit))
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	return decodeSnapshot(r)
+}
+
+func (s *Store) putBase(ctx context.Context, snap *Snapshot, commit ksuid.KSUID) error {
+	b, err := snap.serialize()
+	if err != nil {
+		return err
+	}
+	return storage.Put(ctx, s.engine, s.basePathOf(commit), bytes.NewReader(b))
+}
+
+func (s *Store) basePathOf(commit ksuid.KSUID) *storage.URI {
+	return s.path.JoinPath(commit.String() + ".base.bsup")
 }
 
 // Path return the entire path from the commit object to the root
@@ -210,11 +253,16 @@ func (s *Store) PathRange(ctx context.Context, from, to ksuid.KSUID) ([]ksuid.KS
 			}
 			break
 		}
-		path = append(path, at)
 		o, err := s.Get(ctx, at)
 		if err != nil {
+			// If we get fs.ErrNotExist it means we have vacated and so we can
+			// just return the path at this point.
+			if errors.Is(err, fs.ErrNotExist) && to.IsNil() {
+				break
+			}
 			return nil, err
 		}
+		path = append(path, at)
 		if at == to {
 			break
 		}
@@ -247,6 +295,9 @@ func (s *Store) ReadAll(ctx context.Context, commit, stop ksuid.KSUID) ([]byte, 
 	for commit != ksuid.Nil && commit != stop {
 		b, commitObject, err := s.GetBytes(ctx, commit)
 		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				break
+			}
 			return nil, err
 		}
 		size += len(b)
@@ -339,6 +390,81 @@ func (s *Store) PatchOfPath(ctx context.Context, base *Snapshot, baseID, commit 
 		}
 	}
 	return patch, nil
+}
+
+// FindNearestToTs finds the last commit that is greater than or equal to ts.
+func (s *Store) FindNearestToTs(ctx context.Context, tail ksuid.KSUID, ts nano.Ts) (ksuid.KSUID, error) {
+	at := tail
+	var prev ksuid.KSUID
+	for {
+		_, commit, err := s.GetBytes(ctx, at)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				// Vacated commit.
+				return prev, nil
+			}
+			return ksuid.Nil, err
+		}
+		if ts >= commit.Date {
+			return commit.ID, nil
+		}
+		prev = at
+		at = commit.Parent
+	}
+}
+
+// SetBase establishes a new base (snapshot) at the provided commit and resets
+// the attached caches, then deletes all prior commits.
+func (s *Store) SetBase(ctx context.Context, commit ksuid.KSUID) ([]ksuid.KSUID, error) {
+	path, err := s.Path(ctx, commit)
+	if err != nil {
+		return nil, err
+	}
+	if len(path) <= 1 {
+		return nil, errors.New("cannot set base on earliest commit")
+	}
+	// Create snapshot of previous commit.
+	snap, err := s.buildSnapshot(ctx, path[1])
+	if err != nil {
+		return nil, err
+	}
+	if err := s.putBase(ctx, snap, path[1]); err != nil {
+		return nil, err
+	}
+	s.cache.Purge()
+	s.paths.Purge()
+	s.snapshots.Purge()
+	s.snapshots.Add(path[1], snap)
+	return path[1:], s.deletePath(ctx, path[1:])
+}
+
+// DANGER ZONE - commits should only be removed once a new base has been
+// established.
+func (s *Store) deletePath(ctx context.Context, path []ksuid.KSUID) error {
+	deleteIfExists := func(path *storage.URI) error {
+		err := s.engine.Delete(ctx, path)
+		if errors.Is(err, fs.ErrNotExist) {
+			err = nil
+		}
+		return err
+	}
+	// Attempt to delete prior base (if it exists).
+	_, tail, err := s.GetBytes(ctx, path[len(path)-1])
+	if err == nil && !tail.Parent.IsNil() {
+		deleteIfExists(s.basePathOf(tail.Parent))
+	}
+	group, ctx := errgroup.WithContext(ctx)
+	group.SetLimit(runtime.GOMAXPROCS(0))
+	for _, c := range path {
+		c := c
+		group.Go(func() error {
+			return deleteIfExists(s.pathOf(c))
+		})
+		group.Go(func() error {
+			return deleteIfExists(s.snapshotPathOf(c))
+		})
+	}
+	return group.Wait()
 }
 
 // Vacuumable returns the set of data.Objects in the path of leaf that are not referenced

--- a/lake/journal/queue.go
+++ b/lake/journal/queue.go
@@ -30,18 +30,20 @@ const Nil ID = 0
 const MaxReadRetry = 10
 
 type Queue struct {
-	engine   storage.Engine
-	path     *storage.URI
-	headPath *storage.URI
-	tailPath *storage.URI
+	engine       storage.Engine
+	path         *storage.URI
+	headPath     *storage.URI
+	tailPath     *storage.URI
+	tailLockPath *storage.URI
 }
 
 func New(engine storage.Engine, path *storage.URI) *Queue {
 	return &Queue{
-		engine:   engine,
-		path:     path,
-		headPath: path.JoinPath("HEAD"),
-		tailPath: path.JoinPath("TAIL"),
+		engine:       engine,
+		path:         path,
+		headPath:     path.JoinPath("HEAD"),
+		tailPath:     path.JoinPath("TAIL"),
+		tailLockPath: path.JoinPath("TAIL.lock"),
 	}
 }
 
@@ -79,16 +81,16 @@ func (q *Queue) MoveTail(ctx context.Context, id, base ID) error {
 	return q.writeTail(ctx, id, base)
 }
 
-func (q *Queue) Boundaries(ctx context.Context) (ID, ID, error) {
+func (q *Queue) Boundaries(ctx context.Context) (ID, ID, ID, error) {
 	head, err := q.ReadHead(ctx)
 	if err != nil {
-		return Nil, Nil, err
+		return Nil, Nil, Nil, err
 	}
-	tail, _, err := q.ReadTail(ctx)
+	tail, base, err := q.ReadTail(ctx)
 	if err != nil {
-		return Nil, Nil, err
+		return Nil, Nil, Nil, err
 	}
-	return head, tail, nil
+	return head, tail, base, nil
 }
 
 // XXX This needs concurrency work. See issue #2546.
@@ -147,6 +149,10 @@ func (q *Queue) Load(ctx context.Context, id ID) ([]byte, error) {
 	return storage.Get(ctx, q.engine, q.uri(id))
 }
 
+func (q *Queue) DeleteCommit(ctx context.Context, id ID) error {
+	return q.engine.Delete(ctx, q.uri(id))
+}
+
 func (q *Queue) Open(ctx context.Context, head, tail ID) (io.Reader, error) {
 	if head == Nil {
 		var err error
@@ -178,6 +184,14 @@ func (q *Queue) OpenAsZNG(ctx context.Context, zctx *zed.Context, head, tail ID)
 		return nil, err
 	}
 	return zngio.NewReader(zctx, r), nil
+}
+
+func (q *Queue) putTailLockFile(ctx context.Context) error {
+	return q.engine.PutIfNotExists(ctx, q.tailLockPath, nil)
+}
+
+func (q *Queue) deleteTailLockFile() error {
+	return q.engine.Delete(context.Background(), q.tailLockPath)
 }
 
 func writeID(ctx context.Context, engine storage.Engine, u *storage.URI, id ID) error {

--- a/lake/journal/store.go
+++ b/lake/journal/store.go
@@ -1,6 +1,7 @@
 package journal
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -92,11 +93,21 @@ func (s *Store) load(ctx context.Context) error {
 	if head == current {
 		return nil
 	}
-	unmarshaler := zson.NewZNGUnmarshaler()
-	unmarshaler.Bind(s.keyTypes...)
+	unmarshaler := s.newUnmarshaler()
 	at, table, err := s.getSnapshot(ctx, unmarshaler)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		s.logger.Error("Loading snapshot", zap.Error(err))
+	}
+	if at == Nil {
+		// Load base if it exists.
+		tail, base, err := s.journal.ReadTail(ctx)
+		if err != nil {
+			return err
+		}
+		if table, err = s.loadBase(ctx, base, unmarshaler); err != nil {
+			return err
+		}
+		at = tail
 	}
 	r, err := s.journal.OpenAsZNG(ctx, zed.NewContext(), head, at)
 	if err != nil {
@@ -128,21 +139,31 @@ func (s *Store) load(ctx context.Context) error {
 		if err := unmarshaler.Unmarshal(*val, &e); err != nil {
 			return err
 		}
-		switch e := e.(type) {
-		case *Add:
-			table[e.Entry.Key()] = e.Entry
-		case *Update:
-			key := e.Key()
-			if _, ok := table[key]; !ok {
-				return fmt.Errorf("update to non-existent key in journal store: %T", key)
-			}
-			table[key] = e.Entry
-		case *Delete:
-			delete(table, e.EntryKey)
-		default:
-			return fmt.Errorf("unknown type in journal store: %T", e)
-		}
+		updateTable(table, e)
 	}
+}
+
+func updateTable(table map[string]Entry, e Entry) {
+	switch e := e.(type) {
+	case *Add:
+		table[e.Entry.Key()] = e.Entry
+	case *Update:
+		key := e.Key()
+		if _, ok := table[key]; !ok {
+			panic(fmt.Errorf("update to non-existent key in journal store: %T", key))
+		}
+		table[key] = e.Entry
+	case *Delete:
+		delete(table, e.EntryKey)
+	default:
+		panic(fmt.Errorf("unknown type in journal store: %T", e))
+	}
+}
+
+func (s *Store) newUnmarshaler() *zson.UnmarshalZNGContext {
+	unmarshaler := zson.NewZNGUnmarshaler()
+	unmarshaler.Bind(s.keyTypes...)
+	return unmarshaler
 }
 
 func (s *Store) getSnapshot(ctx context.Context, unmarshaler *zson.UnmarshalZNGContext) (ID, map[string]Entry, error) {
@@ -162,14 +183,20 @@ func (s *Store) getSnapshot(ctx context.Context, unmarshaler *zson.UnmarshalZNGC
 		return Nil, table, errors.New("corrupted journal snapshot")
 	}
 	at := ID(val.Uint())
+	table, err = s.readSnapshot(zr, unmarshaler)
+	return at, table, err
+}
+
+func (s *Store) readSnapshot(r *zngio.Reader, unmarshaler *zson.UnmarshalZNGContext) (map[string]Entry, error) {
+	table := make(map[string]Entry)
 	for {
-		val, err := zr.Read()
+		val, err := r.Read()
 		if val == nil || err != nil {
-			return at, table, err
+			return table, err
 		}
 		var e Entry
 		if err := unmarshaler.Unmarshal(*val, &e); err != nil {
-			return at, nil, err
+			return nil, err
 		}
 		table[e.Key()] = e
 	}
@@ -186,6 +213,10 @@ func (s *Store) putSnapshot(ctx context.Context, at ID, table map[string]Entry) 
 	if err := zw.Write(zed.NewUint64(uint64(at))); err != nil {
 		return err
 	}
+	return s.writeTable(zw, table)
+}
+
+func (s *Store) writeTable(w *zngio.Writer, table map[string]Entry) error {
 	marshaler := zson.NewZNGMarshaler()
 	marshaler.Decorate(zson.StylePackage)
 	for _, entry := range table {
@@ -193,7 +224,7 @@ func (s *Store) putSnapshot(ctx context.Context, at ID, table map[string]Entry) 
 		if err != nil {
 			return err
 		}
-		if err := zw.Write(val); err != nil {
+		if err := w.Write(val); err != nil {
 			return err
 		}
 	}
@@ -360,4 +391,141 @@ func (s *Store) commit(ctx context.Context, fn func() error, entries ...Entry) e
 		return nil
 	}
 	return ErrRetriesExceeded
+}
+
+func (s *Store) MoveTail(ctx context.Context, newTail ID) error {
+	head, tail, base, err := s.journal.Boundaries(ctx)
+	if err != nil {
+		return err
+	}
+	if newTail == tail {
+		// newTail is at tail so we are done here.
+		return nil
+	}
+	if newTail > head {
+		return fmt.Errorf("new tail %d must not be greater than head %d", newTail, head)
+	}
+	if newTail <= tail {
+		return fmt.Errorf("new tail %d must be greater than current tail %d", newTail, tail)
+	}
+	if err := s.journal.putTailLockFile(ctx); err != nil {
+		return err
+	}
+	defer s.journal.deleteTailLockFile()
+	newBase := newTail - 1
+	// Ensure base exists.
+	if _, err := s.journal.Load(ctx, newBase); err != nil {
+		return err
+	}
+	// Clear snapshot
+	if err := s.journal.engine.Delete(ctx, s.snapshotURI()); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	if err := s.putBase(ctx, newBase, tail, base); err != nil {
+		return err
+	}
+	if err := s.journal.MoveTail(ctx, newTail, newBase); err != nil {
+		return err
+	}
+	// Reset cache.
+	s.mu.Lock()
+	s.at = Nil
+	s.mu.Unlock()
+	// Delete old base and old commits.
+	s.journal.engine.Delete(ctx, s.baseURI(base))
+	for at := newBase; at >= tail; at-- {
+		s.journal.DeleteCommit(ctx, at)
+	}
+	return nil
+}
+
+func (s *Store) putBase(ctx context.Context, newBase, tail, oldBase ID) error {
+	u := s.newUnmarshaler()
+	table, err := s.loadBase(ctx, oldBase, u)
+	if err != nil {
+		return err
+	}
+	r, err := s.journal.OpenAsZNG(ctx, zed.NewContext(), newBase, tail)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+	for {
+		val, err := r.Read()
+		if err != nil {
+			return err
+		}
+		if val == nil {
+			break
+		}
+		var e Entry
+		if err := u.Unmarshal(*val, &e); err != nil {
+			return err
+		}
+		updateTable(table, e)
+	}
+	w, err := s.journal.engine.Put(ctx, s.baseURI(newBase))
+	if err != nil {
+		return err
+	}
+	zw := zngio.NewWriter(w)
+	defer zw.Close()
+	return s.writeTable(zw, table)
+}
+
+func (s *Store) loadBase(ctx context.Context, base ID, unmarshaler *zson.UnmarshalZNGContext) (map[string]Entry, error) {
+	r, err := s.journal.engine.Get(ctx, s.baseURI(base))
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			err = nil
+		}
+		return make(map[string]Entry), err
+	}
+	defer r.Close()
+	zr := zngio.NewReader(zed.NewContext(), r)
+	defer zr.Close()
+	return s.readSnapshot(zr, unmarshaler)
+}
+
+func (s *Store) baseURI(base ID) *storage.URI {
+	return s.journal.path.JoinPath(fmt.Sprintf("%d.base.%s", base, ext))
+}
+
+func (s *Store) WalkEntries(ctx context.Context, c func(ID, []Entry) bool) error {
+	head, tail, _, err := s.journal.Boundaries(ctx)
+	if err != nil {
+		return err
+	}
+	at := head
+	for at >= tail {
+		b, err := s.journal.Load(ctx, at)
+		if err != nil {
+			return err
+		}
+		if c(at, s.readEntries(b)) {
+			break
+		}
+		at--
+	}
+	return nil
+}
+
+func (s *Store) readEntries(b []byte) []Entry {
+	var entries []Entry
+	reader := zngbytes.NewDeserializer(bytes.NewReader(b), s.keyTypes)
+	for {
+		o, err := reader.Read()
+		if err != nil {
+			panic(err)
+		}
+		if o == nil {
+			return entries
+		}
+		switch e := o.(Entry).(type) {
+		case *Add:
+			entries = append(entries, e.Entry)
+		case *Update:
+			entries = append(entries, e.Entry)
+		}
+	}
 }

--- a/lake/pool.go
+++ b/lake/pool.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io/fs"
 	"runtime"
+	"slices"
+	"strings"
 	"sync"
 
 	"github.com/brimdata/zed"
@@ -14,6 +16,7 @@ import (
 	"github.com/brimdata/zed/lake/data"
 	"github.com/brimdata/zed/lake/pools"
 	"github.com/brimdata/zed/lakeparse"
+	"github.com/brimdata/zed/pkg/nano"
 	"github.com/brimdata/zed/pkg/storage"
 	"github.com/brimdata/zed/runtime/sam/expr"
 	"github.com/brimdata/zed/zio"
@@ -212,6 +215,74 @@ func (p *Pool) BatchifyBranchTips(ctx context.Context, zctx *zed.Context, f expr
 // XXX this is inefficient but is only meant for interactive queries...?
 func (p *Pool) ObjectExists(ctx context.Context, id ksuid.KSUID) (bool, error) {
 	return p.engine.Exists(ctx, data.SequenceURI(p.DataPath, id))
+}
+
+func (p *Pool) Vacate(ctx context.Context, ts nano.Ts, dryrun bool) ([]ksuid.KSUID, error) {
+	if !dryrun {
+		if err := p.vacateBranchStore(ctx, ts, dryrun); err != nil {
+			return nil, err
+		}
+	}
+	return p.vacateCommits(ctx, ts, dryrun)
+}
+
+func (p *Pool) vacateCommits(ctx context.Context, ts nano.Ts, dryrun bool) ([]ksuid.KSUID, error) {
+	main, err := p.Main(ctx)
+	if err != nil {
+		return nil, err
+	}
+	commit, err := p.commits.FindNearestToTs(ctx, main.Branch.Commit, ts)
+	if err != nil {
+		return nil, err
+	}
+	branches, err := p.branches.All(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var conflicts []string
+	for _, b := range branches {
+		// Find any branches whose history does not include commit and if any
+		// are found fail.
+		path, err := p.commits.Path(ctx, b.Commit)
+		if err != nil {
+			return nil, err
+		}
+		if !slices.Contains(path, commit) {
+			conflicts = append(conflicts, b.Name)
+		}
+	}
+	if len(conflicts) > 0 {
+		slices.Sort(conflicts)
+		v := "branch does not include commit nearest timestamp"
+		if len(conflicts) > 1 {
+			v = "branches do not include commit nearest timestamp"
+		}
+		return nil, fmt.Errorf("cannot vacate at selected time: %s in the deletion path: %s", v, strings.Join(conflicts, ", "))
+	}
+	if dryrun {
+		path, err := p.commits.Path(ctx, commit)
+		if err != nil {
+			return nil, err
+		}
+		return path[1:], nil
+	}
+	return p.commits.SetBase(ctx, commit)
+}
+
+func (p *Pool) vacateBranchStore(ctx context.Context, ts nano.Ts, dryrun bool) error {
+	var werr error
+	at, err := p.branches.EntryWhere(ctx, func(config *branches.Config) bool {
+		if config.Commit.IsNil() {
+			return false
+		}
+		var c *commits.Commit
+		_, c, werr = p.commits.GetBytes(ctx, config.Commit)
+		return werr != nil || ts >= c.Date
+	})
+	if err = errors.Join(err, werr); err != nil {
+		return err
+	}
+	return p.branches.TruncateHistory(ctx, at)
 }
 
 func (p *Pool) Vacuum(ctx context.Context, commit ksuid.KSUID, dryrun bool) ([]ksuid.KSUID, error) {

--- a/lake/ztests/vacate-conflict.yaml
+++ b/lake/ztests/vacate-conflict.yaml
@@ -1,0 +1,17 @@
+# Test that vacate fails if a branch does not include the new base commit.
+script: |
+  export SUPER_DB=test
+  zed init -q
+  zed create -use -q test
+  echo {x:1} | zed load -q -
+  zed branch -q branch1
+  zed branch -q branch2
+  echo {x:1} | zed load -q -use test@branch1 -
+  echo {x:1} | zed load -q -use test@branch2 -
+  echo {x:2} | zed load -q -
+  ! zed vacate -f
+
+outputs:
+  - name: stderr
+    data: |
+      cannot vacate at selected time: branches do not include commit nearest timestamp in the deletion path: branch1, branch2

--- a/lake/ztests/vacate.yaml
+++ b/lake/ztests/vacate.yaml
@@ -1,0 +1,42 @@
+script: |
+  export SUPER_DB=test
+  zed init -q
+  zed create -use -q test
+  echo {x:1} | zed load -message 'commit1' -q -
+  echo {x:2} | zed load -message 'commit2' -q -
+  echo {x:3} | zed load -message 'commit3' -q -
+  echo {x:4} | zed load -message 'commit4' -q -
+  zed vacate -dryrun
+  echo // ===
+  zed vacate -f
+  echo // === 
+  zed query -z 'from test:log | has(message) | yield message'
+  echo // === 
+  zed query -z 'from test'
+  ! zed vacate -f
+  echo {x:5} | zed load -message 'commit5' -q -
+  echo // ===
+  zed vacate -f
+  echo // === 
+  zed query -z 'from test:log | has(message) | yield message'
+
+outputs:
+  - name: stdout
+    data: |
+      would vacate 3 commits
+      // ===
+      vacated 3 commits
+      // ===
+      "commit4"
+      // ===
+      {x:4}
+      {x:3}
+      {x:2}
+      {x:1}
+      // ===
+      vacated 1 commit
+      // ===
+      "commit5"
+  - name: stderr
+    data: |
+      cannot set base on earliest commit

--- a/service/core.go
+++ b/service/core.go
@@ -186,6 +186,7 @@ func (c *Core) addAPIServerRoutes() {
 	c.authhandle("/pool/{pool}/revision/{revision}/vector", handleVectorPost).Methods("POST")
 	c.authhandle("/pool/{pool}/revision/{revision}/vector", handleVectorDelete).Methods("DELETE")
 	c.authhandle("/pool/{pool}/stats", handlePoolStats).Methods("GET")
+	c.authhandle("/pool/{pool}/vacate", handleVacate).Methods("POST")
 	c.authhandle("/query", handleQuery).Methods("OPTIONS", "POST")
 	c.authhandle("/query/describe", handleQueryDescribe).Methods("OPTIONS", "POST")
 	c.authhandle("/query/status/{requestID}", handleQueryStatus).Methods("GET")

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -22,6 +22,7 @@ import (
 	"github.com/brimdata/zed/lake/journal"
 	"github.com/brimdata/zed/lakeparse"
 	"github.com/brimdata/zed/order"
+	"github.com/brimdata/zed/pkg/nano"
 	"github.com/brimdata/zed/pkg/storage"
 	"github.com/brimdata/zed/runtime"
 	"github.com/brimdata/zed/runtime/exec"
@@ -601,6 +602,34 @@ func handleDelete(c *Core, w *ResponseWriter, r *Request) {
 		PoolID:   pool.ID,
 		Branch:   branchName,
 	})
+}
+
+func handleVacate(c *Core, w *ResponseWriter, r *Request) {
+	pool, ok := r.StringFromPath(w, "pool")
+	if !ok {
+		return
+	}
+	dryrun, ok := r.BoolFromQuery(w, "dryrun")
+	if !ok {
+		return
+	}
+	s := r.URL.Query().Get("ts")
+	if s == "" {
+		w.Error(srverr.ErrInvalid("missing required query param: ts"))
+		return
+	}
+	ts, err := nano.ParseRFC3339Nano([]byte(s))
+	if err != nil {
+		w.Error(srverr.ErrInvalid("invalid timestamp value %q: %w", s, err))
+		return
+	}
+	db := lakeapi.FromRoot(c.root)
+	cids, err := db.Vacate(r.Context(), pool, ts, dryrun)
+	if err != nil {
+		w.Error(err)
+		return
+	}
+	w.Respond(http.StatusOK, api.VacateResponse{CommitIDs: cids})
 }
 
 func handleVacuum(c *Core, w *ResponseWriter, r *Request) {

--- a/service/ztests/vacate-conflict.yaml
+++ b/service/ztests/vacate-conflict.yaml
@@ -1,0 +1,20 @@
+# Test that vacate fails when trying to vacate while existing branch is
+# branched from earlier commit.
+script: |
+  source service.sh
+  zed create -use -q test
+  echo {x:1} | zed load -q -
+  zed branch -q branch1
+  zed branch -q branch2
+  echo {x:1} | zed load -q -use test@branch1 -
+  echo {x:1} | zed load -q -use test@branch2 -
+  echo {x:2} | zed load -q -
+  ! zed vacate -f
+
+inputs:
+  - name: service.sh
+
+outputs:
+  - name: stderr
+    data: |
+      status code 500: cannot vacate at selected time: branches do not include commit nearest timestamp in the deletion path: branch1, branch2

--- a/service/ztests/vacate.yaml
+++ b/service/ztests/vacate.yaml
@@ -1,0 +1,44 @@
+script: |
+  source service.sh
+  zed create -use -q test
+  echo {x:1} | zed load -message 'commit1' -q -
+  echo {x:2} | zed load -message 'commit2' -q -
+  echo {x:3} | zed load -message 'commit3' -q -
+  echo {x:4} | zed load -message 'commit4' -q -
+  zed vacate -dryrun
+  echo // ===
+  zed vacate -f
+  echo // === 
+  zed query -z 'from test:log | has(message) | yield message'
+  echo // === 
+  zed query -z 'from test'
+  ! zed vacate -f
+  echo {x:5} | zed load -message 'commit5' -q -
+  echo // === 
+  zed vacate -f
+  echo // === 
+  zed query -z 'from test:log | has(message) | yield message'
+
+inputs:
+  - name: service.sh
+
+outputs:
+  - name: stdout
+    data: |
+      would vacate 3 commits
+      // ===
+      vacated 3 commits
+      // ===
+      "commit4"
+      // ===
+      {x:4}
+      {x:3}
+      {x:2}
+      {x:1}
+      // ===
+      vacated 1 commit
+      // ===
+      "commit5"
+  - name: stderr
+    data: |
+      status code 500: cannot set base on earliest commit


### PR DESCRIPTION
This is a backport of the changes in #6706 that added `vacate` support to `super db`, with this backport adding equivalent functionality to `zed` (specifically, Zed as it was at the time of its final GA release [`v1.18.0`](https://github.com/brimdata/zed-archive/releases/tag/v1.18.0)).