### PR TITLE
rationalize aggregate operator error value handling

### DIFF
--- a/runtime/sam/expr/agg.go
+++ b/runtime/sam/expr/agg.go
@@ -41,7 +41,7 @@ func (a *Aggregator) Apply(sctx *super.Context, f agg.Function, this super.Value
 	}
 	v := a.expr.Eval(this)
 	v = v.Deunion()
-	if !v.IsMissing() {
+	if !v.IsQuiet() {
 		f.Consume(v)
 	}
 }

--- a/runtime/sam/op/aggregate/valrow.go
+++ b/runtime/sam/op/aggregate/valrow.go
@@ -1,12 +1,9 @@
 package aggregate
 
 import (
-	"fmt"
-
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/runtime/sam/expr"
 	"github.com/brimdata/super/runtime/sam/expr/agg"
-	"github.com/brimdata/super/sup"
 )
 
 type valRow []agg.Function
@@ -27,15 +24,6 @@ func (v valRow) apply(sctx *super.Context, aggs []*expr.Aggregator, this super.V
 
 func (v valRow) consumeAsPartial(rec super.Value, exprs []expr.Evaluator) {
 	for k, r := range v {
-		val := exprs[k].Eval(rec)
-		val = val.Deunion()
-		if val.IsError() {
-			panic(fmt.Errorf("consumeAsPartial: encountered error: %s", sup.FormatValue(val)))
-		}
-		//XXX should do soemthing with errors... they could come from
-		// a worker over the network?
-		if !val.IsError() {
-			r.ConsumeAsPartial(val)
-		}
+		r.ConsumeAsPartial(exprs[k].Eval(rec))
 	}
 }

--- a/runtime/vam/expr/agg/collect.go
+++ b/runtime/vam/expr/agg/collect.go
@@ -12,9 +12,6 @@ type collect struct {
 }
 
 func (c *collect) Consume(vec vector.Any) {
-	if _, ok := vec.(*vector.Error); ok {
-		return
-	}
 	typ := vec.Type()
 	var b scode.Builder
 	for i := range vec.Len() {

--- a/runtime/vam/expr/agg/count.go
+++ b/runtime/vam/expr/agg/count.go
@@ -10,7 +10,7 @@ type count struct {
 }
 
 func (a *count) Consume(vec vector.Any) {
-	if k := vec.Kind(); k == vector.KindNull || k == vector.KindError {
+	if vec.Kind() == vector.KindNull {
 		return
 	}
 	a.count += int64(vec.Len())

--- a/runtime/vam/expr/agg/union.go
+++ b/runtime/vam/expr/agg/union.go
@@ -25,7 +25,6 @@ func (u *union) Consume(vec vector.Any) {
 		u.samunion.Update(val.Type(), val.Bytes())
 	case *vector.Dict:
 		u.Consume(vec.Any)
-	case *vector.Error: // ignore
 	default:
 		typ := vec.Type()
 		var b scode.Builder

--- a/runtime/vam/op/aggregate/aggregate.go
+++ b/runtime/vam/op/aggregate/aggregate.go
@@ -90,7 +90,7 @@ func (a *Aggregate) Pull(done bool) (vector.Any, error) {
 }
 
 func (a *Aggregate) consume(keys []vector.Any, vals []vector.Any) {
-	keys, vals, ok := filterQuiet(keys, vals)
+	keys, vals, ok := removeQuietRows(keys, vals)
 	if !ok {
 		return
 	}
@@ -107,42 +107,67 @@ func (a *Aggregate) consume(keys []vector.Any, vals []vector.Any) {
 	table.update(keys, vals)
 }
 
-func filterQuiet(keys []vector.Any, vals []vector.Any) ([]vector.Any, []vector.Any, bool) {
+// removeQuietRows removes rows in which any key is error("quiet").  It returns
+// false if all rows are removed.
+func removeQuietRows(keys, vals []vector.Any) ([]vector.Any, []vector.Any, bool) {
+	if index, ok := notQuietIndex(keys...); ok {
+		if len(index) == 0 {
+			// All slots are quiet.
+			return nil, nil, false
+		}
+		for i, k := range keys {
+			keys[i] = vector.Pick(k, index)
+		}
+		for i, v := range vals {
+			vals[i] = vector.Pick(v, index)
+		}
+	}
+	return keys, vals, true
+}
+
+// notQuietIndex returns the slots that are not quiet across vecs (i.e., the
+// slot's value is not error("quiet") in any of vecs).  It returns nil, true if
+// all slots are quiet and false if no slots are quiet.
+func notQuietIndex(vecs ...vector.Any) ([]uint32, bool) {
+	rb := quietBitmap(vecs...)
+	if rb.IsEmpty() {
+		// No slots are quiet.
+		return nil, false
+	}
+	len := uint64(vecs[0].Len())
+	if rb.GetCardinality() == len {
+		// All slots are quiet.
+		return nil, true
+	}
+	rb.Flip(0, len)
+	return rb.ToArray(), true
+}
+
+// quietBitmap returns a bitmap in which the bit for each slot is set if the
+// slot's value is error("quiet") in any of vecs.
+func quietBitmap(vecs ...vector.Any) *roaring.Bitmap {
 	var rb roaring.Bitmap
-	for _, k := range keys {
-		errVec, ok := k.(*vector.Error)
+	for _, vec := range vecs {
+		errVec, ok := vec.(*vector.Error)
 		if !ok || errVec.Vals.Kind() != vector.KindString {
 			continue
 		}
-		vec := errVec.Vals
-		if c, ok := vec.(*vector.Const); ok {
+		valsVec := errVec.Vals
+		if c, ok := valsVec.(*vector.Const); ok {
 			if string(c.Value().Bytes()) == string(super.Quiet) {
-				// Every slot in this key is error("quiet").
-				return nil, nil, false
+				// Every slot is error("quiet").
+				rb.AddRange(0, uint64(valsVec.Len()))
+				return &rb
 			}
 			continue
 		}
-		for i := range vec.Len() {
-			if vector.StringValue(vec, i) == string(super.Quiet) {
+		for i := range valsVec.Len() {
+			if vector.StringValue(valsVec, i) == string(super.Quiet) {
 				rb.Add(i)
 			}
 		}
 	}
-	if rb.IsEmpty() {
-		return keys, vals, true
-	}
-	if rb.GetCardinality() == uint64(keys[0].Len()) {
-		// Every slot is error("quiet") in some key.
-		return nil, nil, false
-	}
-	index := rb.ToArray()
-	for i, k := range keys {
-		keys[i] = vector.Pick(k, index)
-	}
-	for i, v := range vals {
-		vals[i] = vector.Pick(v, index)
-	}
-	return keys, vals, true
+	return &rb
 }
 
 func (a *Aggregate) newAggTable(keyTypes []super.Type) aggTable {

--- a/runtime/vam/op/aggregate/aggtable.go
+++ b/runtime/vam/op/aggregate/aggtable.go
@@ -63,6 +63,10 @@ func (s *superTable) update(keys []vector.Any, args []vector.Any) {
 			if len(m) > 1 {
 				arg = vector.Pick(arg, index)
 			}
+			arg, ok := removeQuiet(arg)
+			if !ok {
+				continue
+			}
 			if s.partialsIn {
 				row.funcs[i].ConsumeAsPartial(arg)
 			} else {
@@ -70,6 +74,19 @@ func (s *superTable) update(keys []vector.Any, args []vector.Any) {
 			}
 		}
 	}
+}
+
+// removeQuiet removes any error("quiet") values from vec.  It returns false if
+// all values are error("quiet").
+func removeQuiet(vec vector.Any) (vector.Any, bool) {
+	if index, ok := notQuietIndex(vec); ok {
+		if len(index) == 0 {
+			// Every slot is error("quiet").
+			return nil, false
+		}
+		return vector.Pick(vec, index), true
+	}
+	return vec, true
 }
 
 func (s *superTable) newRow(keys []vector.Any, index []uint32) aggRow {

--- a/runtime/vam/op/aggregate/scalar.go
+++ b/runtime/vam/op/aggregate/scalar.go
@@ -60,17 +60,23 @@ func (s *scalarAggregate) Pull(done bool) (vector.Any, error) {
 				vals = append(vals, e.Eval(vec))
 			}
 		}
-		vector.Apply(true, func(vecs ...vector.Any) vector.Any {
-			for i, vec := range vecs {
-				if s.partialsIn {
-					s.funcs[i].ConsumeAsPartial(vec)
-				} else {
-					s.funcs[i].Consume(vec)
-				}
-			}
-			return vector.NewConst(super.Null, vecs[0].Len())
-		}, vals...)
+		vector.Apply(true, s.consume, vals...)
 	}
+}
+
+func (s *scalarAggregate) consume(vecs ...vector.Any) vector.Any {
+	for i, vec := range vecs {
+		vec, ok := removeQuiet(vec)
+		if !ok {
+			continue
+		}
+		if s.partialsIn {
+			s.funcs[i].ConsumeAsPartial(vec)
+		} else {
+			s.funcs[i].Consume(vec)
+		}
+	}
+	return vector.NewConst(super.Null, vecs[0].Len())
 }
 
 func newFuncs(aggs []*expr.Aggregator) []agg.Func {

--- a/runtime/ztests/op/aggregate/any.yaml
+++ b/runtime/ztests/op/aggregate/any.yaml
@@ -6,7 +6,11 @@ input: |
   {k:"k1",v:null}
   {k:"k1",v:1}
   {k:"k2",v:null}
+  {k:"k3",v:error("missing")}
+  {k:"k4",v:error("quiet")}
 
 output: |
   {k:"k1",any:1}
   {k:"k2",any:null}
+  {k:"k3",any:error("missing")}
+  {k:"k4",any:null}

--- a/runtime/ztests/op/aggregate/collect.yaml
+++ b/runtime/ztests/op/aggregate/collect.yaml
@@ -7,6 +7,8 @@ input: |
   {a:2}
   null
   {b:1.5}
+  error("missing")
+  error("quiet")
 
 output: |
-  [{a:1},{a:2},{b:1.5}]
+  [{a:1},{a:2},{b:1.5},error("missing")]

--- a/runtime/ztests/op/aggregate/container-partials.yaml
+++ b/runtime/ztests/op/aggregate/container-partials.yaml
@@ -1,6 +1,7 @@
 # This test exercises the partials paths in the reducers by doing an aggregate
 # with a single-row limit.  We also make sure the partials consumer can handle
-# an empty input by including a record for key "a" with no value field.
+# an empty input by including a record for key "a" with error("quiet") in the
+# value field.
 script: |
   super -s -c "union(x) by key with -limit 1 | sort key" in.sup > union.sup
   super -s -c "collect(x) by key with -limit 1 | sort key" in.sup > collect.sup
@@ -16,9 +17,9 @@ inputs:
       {key:"b",x:1::int32}
       {key:"a",x:8::int32}
       {key:"b",x:1::int32}
-      {key:"a"}
-      {key:"a"}
-      {key:"a"}
+      {key:"a",x:error("quiet")}
+      {key:"a",x:error("quiet")}
+      {key:"a",x:error("quiet")}
 
 outputs:
   - name: union.sup

--- a/runtime/ztests/op/aggregate/count-star.yaml
+++ b/runtime/ztests/op/aggregate/count-star.yaml
@@ -8,4 +8,4 @@ input: |
   {a:null}
 
 output: |
-  {c1:3,c2:3,c3:1}
+  {c1:3,c2:3,c3:2}

--- a/runtime/ztests/op/aggregate/count.yaml
+++ b/runtime/ztests/op/aggregate/count.yaml
@@ -13,9 +13,8 @@ input: |
   {_path:"conn",foo:"8"}
   {_path:"conn",foo:"9"}
   {_path:"conn",foo:"10"}
-
-output-flags: -f table
+  error("missing")
+  error("quiet")
 
 output: |
-  count
-  10
+  {count:12}

--- a/runtime/ztests/op/aggregate/dcount.yaml
+++ b/runtime/ztests/op/aggregate/dcount.yaml
@@ -8,6 +8,8 @@ input: |
   {x:1}
   {x:1::int8}
   1
+  error("missing")
+  error("quiet")
 
 output: |
-  {dcount:3}
+  {dcount:4}

--- a/runtime/ztests/op/aggregate/distinct.yaml
+++ b/runtime/ztests/op/aggregate/distinct.yaml
@@ -21,8 +21,10 @@ input: |
   {key:"a",n:2,b:false}
   {key:"b",n:1,b:true}
   {key:"b",n:0,b:true}
-  {key:"a",n:1,b:false}
+  {key:"c",n:error("missing"),b:error("missing")}
+  {key:"c",n:error("quiet"),b:error("quiet")}
 
 output: |
   {key:"a",and:false,any:1,avg:1.5,collect:["a"],count:2,dcount:2,max:2,min:1,or:true,sum:3,union:|[1,2]|}
   {key:"b",and:true,any:1,avg:0.5,collect:["b"],count:2,dcount:2,max:1,min:0,or:true,sum:1,union:|[0,1]|}
+  {key:"c",and:null,any:error("missing"),avg:null,collect:["c"],count:1,dcount:1,max:null,min:null,or:null,sum:null,union:|[error("missing")]|}

--- a/runtime/ztests/op/aggregate/fuse.yaml
+++ b/runtime/ztests/op/aggregate/fuse.yaml
@@ -5,6 +5,21 @@ vector: true
 input: |
   {a:"hello",b:"world"}
   {a:"goodnight",b:123::int32}
+  error("missing")
+
+output: |
+  <{a:string,b:int32|string}|error(string)>
+
+---
+
+spq: fuse(this)
+
+vector: true
+
+input: |
+  {a:"hello",b:"world"}
+  {a:"goodnight",b:123::int32}
+  error("quiet")
 
 output: |
   <{a:string,b:int32|string}>

--- a/runtime/ztests/op/aggregate/reducers.yaml
+++ b/runtime/ztests/op/aggregate/reducers.yaml
@@ -6,7 +6,10 @@ input: |
   {key1:"a",key2:"x",n:1::int32}
   {key1:"a",key2:"y",n:2::int32}
   {key1:"b",key2:"z",n:1::int32}
+  {key1:"c",key2:"0",n:error("missing")}
+  {key1:"c",key2:"1",n:error("quiet")}
 
 output: |
   {key1:"a",any:1::int32,sum:3,avg:1.5,min:1,max:2}
   {key1:"b",any:1::int32,sum:1,avg:1.,min:1,max:1}
+  {key1:"c",any:error("missing"),sum:null,avg:null,min:null,max:null}


### PR DESCRIPTION
Error value handling in the aggregate operator differs between sam and vam, and neither implementation is really consistent with the philosophy for error value handling in other parts of the system.  Improve the situation by making both implementations consistent about ignoring error("quiet") and preserving other errors.

Partially fixes #5039