### PR TITLE
vam: fix malformed vector bug in unnest operator

### DIFF
--- a/runtime/vam/op/unnest.go
+++ b/runtime/vam/op/unnest.go
@@ -68,8 +68,11 @@ func (u *Unnest) flatten(vec vector.Any, slot uint32) vector.Any {
 		}
 		right := u.flatten(fields[1], slot)
 		lindex := make([]uint32, right.Len())
-		left := vector.NewView(vector.Pick(fields[0], []uint32{slot}), lindex)
-		return vector.Apply(true, func(vecs ...vector.Any) vector.Any {
+		for i := range lindex {
+			lindex[i] = slot
+		}
+		left := vector.Pick(fields[0], lindex)
+		return vector.Apply(false, func(vecs ...vector.Any) vector.Any {
 			fields := slices.Clone(vec.Typ.Fields)
 			fields[1].Type = vecs[1].Type()
 			typ := u.sctx.MustLookupTypeRecord(fields)
@@ -94,7 +97,9 @@ func flattenArrayOrSet(vec vector.Any, offsets []uint32, slot uint32) vector.Any
 	if len(index) == 0 {
 		return nil
 	}
-	return vector.Pick(vector.Deunion(vec), index)
+	// Deunion deeply.
+	vec = vector.Apply(true, func(vecs ...vector.Any) vector.Any { return vecs[0] }, vec)
+	return vector.Pick(vec, index)
 }
 
 // deunionTypeOf returns the type of the value beneath any unions at slot in

--- a/runtime/ztests/op/unnest.yaml
+++ b/runtime/ztests/op/unnest.yaml
@@ -18,3 +18,21 @@ output: |
   7
   8
   9
+
+---
+
+spq: unnest {a,b} | values a+b
+
+vector: true
+
+input: |
+  {a:1,b:[1,2,3]}
+  {a:2,b:[10,20,30]}
+
+output: |
+  2
+  3
+  4
+  12
+  22
+  32


### PR DESCRIPTION
The vam unnest operator can produce "unconventional" vectors that other parts of the runtime can't handle because it calls vector.NewView directly.  For example, this can produce a vector.View containing a vector.Const, which will cause the arithmetic and comparison operators to panic, instead of a new vector.Const with the desired length. Replace vector.NewView with vector.Pick, which always returns conventional vectors.