### PR TITLE
remove some string.Builder fields

### DIFF
--- a/runtime/sam/expr/function/string.go
+++ b/runtime/sam/expr/function/string.go
@@ -9,13 +9,12 @@ import (
 )
 
 type Concat struct {
-	sctx    *super.Context
-	builder strings.Builder
+	sctx *super.Context
 }
 
 func (c *Concat) Call(args []super.Value) super.Value {
 	args = underAll(args)
-	c.builder.Reset()
+	var b strings.Builder
 	for _, arg := range args {
 		if arg.IsError() {
 			return arg
@@ -26,9 +25,9 @@ func (c *Concat) Call(args []super.Value) super.Value {
 		if !arg.IsString() {
 			return c.sctx.WrapError("concat: string arg required", arg)
 		}
-		c.builder.WriteString(super.DecodeString(arg.Bytes()))
+		b.WriteString(super.DecodeString(arg.Bytes()))
 	}
-	return super.NewString(c.builder.String())
+	return super.NewString(b.String())
 }
 
 type Position struct {
@@ -161,8 +160,7 @@ func (s *Split) Call(args []super.Value) super.Value {
 }
 
 type Join struct {
-	sctx    *super.Context
-	builder strings.Builder
+	sctx *super.Context
 }
 
 func (j *Join) Call(args []super.Value) super.Value {
@@ -185,10 +183,9 @@ func (j *Join) Call(args []super.Value) super.Value {
 		}
 		separator = super.DecodeString(sepVal.Bytes())
 	}
-	b := j.builder
-	b.Reset()
-	it := splitsVal.Bytes().Iter()
+	var b strings.Builder
 	var sep string
+	it := splitsVal.Bytes().Iter()
 	for !it.Done() {
 		b.WriteString(sep)
 		b.WriteString(super.DecodeString(it.Next()))

--- a/runtime/vam/expr/function/string.go
+++ b/runtime/vam/expr/function/string.go
@@ -10,8 +10,7 @@ import (
 )
 
 type Concat struct {
-	sctx    *super.Context
-	builder strings.Builder
+	sctx *super.Context
 }
 
 func (c *Concat) Call(args ...vector.Any) vector.Any {
@@ -24,22 +23,20 @@ func (c *Concat) Call(args ...vector.Any) vector.Any {
 			return vector.NewWrappedError(c.sctx, "concat: string arg required", arg)
 		}
 	}
-	n := args[0].Len()
 	out := vector.NewStringEmpty(0)
-	for i := range n {
-		c.builder.Reset()
+	for i := range args[0].Len() {
+		var b strings.Builder
 		for _, arg := range args {
 			s := vector.StringValue(arg, i)
-			c.builder.WriteString(s)
+			b.WriteString(s)
 		}
-		out.Append(c.builder.String())
+		out.Append(b.String())
 	}
 	return out
 }
 
 type Join struct {
-	sctx    *super.Context
-	builder strings.Builder
+	sctx *super.Context
 }
 
 func (j *Join) Call(args ...vector.Any) vector.Any {
@@ -66,15 +63,15 @@ func (j *Join) Call(args ...vector.Any) vector.Any {
 			seperator = vector.StringValue(sepVal, i)
 		}
 		off, end := vector.ContainerOffset(splitsVal, i)
-		j.builder.Reset()
+		var b strings.Builder
 		var sep string
 		for ; off < end; off++ {
 			s := vector.StringValue(inner, off)
-			j.builder.WriteString(sep)
-			j.builder.WriteString(s)
+			b.WriteString(sep)
+			b.WriteString(s)
 			sep = seperator
 		}
-		out.Append(j.builder.String())
+		out.Append(b.String())
 	}
 	return out
 }


### PR DESCRIPTION
A few structs contain a string.Builder field intended to reduce load on the garbage collector.  Since string.Builder contains no reusable state after a call to its Reset method, remove the fields in favor of stack allocation.  It's simpler and no more expensive.