### PR TITLE
add vector.Null

### DIFF
--- a/runtime/vam/expr/aggregator.go
+++ b/runtime/vam/expr/aggregator.go
@@ -46,12 +46,12 @@ func (*Aggregator) apply(args ...vector.Any) vector.Any {
 	bools, _ := BoolMask(where)
 	if bools.IsEmpty() {
 		// everything is filtered.
-		return vector.NewConst(super.Null, vec.Len())
+		return vector.NewNull(vec.Len())
 	}
 	if bools.GetCardinality() == uint64(vec.Len()) {
 		return vec
 	}
 	index := bools.ToArray()
-	nulls := vector.NewConst(super.Null, vec.Len()-uint32(len(index)))
+	nulls := vector.NewNull(vec.Len() - uint32(len(index)))
 	return vector.Combine(nulls, index, vector.Pick(vec, index))
 }

--- a/runtime/vam/expr/arrayexpr.go
+++ b/runtime/vam/expr/arrayexpr.go
@@ -27,7 +27,7 @@ func (a *ArrayExpr) Eval(this vector.Any) vector.Any {
 	if len(a.elems) == 0 {
 		typ := a.sctx.LookupTypeArray(super.TypeNull)
 		offsets := make([]uint32, this.Len()+1)
-		nullVec := vector.NewConst(super.Null, 0)
+		nullVec := vector.NewNull(0)
 		return vector.NewArray(typ, offsets, nullVec)
 	}
 	var vecs []vector.Any

--- a/runtime/vam/expr/cast/cast.go
+++ b/runtime/vam/expr/cast/cast.go
@@ -21,7 +21,7 @@ func To(sctx *super.Context, vec vector.Any, typ super.Type) vector.Any {
 			tags[i] = uint32(tag)
 		}
 		vecs := make([]vector.Any, len(union.Types))
-		vecs[tag] = vector.NewConst(super.Null, vec.Len())
+		vecs[tag] = vector.NewNull(vec.Len())
 		return vector.NewUnion(union, tags, vecs)
 	case vector.KindError:
 		return vec

--- a/runtime/vam/expr/function/coalesce.go
+++ b/runtime/vam/expr/function/coalesce.go
@@ -1,7 +1,6 @@
 package function
 
 import (
-	"github.com/brimdata/super"
 	"github.com/brimdata/super/vector"
 )
 
@@ -15,5 +14,5 @@ func (c *Coalesce) Call(vecs ...vector.Any) vector.Any {
 			return vec
 		}
 	}
-	return vector.NewConst(super.Null, vecs[0].Len())
+	return vector.NewNull(vecs[0].Len())
 }

--- a/runtime/vam/expr/function/nullif.go
+++ b/runtime/vam/expr/function/nullif.go
@@ -22,7 +22,7 @@ func (n *NullIf) Call(vecs ...vector.Any) vector.Any {
 		return vecs[1]
 	}
 	result := n.compare.Compare(vecs[0], vecs[1])
-	if result.Type().Kind() == super.ErrorKind {
+	if k := result.Kind(); k == vector.KindNull || k == vector.KindError {
 		return vecs[0]
 	}
 	var index []uint32
@@ -34,7 +34,7 @@ func (n *NullIf) Call(vecs ...vector.Any) vector.Any {
 	if len(index) == 0 {
 		return vecs[0]
 	}
-	nullsVec := vector.NewConst(super.Null, uint32(len(index)))
+	nullsVec := vector.NewNull(uint32(len(index)))
 	if len(index) == int(vecs[0].Len()) {
 		return nullsVec
 	}

--- a/runtime/vam/expr/literal.go
+++ b/runtime/vam/expr/literal.go
@@ -16,5 +16,8 @@ func NewLiteral(val super.Value) *Literal {
 }
 
 func (l Literal) Eval(val vector.Any) vector.Any {
+	if l.val.IsNull() {
+		return vector.NewNull(val.Len())
+	}
 	return vector.NewConst(l.val, val.Len())
 }

--- a/runtime/vam/expr/logic.go
+++ b/runtime/vam/expr/logic.go
@@ -311,7 +311,7 @@ func (p *PredicateWalk) evalForList(lhs, rhs vector.Any, offsets, index []uint32
 	}
 	truesVec := vector.NewFalse(n)
 	trues.WriteDenseTo(truesVec.GetBits())
-	nullsVec := vector.NewConst(super.Null, n)
+	nullsVec := vector.NewNull(n)
 	return combine(truesVec, nullsVec, nulls.ToArray())
 }
 
@@ -328,7 +328,7 @@ func hasTrue(vec vector.Any) bool {
 	var hasTrue bool
 	vector.Apply(true, func(vecs ...vector.Any) vector.Any {
 		vec := vecs[0]
-		if !hasTrue {
+		if !hasTrue && vec.Kind() == vector.KindBool {
 			for i := range vec.Len() {
 				if vector.BoolValue(vec, i) {
 					hasTrue = true

--- a/runtime/vam/expr/mapexpr.go
+++ b/runtime/vam/expr/mapexpr.go
@@ -27,7 +27,7 @@ func (m *MapExpr) Eval(this vector.Any) vector.Any {
 	if len(m.entries) == 0 {
 		mtyp := m.sctx.LookupTypeMap(super.TypeNull, super.TypeNull)
 		offsets := make([]uint32, this.Len()+1)
-		c := vector.NewConst(super.Null, 0)
+		c := vector.NewNull(0)
 		return vector.NewMap(mtyp, offsets, c, c)
 	}
 	var vecs []vector.Any

--- a/runtime/vam/expr/quiet.go
+++ b/runtime/vam/expr/quiet.go
@@ -98,5 +98,5 @@ func (d *Dequiet) dequiet(vec vector.Any) vector.Any {
 }
 
 func (d *Dequiet) quietTmp(n uint32) vector.Any {
-	return vector.NewError(d.rmtyp, vector.NewConst(super.Null, n))
+	return vector.NewError(d.rmtyp, vector.NewNull(n))
 }

--- a/runtime/vam/expr/search.go
+++ b/runtime/vam/expr/search.go
@@ -38,6 +38,9 @@ func NewSearch(sctx *super.Context, s string, val super.Value, e Evaluator) Eval
 			}
 			return out
 		}
+		if val.IsNull() {
+			return vector.NewNull(vec.Len())
+		}
 		return eq.eval(vec, vector.NewConst(val, vec.Len()))
 	}
 	return &search{sctx, e, vectorPred, stringPred, nil}

--- a/runtime/vam/expr/setexpr.go
+++ b/runtime/vam/expr/setexpr.go
@@ -19,7 +19,7 @@ func (s *setExpr) Eval(this vector.Any) vector.Any {
 	if len(s.elems) == 0 {
 		typ := s.sctx.LookupTypeSet(super.TypeNull)
 		offsets := make([]uint32, this.Len()+1)
-		c := vector.NewConst(super.Null, 0)
+		c := vector.NewNull(0)
 		return vector.NewSet(typ, offsets, c)
 	}
 	var vecs []vector.Any

--- a/runtime/vam/expr/udf.go
+++ b/runtime/vam/expr/udf.go
@@ -32,7 +32,7 @@ func (u *UDF) Call(args ...vector.Any) vector.Any {
 	}
 	defer func() { u.stackDepth-- }()
 	if len(u.fields) == 0 {
-		return u.Body.Eval(vector.NewConst(super.Null, args[0].Len()))
+		return u.Body.Eval(vector.NewNull(args[0].Len()))
 	}
 	fields := slices.Clone(u.fields)
 	for i := range args {

--- a/runtime/vam/op/aggregate/aggregate.go
+++ b/runtime/vam/op/aggregate/aggregate.go
@@ -84,7 +84,7 @@ func (a *Aggregate) Pull(done bool) (vector.Any, error) {
 			a.consume(args[:len(keys)], args[len(keys):])
 			// XXX Perhaps there should be a "consume" version of Apply where
 			// no return value is expected.
-			return vector.NewConst(super.Null, args[0].Len())
+			return vector.NewNull(args[0].Len())
 		}, append(keys, vals...)...)
 	}
 }

--- a/runtime/vam/op/aggregate/aggtable.go
+++ b/runtime/vam/op/aggregate/aggtable.go
@@ -105,7 +105,7 @@ func (s *superTable) newRow(keys []vector.Any, index []uint32) aggRow {
 
 func (s *superTable) materialize() vector.Any {
 	if len(s.rows) == 0 {
-		return vector.NewConst(super.Null, 0)
+		return vector.NewNull(0)
 	}
 	var vecs []vector.Any
 	for i := range s.rows[0].keys {

--- a/runtime/vam/op/aggregate/scalar.go
+++ b/runtime/vam/op/aggregate/scalar.go
@@ -76,7 +76,7 @@ func (s *scalarAggregate) consume(vecs ...vector.Any) vector.Any {
 			s.funcs[i].Consume(vec)
 		}
 	}
-	return vector.NewConst(super.Null, vecs[0].Len())
+	return vector.NewNull(vecs[0].Len())
 }
 
 func newFuncs(aggs []*expr.Aggregator) []agg.Func {

--- a/runtime/vam/op/cachedsubquery.go
+++ b/runtime/vam/op/cachedsubquery.go
@@ -39,7 +39,7 @@ func (c *cachedSubquery) exec() vector.Any {
 		vecs = append(vecs, vec)
 	}
 	if len(vecs) == 0 {
-		return vector.NewConst(super.Null, 1)
+		return vector.NewNull(1)
 	}
 	if len(vecs) == 1 && vecs[0].Len() == 1 {
 		return vecs[0]

--- a/runtime/vcache/const.go
+++ b/runtime/vcache/const.go
@@ -29,6 +29,9 @@ func (c *const_) project(loader *loader, projection field.Projection) vector.Any
 	// Map the const super.Value in the csup's type context to
 	// a new one in the query type context.
 	val := c.meta.Value
+	if val.IsNull() {
+		return vector.NewNull(c.length())
+	}
 	typ, err := loader.sctx.TranslateType(val.Type())
 	if err != nil {
 		panic(err)

--- a/runtime/vcache/primitive.go
+++ b/runtime/vcache/primitive.go
@@ -130,7 +130,7 @@ func (p *primitive) newVector(loader *loader) vector.Any {
 	case *super.TypeEnum:
 		return vector.NewEnum(typ, p.load(loader).([]uint64))
 	case *super.TypeOfNull:
-		return vector.NewConst(super.Null, p.length())
+		return vector.NewNull(p.length())
 	}
 	panic(fmt.Errorf("internal error: vcache.loadPrimitive got unknown type %#v", p.meta.Typ))
 }

--- a/sio/parquetio/vectorreader.go
+++ b/sio/parquetio/vectorreader.go
@@ -161,7 +161,7 @@ func (v *vectorBuilder) build(a arrow.Array, nullable bool) (vector.Any, error) 
 	// Order here follows that of the arrow.Type constants.
 	switch dt.ID() {
 	case arrow.NULL:
-		return vector.NewConst(super.Null, length), nil
+		return vector.NewNull(length), nil
 	case arrow.BOOL:
 		vec := vector.NewFalse(length)
 		arr := a.(*array.Boolean)
@@ -394,7 +394,7 @@ func (v *vectorBuilder) buildNullableUnion(vec vector.Any, a arrow.Array) vector
 		}
 	}
 	var vecs [2]vector.Any
-	vecs[nullTag] = vector.NewConst(super.Null, vec.Len()-uint32(len(vecIndex)))
+	vecs[nullTag] = vector.NewNull(vec.Len() - uint32(len(vecIndex)))
 	vecs[vecTag] = vector.Pick(vec, vecIndex)
 	return vector.NewUnion(unionType, tags, vecs[:])
 }

--- a/vector/builder.go
+++ b/vector/builder.go
@@ -411,10 +411,10 @@ type nullBuilder struct {
 	n uint32
 }
 
-func (c *nullBuilder) Write(bytes scode.Bytes) {
+func (c *nullBuilder) Write(scode.Bytes) {
 	c.n++
 }
 
-func (c *nullBuilder) Build(sctx *super.Context) Any {
-	return NewConst(super.Null, c.n)
+func (c *nullBuilder) Build(*super.Context) Any {
+	return NewNull(c.n)
 }

--- a/vector/const.go
+++ b/vector/const.go
@@ -16,6 +16,9 @@ type Const struct {
 var _ Any = (*Const)(nil)
 
 func NewConst(val super.Value, len uint32) *Const {
+	if val.IsNull() {
+		panic("null val")
+	}
 	return &Const{val, len}
 }
 
@@ -40,8 +43,6 @@ func (c *Const) Kind() Kind {
 		return KindNet
 	case id == super.IDType:
 		return KindType
-	case id == super.IDNull:
-		return KindNull
 	}
 	panic(fmt.Sprintf("%#v\n", super.TypeUnder(c.val.Type())))
 }

--- a/vector/null.go
+++ b/vector/null.go
@@ -1,0 +1,30 @@
+package vector
+
+import (
+	"github.com/brimdata/super"
+	"github.com/brimdata/super/scode"
+)
+
+type Null struct {
+	len uint32
+}
+
+func NewNull(len uint32) *Null {
+	return &Null{len}
+}
+
+func (*Null) Kind() Kind {
+	return KindNull
+}
+
+func (n *Null) Len() uint32 {
+	return n.len
+}
+
+func (*Null) Serialize(b *scode.Builder, _ uint32) {
+	b.Append(nil)
+}
+
+func (*Null) Type() super.Type {
+	return super.TypeNull
+}


### PR DESCRIPTION
It replaces vector.Const with super.Null inside as the representation for null vectors.

This is a step toward changing the value wrapped inside vector.Const from super.Value to vector.Any.