### PR TITLE
change the CSUP write path to take vectors instead of super.Values

### DIFF
--- a/csup/array.go
+++ b/csup/array.go
@@ -4,7 +4,7 @@ import (
 	"io"
 
 	"github.com/brimdata/super"
-	"github.com/brimdata/super/scode"
+	"github.com/brimdata/super/vector"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -25,15 +25,22 @@ func NewArrayEncoder(typ *super.TypeArray) *ArrayEncoder {
 	}
 }
 
-func (a *ArrayEncoder) Write(body scode.Bytes) {
-	a.count++
-	it := body.Iter()
-	var len uint32
-	for !it.Done() {
-		a.values.Write(it.Next())
-		len++
+func (a *ArrayEncoder) Write(vec vector.Any) {
+	if vec.Len() == 0 {
+		return
 	}
-	a.offsets.writeLen(len)
+	switch vec := vec.(type) {
+	case *vector.Array:
+		a.count += vec.Len()
+		a.values.Write(vec.Values)
+		a.offsets.write(vec.Offsets)
+	case *vector.Set:
+		a.count += vec.Len()
+		a.values.Write(vec.Values)
+		a.offsets.write(vec.Offsets)
+	default:
+		panic(vec)
+	}
 }
 
 func (a *ArrayEncoder) Encode(group *errgroup.Group) {

--- a/csup/bytes.go
+++ b/csup/bytes.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/scode"
+	"github.com/brimdata/super/vector"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -14,7 +15,7 @@ type BytesEncoder struct {
 	typ      super.Type
 	min, max []byte
 	bytes    scode.Bytes
-	offsets  Uint32Encoder
+	offsets  *offsetsEncoder
 
 	// These values are used for the Encode pass.
 	bytesFmt uint8
@@ -26,19 +27,43 @@ func NewBytesEncoder(typ super.Type) *BytesEncoder {
 	return &BytesEncoder{
 		typ:     typ,
 		bytes:   scode.Bytes{},
-		offsets: Uint32Encoder{vals: []uint32{0}},
+		offsets: newOffsetsEncoder(),
 	}
 }
 
-func (b *BytesEncoder) Write(vb scode.Bytes) {
-	if len(b.bytes) == 0 || bytes.Compare(vb, b.min) < 0 {
-		b.min = append(b.min[:0], vb...)
+func (b *BytesEncoder) Write(vec vector.Any) {
+	if vec.Len() == 0 {
+		return
 	}
-	if len(b.bytes) == 0 || bytes.Compare(vb, b.max) > 0 {
-		b.max = append(b.max[:0], vb...)
+	switch vec := vec.(type) {
+	case *vector.Bytes:
+		b.writeTable(vec.Table())
+	case *vector.String:
+		b.writeTable(vec.Table())
+	case *vector.TypeValue:
+		b.writeTable(vec.Table())
+	default:
+		panic(vec)
 	}
-	b.bytes = append(b.bytes, vb...)
-	b.offsets.Write(uint32(len(b.bytes)))
+}
+
+func (b *BytesEncoder) writeTable(table vector.BytesTable) {
+	if len(b.bytes) == 0 {
+		val := table.Bytes(0)
+		b.min = append(b.min[:0], val...)
+		b.max = append(b.max[:0], val...)
+	}
+	for slot := range table.Len() {
+		val := table.Bytes(slot)
+		if bytes.Compare(val, b.min) < 0 {
+			b.min = append(b.min[:0], val...)
+		}
+		if bytes.Compare(val, b.max) > 0 {
+			b.max = append(b.max[:0], val...)
+		}
+	}
+	b.bytes = append(b.bytes, table.RawBytes()...)
+	b.offsets.write(table.RawOffsets())
 }
 
 func (b *BytesEncoder) Encode(group *errgroup.Group) {
@@ -88,17 +113,20 @@ func (b *BytesEncoder) value(slot uint32) []byte {
 }
 
 func (b *BytesEncoder) Dict() (PrimitiveEncoder, []byte, []uint32) {
+	if len(b.bytes) == 0 {
+		return nil, nil, nil
+	}
 	m := make(map[string]byte)
 	var counts []uint32
 	index := make([]byte, len(b.offsets.vals)-1)
-	entries := NewBytesEncoder(b.typ)
+	table := vector.NewBytesTableEmpty(256)
 	for k := range uint32(len(index)) {
 		tag, ok := m[string(b.value(k))]
 		if !ok {
 			tag = byte(len(counts))
 			v := b.value(k)
 			m[string(v)] = tag
-			entries.Write(v)
+			table.Append(v)
 			counts = append(counts, 0)
 			if len(counts) > math.MaxUint8 {
 				return nil, nil, nil
@@ -107,7 +135,9 @@ func (b *BytesEncoder) Dict() (PrimitiveEncoder, []byte, []uint32) {
 		index[k] = tag
 		counts[tag]++
 	}
-	return entries, index, counts
+	encoder := NewBytesEncoder(b.typ)
+	encoder.Write(vector.NewBytes(table))
+	return encoder, index, counts
 }
 
 func (b *BytesEncoder) ConstValue() super.Value {

--- a/csup/dynamic.go
+++ b/csup/dynamic.go
@@ -4,12 +4,14 @@ import (
 	"io"
 
 	"github.com/brimdata/super"
+	"github.com/brimdata/super/vector"
 	"golang.org/x/sync/errgroup"
 )
 
 type DynamicEncoder struct {
 	cctx   *Context
-	tags   Uint32Encoder
+	tags   []uint32
+	tagEnc *Uint32Encoder
 	values []Encoder
 	which  map[super.Type]uint32
 	len    uint32
@@ -26,23 +28,56 @@ func NewDynamicEncoder() *DynamicEncoder {
 // written to it.  No need to define the schema up front!
 // We track the types seen first-come, first-served and the
 // CSUP metadata structure follows accordingly.
-func (d *DynamicEncoder) Write(val super.Value) {
-	typ := val.Type()
+func (d *DynamicEncoder) Write(vec vector.Any) {
+	if vec.Len() == 0 {
+		return
+	}
+	if dynamic, ok := vec.(*vector.Dynamic); ok {
+		d.appendDynamic(dynamic)
+	} else {
+		d.appendVec(vec)
+	}
+}
+
+func (d *DynamicEncoder) appendDynamic(vec *vector.Dynamic) {
+	var tagmap []uint32 // input tags to local tags
+	for _, vec := range vec.Values {
+		tagmap = append(tagmap, d.lookupType(vec.Type()))
+	}
+	for _, intag := range vec.Tags {
+		d.tags = append(d.tags, tagmap[intag])
+	}
+	for intag, vec := range vec.Values {
+		d.values[tagmap[intag]].Write(vec)
+	}
+	d.len += vec.Len()
+}
+
+func (d *DynamicEncoder) appendVec(vec vector.Any) {
+	tag := d.lookupType(vec.Type())
+	for range vec.Len() {
+		//XXX there's a better way, but let's get this working
+		d.tags = append(d.tags, tag)
+	}
+	d.values[tag].Write(vec)
+	d.len += vec.Len()
+}
+
+func (d *DynamicEncoder) lookupType(typ super.Type) uint32 {
 	tag, ok := d.which[typ]
 	if !ok {
 		tag = uint32(len(d.values))
 		d.values = append(d.values, NewEncoder(typ))
 		d.which[typ] = tag
 	}
-	d.tags.Write(tag)
-	d.len++
-	d.values[tag].Write(val.Bytes())
+	return tag
 }
 
 func (d *DynamicEncoder) Encode() (ID, uint64, error) {
 	var group errgroup.Group
+	d.tagEnc = &Uint32Encoder{vals: d.tags}
 	if len(d.values) > 1 {
-		d.tags.Encode(&group)
+		d.tagEnc.Encode(&group)
 	}
 	for _, val := range d.values {
 		val.Encode(&group)
@@ -55,7 +90,7 @@ func (d *DynamicEncoder) Encode() (ID, uint64, error) {
 		return id, off, nil
 	}
 	values := make([]ID, 0, len(d.values))
-	off, tags := d.tags.Segment(0)
+	off, tags := d.tagEnc.Segment(0)
 	for _, val := range d.values {
 		var id ID
 		off, id = val.Metadata(d.cctx, off)
@@ -70,7 +105,7 @@ func (d *DynamicEncoder) Encode() (ID, uint64, error) {
 
 func (d *DynamicEncoder) Emit(w io.Writer) error {
 	if len(d.values) > 1 {
-		if err := d.tags.Emit(w); err != nil {
+		if err := d.tagEnc.Emit(w); err != nil {
 			return err
 		}
 	}

--- a/csup/encoder.go
+++ b/csup/encoder.go
@@ -5,13 +5,13 @@ import (
 	"io"
 
 	"github.com/brimdata/super"
-	"github.com/brimdata/super/scode"
+	"github.com/brimdata/super/vector"
 	"golang.org/x/sync/errgroup"
 )
 
 type Encoder interface {
 	// Write collects up values to be encoded into memory.
-	Write(scode.Bytes)
+	Write(vector.Any)
 	// Encode encodes all in-memory vector data into its storage-ready serialized format.
 	// Vectors may be encoded concurrently and errgroup.Group is used to sync
 	// and return errors.
@@ -89,6 +89,10 @@ func (n *NamedEncoder) Metadata(cctx *Context, off uint64) (uint64, ID) {
 	return off, cctx.enter(&Named{n.name, id})
 }
 
+func (n *NamedEncoder) Write(vec vector.Any) {
+	n.Encoder.Write(vec.(*vector.Named).Any)
+}
+
 type ErrorEncoder struct {
 	Encoder
 }
@@ -96,4 +100,8 @@ type ErrorEncoder struct {
 func (e *ErrorEncoder) Metadata(cctx *Context, off uint64) (uint64, ID) {
 	off, id := e.Encoder.Metadata(cctx, off)
 	return off, cctx.enter(&Error{id})
+}
+
+func (e *ErrorEncoder) Write(vec vector.Any) {
+	e.Encoder.Write(vec.(*vector.Error).Vals)
 }

--- a/csup/field.go
+++ b/csup/field.go
@@ -3,7 +3,6 @@ package csup
 import (
 	"io"
 
-	"github.com/brimdata/super/scode"
 	"github.com/brimdata/super/vector"
 	"golang.org/x/sync/errgroup"
 )
@@ -12,15 +11,21 @@ type FieldEncoder struct {
 	name   string
 	values Encoder
 	opt    bool
-	rle    vector.RLE
+	rle    []uint32
 	nones  *Uint32Encoder
 }
 
-func (f *FieldEncoder) write(body scode.Bytes, slot uint32) {
-	f.values.Write(body)
-	if f.opt {
-		f.rle.Touch(slot)
+func (f *FieldEncoder) write(vec vector.Any) {
+	if opt, ok := vec.(*vector.Optional); ok {
+		// RLEs have the nice property that you can just concatenate them
+		// to append two vectors.
+		// XXX We currently compute the RLE from the Dynamic but Optional needs
+		// to be updated to keep the RLEs around and materialize the Dynamic on demand.
+		f.rle = append(f.rle, opt.RLE()...)
+		vec = opt.Values[0]
+
 	}
+	f.values.Write(vec)
 }
 
 func (f *FieldEncoder) Metadata(cctx *Context, off uint64) (uint64, Field) {
@@ -40,8 +45,7 @@ func (f *FieldEncoder) Metadata(cctx *Context, off uint64) (uint64, Field) {
 
 func (f *FieldEncoder) Encode(group *errgroup.Group, count uint32) {
 	if f.opt {
-		runs := f.rle.End(count)
-		f.nones = &Uint32Encoder{vals: runs}
+		f.nones = &Uint32Encoder{vals: f.rle}
 		f.nones.Encode(group)
 	}
 	f.values.Encode(group)

--- a/csup/float.go
+++ b/csup/float.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/pkg/byteconv"
-	"github.com/brimdata/super/scode"
+	"github.com/brimdata/super/vector"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -23,15 +23,24 @@ func NewFloatEncoder(typ super.Type) *FloatEncoder {
 	return &FloatEncoder{typ: typ}
 }
 
-func (f *FloatEncoder) Write(bytes scode.Bytes) {
-	v := super.DecodeFloat(bytes)
-	if len(f.vals) == 0 || v < f.min {
-		f.min = v
+func (f *FloatEncoder) Write(vec vector.Any) {
+	if vec.Len() == 0 {
+		return
 	}
-	if len(f.vals) == 0 || v > f.max {
-		f.max = v
+	fv := vec.(*vector.Float)
+	if len(f.vals) == 0 {
+		f.min = fv.Values[0]
+		f.max = fv.Values[0]
 	}
-	f.vals = append(f.vals, v)
+	for _, v := range fv.Values {
+		if v < f.min {
+			f.min = v
+		}
+		if v > f.max {
+			f.max = v
+		}
+	}
+	f.vals = append(f.vals, fv.Values...)
 }
 
 func (f *FloatEncoder) Encode(group *errgroup.Group) {

--- a/csup/fusion.go
+++ b/csup/fusion.go
@@ -4,7 +4,7 @@ import (
 	"io"
 
 	"github.com/brimdata/super"
-	"github.com/brimdata/super/scode"
+	"github.com/brimdata/super/vector"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -24,10 +24,13 @@ func NewFusionEncoder(typ *super.TypeFusion) *FusionEncoder {
 	}
 }
 
-func (f *FusionEncoder) Write(body scode.Bytes) {
-	it := body.Iter()
-	f.values.Write(it.Next())
-	f.subTypes.Write(it.Next())
+func (f *FusionEncoder) Write(vec vector.Any) {
+	if vec.Len() == 0 {
+		return
+	}
+	fusion := vec.(*vector.Fusion)
+	f.values.Write(fusion.Values)
+	f.subTypes.Write(fusion.SubTypes)
 }
 
 func (f *FusionEncoder) Emit(w io.Writer) error {

--- a/csup/int.go
+++ b/csup/int.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/pkg/byteconv"
-	"github.com/brimdata/super/scode"
+	"github.com/brimdata/super/vector"
 	"github.com/ronanh/intcomp"
 	"golang.org/x/sync/errgroup"
 )
@@ -23,15 +23,24 @@ func NewIntEncoder(typ super.Type) *IntEncoder {
 	}
 }
 
-func (i *IntEncoder) Write(bytes scode.Bytes) {
-	v := super.DecodeInt(bytes)
-	if len(i.vals) == 0 || v < i.min {
-		i.min = v
+func (i *IntEncoder) Write(vec vector.Any) {
+	if vec.Len() == 0 {
+		return
 	}
-	if len(i.vals) == 0 || v > i.max {
-		i.max = v
+	iv := vec.(*vector.Int)
+	if len(i.vals) == 0 {
+		i.min = iv.Values[0]
+		i.max = iv.Values[0]
 	}
-	i.vals = append(i.vals, v)
+	for _, v := range iv.Values {
+		if v < i.min {
+			i.min = v
+		}
+		if v > i.max {
+			i.max = v
+		}
+	}
+	i.vals = append(i.vals, iv.Values...)
 }
 
 func (i *IntEncoder) Encode(group *errgroup.Group) {
@@ -95,15 +104,24 @@ func NewUintEncoder(typ super.Type) *UintEncoder {
 	return &UintEncoder{typ: typ}
 }
 
-func (u *UintEncoder) Write(bytes scode.Bytes) {
-	v := super.DecodeUint(bytes)
-	if len(u.vals) == 0 || v < u.min {
-		u.min = v
+func (u *UintEncoder) Write(vec vector.Any) {
+	if vec.Len() == 0 {
+		return
 	}
-	if len(u.vals) == 0 || v > u.max {
-		u.max = v
+	uv := vec.(*vector.Uint)
+	if len(u.vals) == 0 {
+		u.min = uv.Values[0]
+		u.max = uv.Values[0]
 	}
-	u.vals = append(u.vals, v)
+	for _, v := range uv.Values {
+		if v < u.min {
+			u.min = v
+		}
+		if v > u.max {
+			u.max = v
+		}
+	}
+	u.vals = append(u.vals, uv.Values...)
 }
 
 func (u *UintEncoder) Encode(group *errgroup.Group) {
@@ -166,13 +184,19 @@ func (u *Uint32Encoder) Write(v uint32) {
 	u.vals = append(u.vals, v)
 }
 
+func (u *Uint32Encoder) Append(vals []uint32) {
+	u.vals = append(u.vals, vals...)
+}
+
 func (u *Uint32Encoder) Encode(group *errgroup.Group) {
-	group.Go(func() error {
-		u.bytesLen = uint64(len(u.vals) * 4)
-		compressed := intcomp.CompressUint32(u.vals, nil)
-		u.out = byteconv.ReinterpretSlice[byte](compressed)
-		return nil
-	})
+	if len(u.vals) != 0 {
+		group.Go(func() error {
+			u.bytesLen = uint64(len(u.vals) * 4)
+			compressed := intcomp.CompressUint32(u.vals, nil)
+			u.out = byteconv.ReinterpretSlice[byte](compressed)
+			return nil
+		})
+	}
 }
 
 func (u *Uint32Encoder) Emit(w io.Writer) error {
@@ -198,13 +222,18 @@ type offsetsEncoder struct {
 }
 
 func newOffsetsEncoder() *offsetsEncoder {
-	return &offsetsEncoder{
-		Uint32Encoder{vals: []uint32{0}},
-	}
+	return &offsetsEncoder{}
 }
 
-func (o *offsetsEncoder) writeLen(size uint32) {
-	o.vals = append(o.vals, o.vals[len(o.vals)-1]+size)
+func (o *offsetsEncoder) write(offsets []uint32) {
+	if len(o.vals) == 0 {
+		o.vals = offsets
+	} else {
+		base := o.vals[len(o.vals)-1]
+		for _, off := range offsets {
+			o.vals = append(o.vals, base+off)
+		}
+	}
 }
 
 func ReadUint32s(loc Segment, r io.ReaderAt) ([]uint32, error) {

--- a/csup/map.go
+++ b/csup/map.go
@@ -4,7 +4,7 @@ import (
 	"io"
 
 	"github.com/brimdata/super"
-	"github.com/brimdata/super/scode"
+	"github.com/brimdata/super/vector"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -23,16 +23,15 @@ func NewMapEncoder(typ *super.TypeMap) *MapEncoder {
 	}
 }
 
-func (m *MapEncoder) Write(body scode.Bytes) {
-	m.count++
-	var len uint32
-	it := body.Iter()
-	for !it.Done() {
-		m.keys.Write(it.Next())
-		m.values.Write(it.Next())
-		len++
+func (m *MapEncoder) Write(vec vector.Any) {
+	if vec.Len() == 0 {
+		return
 	}
-	m.offsets.writeLen(len)
+	mapVec := vec.(*vector.Map)
+	m.count += vec.Len()
+	m.keys.Write(mapVec.Keys)
+	m.values.Write(mapVec.Values)
+	m.offsets.write(mapVec.Offsets)
 }
 
 func (m *MapEncoder) Emit(w io.Writer) error {

--- a/csup/object_test.go
+++ b/csup/object_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/brimdata/super/pkg/field"
 	"github.com/brimdata/super/sio"
 	"github.com/brimdata/super/sup"
+	"github.com/brimdata/super/vector"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,9 +22,11 @@ func TestObjectProjectMetadata(t *testing.T) {
 		"{a:2,b:{c:5,d:0.8}}",
 		"{a:3,b:{c:6,d:0.9}}",
 	}
+	builder := vector.NewDynamicBuilder()
 	for _, s := range supValues {
-		require.NoError(t, w.Write(sup.MustParseValue(sctx, s)))
+		builder.Write(sup.MustParseValue(sctx, s))
 	}
+	require.NoError(t, w.Write(builder.Build(sctx)))
 	require.NoError(t, w.Close())
 	csupBytes := b.Bytes()
 

--- a/csup/record.go
+++ b/csup/record.go
@@ -4,7 +4,7 @@ import (
 	"io"
 
 	"github.com/brimdata/super"
-	"github.com/brimdata/super/scode"
+	"github.com/brimdata/super/vector"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -32,15 +32,14 @@ func NewRecordEncoder(typ *super.TypeRecord) *RecordEncoder {
 	return &RecordEncoder{fields: fields, nopt: nopt}
 }
 
-func (r *RecordEncoder) Write(body scode.Bytes) {
-	slot := r.count
-	r.count++
-	it := scode.NewRecordIter(body, r.nopt)
-	for _, f := range r.fields {
-		elem, none := it.Next(f.opt)
-		if !none {
-			f.write(elem, slot)
-		}
+func (r *RecordEncoder) Write(vec vector.Any) {
+	if vec.Len() == 0 {
+		return
+	}
+	rec := vec.(*vector.Record)
+	r.count += rec.Len()
+	for k, f := range r.fields {
+		f.write(rec.Fields[k])
 	}
 }
 

--- a/csup/scode.go
+++ b/csup/scode.go
@@ -8,6 +8,7 @@ import (
 	"github.com/brimdata/super/order"
 	"github.com/brimdata/super/runtime/sam/expr"
 	"github.com/brimdata/super/scode"
+	"github.com/brimdata/super/vector"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -34,9 +35,25 @@ func NewScodeEncoder(typ super.Type) *ScodeEncoder {
 	}
 }
 
-func (p *ScodeEncoder) Write(body scode.Bytes) {
-	p.update(body)
-	p.bytes = scode.Append(p.bytes, body)
+// XXX TBD: change all the scode primitives to be native and get rid of
+// this slow path here.
+func (p *ScodeEncoder) Write(vec vector.Any) {
+	if vec.Len() == 0 {
+		return
+	}
+	var b scode.Builder
+	for slot := range vec.Len() {
+		b.Reset()
+		vec.Serialize(&b, slot)
+		body := b.Bytes().Body()
+		p.update(body)
+		p.bytes = scode.Append(p.bytes, body)
+	}
+}
+
+func (p *ScodeEncoder) WriteBytes(bytes scode.Bytes) {
+	p.update(bytes)
+	p.bytes = scode.Append(p.bytes, bytes)
 }
 
 func (p *ScodeEncoder) update(body scode.Bytes) {
@@ -103,7 +120,7 @@ func (p *ScodeEncoder) Dict() (PrimitiveEncoder, []byte, []uint32) {
 			tag = byte(len(counts))
 			m[string(v)] = tag
 			counts = append(counts, 0)
-			entries.Write(v)
+			entries.WriteBytes(v)
 			if len(counts) > math.MaxUint8 {
 				return nil, nil, nil
 			}

--- a/csup/union.go
+++ b/csup/union.go
@@ -4,7 +4,7 @@ import (
 	"io"
 
 	"github.com/brimdata/super"
-	"github.com/brimdata/super/scode"
+	"github.com/brimdata/super/vector"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -28,12 +28,16 @@ func NewUnionEncoder(typ *super.TypeUnion) *UnionEncoder {
 	}
 }
 
-func (u *UnionEncoder) Write(body scode.Bytes) {
-	u.count++
-	typ, zv := u.typ.Untag(body)
-	tag := u.typ.TagOf(typ)
-	u.tags.Write(uint32(tag))
-	u.values[tag].Write(zv)
+func (u *UnionEncoder) Write(vec vector.Any) {
+	if vec.Len() == 0 {
+		return
+	}
+	union := vec.(*vector.Union)
+	u.count += vec.Len()
+	u.tags.Append(union.Tags)
+	for tag := range u.values {
+		u.values[tag].Write(union.Values[tag])
+	}
 }
 
 func (u *UnionEncoder) Emit(w io.Writer) error {

--- a/csup/writer.go
+++ b/csup/writer.go
@@ -9,18 +9,19 @@ import (
 	"github.com/brimdata/super/sio"
 	"github.com/brimdata/super/sio/bsupio"
 	"github.com/brimdata/super/sup"
+	"github.com/brimdata/super/vector"
 )
 
 var maxObjectSize uint32 = 120_000
 
-// Writer implements the sio.Writer interface. A Writer creates a vector
-// CSUP object from a stream of super.Records.
+// Writer implements the vector.Writer interface. A Writer creates a vector
+// CSUP object from a stream of vector.Any.
 type Writer struct {
 	writer  io.WriteCloser
 	dynamic *DynamicEncoder
 }
 
-var _ sio.Writer = (*Writer)(nil)
+var _ vector.Writer = (*Writer)(nil)
 
 func NewWriter(w io.WriteCloser) *Writer {
 	return &Writer{
@@ -37,10 +38,12 @@ func (w *Writer) Close() error {
 	return firstErr
 }
 
-func (w *Writer) Write(val super.Value) error {
-	w.dynamic.Write(val)
-	if w.dynamic.len >= maxObjectSize {
-		return w.finalizeObject()
+func (w *Writer) Write(vec vector.Any) error {
+	if vec.Len() != 0 {
+		w.dynamic.Write(vec)
+		if w.dynamic.len >= maxObjectSize {
+			return w.finalizeObject()
+		}
 	}
 	return nil
 }
@@ -84,4 +87,35 @@ func (w *Writer) finalizeObject() error {
 	// Set new dynamic so we can write the next object.
 	w.dynamic = NewDynamicEncoder()
 	return nil
+}
+
+// XXX ValWriter provides a temporary interface to support writing super.Values
+// to CSUP.  We should remove this at some point in factor of vector-only writes.
+type ValWriter struct {
+	sctx    *super.Context
+	writer  *Writer
+	builder *vector.DynamicBuilder
+}
+
+var _ sio.Writer = (*ValWriter)(nil)
+
+func NewValWriter(w io.WriteCloser) *ValWriter {
+	return &ValWriter{
+		sctx:    super.NewContext(), //XXX
+		writer:  NewWriter(w),
+		builder: vector.NewDynamicBuilder(),
+	}
+}
+
+func (v *ValWriter) Write(val super.Value) error {
+	v.builder.Write(val)
+	return nil
+}
+
+func (v *ValWriter) Close() error {
+	err := v.writer.Write(v.builder.Build(v.sctx))
+	if closeErr := v.writer.Close(); err == nil {
+		err = closeErr
+	}
+	return err
 }

--- a/db/data/vector.go
+++ b/db/data/vector.go
@@ -10,9 +10,11 @@ import (
 	"github.com/brimdata/super/csup"
 	"github.com/brimdata/super/pkg/bufwriter"
 	"github.com/brimdata/super/pkg/storage"
-	"github.com/brimdata/super/sio"
+	"github.com/brimdata/super/runtime/vam"
+	"github.com/brimdata/super/sbuf"
 	"github.com/brimdata/super/sio/bsupio"
 	"github.com/brimdata/super/sio/csupio"
+	"github.com/brimdata/super/vector"
 	"github.com/segmentio/ksuid"
 )
 
@@ -33,8 +35,20 @@ func CreateVector(ctx context.Context, engine storage.Engine, path *storage.URI,
 	}
 	// Note here that writer.Close closes the Put but reader.Close does not
 	// close the Get.
-	reader := bsupio.NewReader(super.NewContext(), get)
-	err = sio.Copy(w, reader)
+	sctx := super.NewContext()
+	reader := bsupio.NewReader(sctx, get)
+	puller := vam.NewDematerializer(sctx, sbuf.NewPuller(reader))
+	for {
+		var vec vector.Any
+		vec, err = puller.Pull(false)
+		if vec == nil || err != nil {
+			break
+		}
+		err = w.Write(vec)
+		if err != nil {
+			break
+		}
+	}
 	if closeErr := w.Close(); err == nil {
 		err = closeErr
 	}

--- a/db/writer.go
+++ b/db/writer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/brimdata/super/runtime/sam/expr"
 	"github.com/brimdata/super/sbuf"
 	"github.com/brimdata/super/sio"
+	"github.com/brimdata/super/vector"
 	"github.com/segmentio/ksuid"
 	"golang.org/x/sync/errgroup"
 )
@@ -164,6 +165,7 @@ func (w *Writer) Stats() ImportStats {
 type SortedWriter struct {
 	comparator    *expr.Comparator
 	ctx           context.Context
+	sctx          *super.Context
 	pool          *Pool
 	sortKey       order.SortKey
 	lastKey       super.Value
@@ -177,6 +179,7 @@ func NewSortedWriter(ctx context.Context, sctx *super.Context, pool *Pool, vecto
 	return &SortedWriter{
 		comparator:    ImportComparator(sctx, pool),
 		ctx:           ctx,
+		sctx:          sctx,
 		sortKey:       pool.SortKeys.Primary(),
 		pool:          pool,
 		vectorEnabled: vectorEnabled,
@@ -205,8 +208,14 @@ again:
 		w.Abort()
 		return err
 	}
+
 	if w.vectorWriter != nil {
-		if err := w.vectorWriter.Write(val); err != nil {
+		// XXX TBD: this is slow and creates a vector per value when writing vectors
+		// to a database.  This will change when we convert the database from
+		// mixed BSUP/CSUP to CSUP only.
+		builder := vector.NewBuilder(val.Type())
+		builder.Write(val.Bytes())
+		if err := w.vectorWriter.Write(builder.Build(w.sctx)); err != nil {
 			w.Abort()
 			return err
 		}

--- a/fuzz/fuzz.go
+++ b/fuzz/fuzz.go
@@ -16,6 +16,7 @@ import (
 	"github.com/brimdata/super/compiler/optimizer/demand"
 	"github.com/brimdata/super/compiler/parser"
 	"github.com/brimdata/super/compiler/semantic"
+	"github.com/brimdata/super/csup"
 	"github.com/brimdata/super/pkg/field"
 	"github.com/brimdata/super/pkg/nano"
 	"github.com/brimdata/super/pkg/storage/mock"
@@ -67,7 +68,7 @@ func WriteBSUP(t testing.TB, valuesIn []super.Value, buf *bytes.Buffer) {
 }
 
 func WriteCSUP(t testing.TB, valuesIn []super.Value, buf *bytes.Buffer) {
-	writer := csupio.NewWriter(sio.NopCloser(buf))
+	writer := csup.NewValWriter(sio.NopCloser(buf))
 	require.NoError(t, sio.Copy(writer, sbuf.NewArray(valuesIn)))
 	require.NoError(t, writer.Close())
 }

--- a/sio/anyio/writer.go
+++ b/sio/anyio/writer.go
@@ -5,10 +5,10 @@ import (
 	"io"
 
 	"github.com/brimdata/super"
+	"github.com/brimdata/super/csup"
 	"github.com/brimdata/super/sio"
 	"github.com/brimdata/super/sio/arrowio"
 	"github.com/brimdata/super/sio/bsupio"
-	"github.com/brimdata/super/sio/csupio"
 	"github.com/brimdata/super/sio/csvio"
 	"github.com/brimdata/super/sio/dbio"
 	"github.com/brimdata/super/sio/jsonio"
@@ -39,7 +39,7 @@ func NewWriter(w io.WriteCloser, opts WriterOpts) (sio.WriteCloser, error) {
 		}
 		return bsupio.NewWriterWithOpts(w, *opts.BSUP), nil
 	case "csup":
-		return csupio.NewWriter(w), nil
+		return csup.NewValWriter(w), nil
 	case "csv":
 		return csvio.NewWriter(w, opts.CSV), nil
 	case "db":

--- a/vector/any.go
+++ b/vector/any.go
@@ -16,6 +16,10 @@ type Puller interface {
 	Pull(done bool) (Any, error)
 }
 
+type Writer interface {
+	Write(Any) error
+}
+
 // ValueAt returns the value in vec at slot.  If b is not nil, ValueAt calls b's
 // Truncate method and builds the value in it.  To safely reuse b while the
 // value is live, call b's Reset method or the value's Copy method.

--- a/vector/bytes.go
+++ b/vector/bytes.go
@@ -78,6 +78,14 @@ func NewBytesTableEmpty(cap uint32) BytesTable {
 	return BytesTable{make([]uint32, 1, cap+1), nil}
 }
 
+func (b BytesTable) RawBytes() []byte {
+	return b.bytes
+}
+
+func (b BytesTable) RawOffsets() []uint32 {
+	return b.offsets
+}
+
 func (b BytesTable) Bytes(slot uint32) []byte {
 	return b.bytes[b.offsets[slot]:b.offsets[slot+1]]
 }

--- a/vector/record.go
+++ b/vector/record.go
@@ -67,23 +67,23 @@ func (r *Record) Serialize(b *scode.Builder, slot uint32) {
 	b.EndContainer()
 }
 
-func buildTags(nones []uint32, n uint32) ([]uint32, uint32) {
+func buildTags(runlens []uint32, n uint32) ([]uint32, uint32) {
 	tags := make([]uint32, n)
 	off := 0
 	var noneLen uint32
-	for in := 0; in < len(nones); {
-		noneRun := nones[in]
+	for in := 0; in < len(runlens); {
+		noneRun := runlens[in]
 		in++
 		for k := range int(noneRun) {
 			tags[off+k] = 1
 		}
 		off += int(noneRun)
 		noneLen += noneRun
-		if in >= len(nones) {
+		if in >= len(runlens) {
 			break
 		}
 		// skip over values (leaving tags 0)
-		off += int(nones[in])
+		off += int(runlens[in])
 		in++
 	}
 	return tags, noneLen
@@ -176,11 +176,11 @@ func isNone(vec Any, slot uint32) bool {
 	return false
 }
 
-func NewFieldFromRLE(sctx *super.Context, vec Any, length uint32, nones []uint32) Any {
-	if len(nones) == 0 {
+func NewFieldFromRLE(sctx *super.Context, vec Any, length uint32, runlens []uint32) Any {
+	if len(runlens) == 0 {
 		return vec
 	}
-	tags, noneLen := buildTags(nones, length)
+	tags, noneLen := buildTags(runlens, length)
 	if noneLen == 0 {
 		// This field is optional but everything is here in this instance.
 		return vec
@@ -196,6 +196,17 @@ type Optional struct {
 
 func (o *Optional) Type() super.Type {
 	return o.Dynamic.Values[0].Type()
+}
+
+func (f *Optional) RLE() []uint32 {
+	var rle RLE
+	for slot := range f.Len() {
+		// Touch all the values
+		if f.Tags[slot] == 0 {
+			rle.Touch(slot)
+		}
+	}
+	return rle.End(f.Len())
 }
 
 func Opt(vec Any) Any {


### PR DESCRIPTION
This commit adds the vector.Writer interface to package vector and ports the csup package from a sio.Writer to a vector.Writer.  This means that, finally, vectors can be written directly from vector form to CSUP form without a round-trip to sequence serialization.  This leaves the current CSUP format unchanged.

The next step is to wire up the output of the vam to use this direct path by asserting if the output implemented vector.Writer.  We also need to get rid of the remaining scode primitives in CSUP by making them native and updating the CSUP format.  The interface between csup/vcache vector.Option also needs to be adapted to retain the runlens and only expand them to a Dynamic when needed.