### PR TITLE
fix off-by-one error in CSUP offsets encoder

### DIFF
--- a/csup/csup_test.go
+++ b/csup/csup_test.go
@@ -5,7 +5,12 @@ import (
 	"testing"
 
 	"github.com/brimdata/super"
+	"github.com/brimdata/super/csup"
 	"github.com/brimdata/super/fuzz"
+	"github.com/brimdata/super/sio"
+	"github.com/brimdata/super/sio/csupio"
+	"github.com/brimdata/super/sup"
+	"github.com/brimdata/super/vector"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,4 +40,33 @@ func roundtrip(t *testing.T, valuesIn []super.Value) {
 	valuesOut, err := fuzz.ReadCSUP(buf.Bytes(), nil)
 	require.NoError(t, err)
 	fuzz.CompareValues(t, valuesIn, valuesOut)
+}
+
+func TestCSUPBatchBug(t *testing.T) {
+	var b bytes.Buffer
+	w := csup.NewSerializer(sio.NopCloser(&b))
+	sctx := super.NewContext()
+	v1, err := sup.ParseValue(sctx, `{a: [1,2,3]}`)
+	require.NoError(t, err)
+	val2, err := sup.ParseValue(sctx, `{a:[4,5]}`)
+	require.NoError(t, err)
+	err = w.Push(valToVec(sctx, v1))
+	require.NoError(t, err)
+	err = w.Push(valToVec(sctx, val2))
+	err = w.Close()
+	require.NoError(t, err)
+	r, err := csupio.NewReader(sctx, bytes.NewReader(b.Bytes()), nil)
+	require.NoError(t, err)
+	val, err := r.Read()
+	require.NoError(t, err)
+	require.Equal(t, "{a:[1,2,3]}", sup.String(val))
+	val, err = r.Read()
+	require.NoError(t, err)
+	require.Equal(t, "{a:[4,5]}", sup.String(val))
+}
+
+func valToVec(sctx *super.Context, val super.Value) vector.Any {
+	b := vector.NewDynamicBuilder()
+	b.Write(val)
+	return b.Build(sctx)
 }

--- a/csup/int.go
+++ b/csup/int.go
@@ -230,7 +230,7 @@ func (o *offsetsEncoder) write(offsets []uint32) {
 		o.vals = offsets
 	} else {
 		base := o.vals[len(o.vals)-1]
-		for _, off := range offsets {
+		for _, off := range offsets[1:] {
 			o.vals = append(o.vals, base+off)
 		}
 	}


### PR DESCRIPTION
This bug manifests only when writing consecutive vectors to the CSUP serializer.