### PR TITLE
ignore null in concat() and f-strings

### DIFF
--- a/runtime/sam/expr/function/string.go
+++ b/runtime/sam/expr/function/string.go
@@ -20,7 +20,7 @@ func (c *Concat) Call(args []super.Value) super.Value {
 			return arg
 		}
 		if arg.IsNull() {
-			return super.Null
+			continue
 		}
 		if !arg.IsString() {
 			return c.sctx.WrapError("concat: string arg required", arg)

--- a/runtime/vam/expr/function/string.go
+++ b/runtime/vam/expr/function/string.go
@@ -14,20 +14,28 @@ type Concat struct {
 }
 
 func (c *Concat) Call(args ...vector.Any) vector.Any {
-	if vec, ok := expr.CheckForNullThenError(args); ok {
-		return vec
-	}
-	args = underAll(args)
-	for _, arg := range args {
-		if arg.Kind() != vector.KindString {
-			return vector.NewWrappedError(c.sctx, "concat: string arg required", arg)
+	n := args[0].Len()
+	vecs := args[:0]
+	for _, vec := range args {
+		switch vec.Kind() {
+		case vector.KindString:
+			vecs = append(vecs, vec)
+		case vector.KindNull:
+			// Ignored.
+		case vector.KindError:
+			return vec
+		default:
+			return vector.NewWrappedError(c.sctx, "concat: string arg required", vec)
 		}
 	}
+	if len(vecs) == 0 {
+		return vector.NewConstString("", n)
+	}
 	out := vector.NewStringEmpty(0)
-	for i := range args[0].Len() {
+	for i := range n {
 		var b strings.Builder
-		for _, arg := range args {
-			s := vector.StringValue(arg, i)
+		for _, vec := range vecs {
+			s := vector.StringValue(vec, i)
 			b.WriteString(s)
 		}
 		out.Append(b.String())

--- a/runtime/ztests/expr/f-string.yaml
+++ b/runtime/ztests/expr/f-string.yaml
@@ -1,0 +1,18 @@
+spq: f"{a}{b}{c}"
+
+vector: true
+
+input: |
+  {a:1,b:" ",c:3.3.3.3}
+  {a:null,b:null,c:null}
+  {a:null,b:2,c:null}
+  {a:1,b:null,c:3}
+  {a:1,b:error("missing"),c:error("quiet")}
+  {a:1,b:error("quiet"),c:error("missing")}
+
+output: |
+  "1 3.3.3.3"
+  ""
+  "2"
+  "13"
+  error("missing")

--- a/runtime/ztests/expr/function/concat.yaml
+++ b/runtime/ztests/expr/function/concat.yaml
@@ -4,25 +4,35 @@ vector: true
 
 input: |
   {a:"hello",b:" ",c:"world"}
-  {a:"test",b:null,c:"end"}
-  {a:123,b:"test",c:"fail"}
+  {a:null,b:null,c:null}
+  {a:null,b:"b",c:null}
+  {a:"a",b:null,c:"c"}
+  {a:"a",b:2,c:error("quiet")}
+  {a:"a",b:error("quiet"),c:3}
 
 output: |
   "hello world"
-  null
-  error({message:"concat: string arg required",on:123})
+  ""
+  "b"
+  "ac"
+  error({message:"concat: string arg required",on:2})
 
 ---
 
-spq: concat(a)
+spq: concat(this)
 
 vector: true
 
 input: |
-  {a:"single"}
+  "single"
+  null
+  1
+  error("quiet")
 
 output: |
   "single"
+  ""
+  error({message:"concat: string arg required",on:1})
 
 ---
 


### PR DESCRIPTION
concat() returns null if any parameter is null and none is an error. Change it to ignore nulls by treating them as zero-length strings. This matches SQL concat() semantics.

f-strings are implemented via concat() so their behavior changes similarly.

Fixes #6026.