### PR TITLE
go vet book/super-example/main.go with GOOS=js GOARCH=wasm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ endif
 #PEG_DEP=peg
 
 vet:
-	@go vet ./...
+	go vet ./...
+	$(MAKE) -C book $@
 
 fmt:
 	gofmt -s -w .

--- a/book/Makefile
+++ b/book/Makefile
@@ -11,3 +11,6 @@ super-example/wasm_exec.js:
 
 node_modules:
 	npm install
+
+vet:
+	GOOS=js GOARCH=wasm go vet super-example/main.go


### PR DESCRIPTION
"make vet" does not check this file because it contains a "js && wasm" build constraint.  Add a vet rule to book/Makefile that satisfies the build constraint and update the the top-level Makefile's vet rule to invoke it.