### PR TITLE
ztest: include .yaml file extension in go test name

### DIFF
--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -193,7 +193,6 @@ func Run(t *testing.T, dirname string) {
 	}
 	for _, b := range bundles {
 		name := filepath.Base(b.FileName)
-		name = strings.TrimSuffix(name, ".yaml")
 		if z := b.Test; z != nil {
 			name = fmt.Sprintf("%s/%d", name, z.Line)
 		}


### PR DESCRIPTION
The ztest package generates go test names by striping the .yaml extension from test file names, appending a slash followed by the line number at which test test begins.  For example, go test executes the first test in dir/file.yaml as TestSPQ/dir/file/1.

Change ztest to keep the .yaml extension when generating go test names so shell completion can be used to run tests in a single file without having to delete the extension.  This makes it easier to run tests in a single file by tab-completing the last word of "go test -run ./" (for SPQ-style tests) or "make TEST=./". (for shell-style tests).