### PR TITLE
sio/anyio: rename NewReaderWithOpts to NewReader

### DIFF
--- a/book/super-example/main.go
+++ b/book/super-example/main.go
@@ -67,7 +67,7 @@ func run(opts opts) wasm.Promise {
 		zctx := super.NewContext()
 		var readers []sio.Reader
 		if r != nil {
-			rc, err := anyio.NewReaderWithOpts(zctx, r, anyio.ReaderOpts{Format: opts.InputFormat})
+			rc, err := anyio.NewReader(zctx, r, anyio.ReaderOpts{Format: opts.InputFormat})
 			if err != nil {
 				return "", err
 			}

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -457,7 +457,7 @@ func handleBranchLoad(c *Core, w *ResponseWriter, r *Request) {
 		BSUP: bsupio.ReaderOpts{Validate: true},
 	}
 	sctx := super.NewContext()
-	zrc, err := anyio.NewReaderWithOpts(sctx, reader, opts)
+	zrc, err := anyio.NewReader(sctx, reader, opts)
 	if err != nil {
 		w.Error(srverr.ErrInvalid(err))
 		return

--- a/service/request.go
+++ b/service/request.go
@@ -175,7 +175,7 @@ func (r *Request) Unmarshal(w *ResponseWriter, body any, templates ...any) bool 
 	if !ok {
 		return false
 	}
-	zrc, err := anyio.NewReaderWithOpts(super.NewContext(), r.Body, anyio.ReaderOpts{Format: format})
+	zrc, err := anyio.NewReader(super.NewContext(), r.Body, anyio.ReaderOpts{Format: format})
 	if err != nil {
 		w.Error(srverr.ErrInvalid(err))
 		return false

--- a/sio/anyio/file.go
+++ b/sio/anyio/file.go
@@ -48,7 +48,7 @@ func NewFile(sctx *super.Context, rc io.ReadCloser, path string, opts ReaderOpts
 	if err != nil {
 		return nil, err
 	}
-	zr, err := NewReaderWithOpts(sctx, r, opts)
+	zr, err := NewReader(sctx, r, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/sio/anyio/reader.go
+++ b/sio/anyio/reader.go
@@ -30,11 +30,7 @@ type ReaderOpts struct {
 	CSV    csvio.ReaderOpts
 }
 
-func NewReader(sctx *super.Context, r io.Reader) (sio.ReadCloser, error) {
-	return NewReaderWithOpts(sctx, r, ReaderOpts{})
-}
-
-func NewReaderWithOpts(sctx *super.Context, r io.Reader, opts ReaderOpts) (sio.ReadCloser, error) {
+func NewReader(sctx *super.Context, r io.Reader, opts ReaderOpts) (sio.ReadCloser, error) {
 	if opts.Format != "" && opts.Format != "auto" {
 		return lookupReader(sctx, r, opts)
 	}

--- a/spq_test.go
+++ b/spq_test.go
@@ -101,7 +101,7 @@ func loadZTestInputsAndOutputs(ztestDirs map[string]struct{}) (map[string]string
 // isValid returns true if and only if s can be read fully without error by
 // anyio and contains at least one value.
 func isValid(s string) bool {
-	zrc, err := anyio.NewReader(super.NewContext(), strings.NewReader(s))
+	zrc, err := anyio.NewReader(super.NewContext(), strings.NewReader(s), anyio.ReaderOpts{})
 	if err != nil {
 		return false
 	}
@@ -134,7 +134,7 @@ func runAllBoomerangs(t *testing.T, format string, data map[string]string) {
 func runOneBoomerang(t *testing.T, format, data string) {
 	// Create an auto-detecting reader for data.
 	sctx := super.NewContext()
-	dataReadCloser, err := anyio.NewReader(sctx, strings.NewReader(data))
+	dataReadCloser, err := anyio.NewReader(sctx, strings.NewReader(data), anyio.ReaderOpts{})
 	require.NoError(t, err)
 	defer dataReadCloser.Close()
 
@@ -168,7 +168,7 @@ func runOneBoomerang(t *testing.T, format, data string) {
 	}
 
 	// Create a reader for baseline.
-	baselineReader, err := anyio.NewReaderWithOpts(super.NewContext(), bytes.NewReader(baseline.Bytes()), anyio.ReaderOpts{
+	baselineReader, err := anyio.NewReader(super.NewContext(), bytes.NewReader(baseline.Bytes()), anyio.ReaderOpts{
 		Format: format,
 		BSUP: bsupio.ReaderOpts{
 			Validate: true,

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -539,5 +539,5 @@ func newInputReader(sctx *super.Context, input string, flags []string) (sio.Read
 	if err != nil {
 		return nil, err
 	}
-	return anyio.NewReaderWithOpts(sctx, r, inflags.ReaderOpts)
+	return anyio.NewReader(sctx, r, inflags.ReaderOpts)
 }


### PR DESCRIPTION
The existing NewReader, witch omits the ReaderOpts parameter, is rarely used.