### PR TITLE
sam: fix buffer reuse bug in infer operator

### DIFF
--- a/runtime/sam/op/infer/op.go
+++ b/runtime/sam/op/infer/op.go
@@ -164,7 +164,7 @@ func (c *converter) enq(val super.Value) bool {
 		}
 		c.queues[typ] = make([]super.Value, 0, c.limit)
 	}
-	c.queues[typ] = append(q, val)
+	c.queues[typ] = append(q, val.Copy())
 	return false
 }
 


### PR DESCRIPTION
The infer operator accumulates super.Values that may belong to an sbuf.Batch without copying them, which is a bug since batches can be reused.  This is the likely cause of panics and incorrect output from the test at line 37 of runtime/ztests/op/infer.yaml that we've seen on Windows in CI.  Fix the bug by copying accumulated values.