### PR TITLE
Fix markdown link checker

### DIFF
--- a/.github/workflows/markdown-lint.yaml
+++ b/.github/workflows/markdown-lint.yaml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Lint
       run: make markdown-lint
-    - uses: umbrelladocs/action-linkspector@v1
+    - uses: umbrelladocs/action-linkspector@v1.4.0
       with:
         fail_on_error: true
         filter_mode: nofilter


### PR DESCRIPTION
We recently had [this failed job](https://github.com/brimdata/super/actions/runs/23217386807) of the markdown link checker. I've since confirmed that this can be reproduced with the checker's latest release that came out yesterday, but the prior release still works, so I pin us to that prior release here. I've opened https://github.com/UmbrellaDocs/action-linkspector/issues/54 with the maintainers of the Action in hopes they'll fix the problem in an upcoming release.