### PR TITLE
Sign Windows builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,15 +22,14 @@ jobs:
     - run: make test-heavy
     - name: Install SSL.com CodeSignTool
       run: |
-        wget https://www.ssl.com/download/codesigntool-for-linux-and-macos/ -O /tmp/codesigntool.zip
+        curl -o /tmp/codesigntool.zip https://www.ssl.com/download/codesigntool-for-linux-and-macos/
         unzip /tmp/codesigntool.zip -d /tmp/codesigntool
         cat > /usr/local/bin/CodeSignTool << 'EOF'
         #!/bin/sh
         CODE_SIGN_TOOL_PATH=/tmp/codesigntool bash /tmp/codesigntool/CodeSignTool.sh "$@"
         EOF
-        chmod +x /tmp/codesigntool/CodeSignTool.sh /usr/local/bin/CodeSignTool
-    - name: Setup Java
-      uses: actions/setup-java@v4
+        chmod +x /usr/local/bin/CodeSignTool
+    - uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '17'
@@ -39,12 +38,12 @@ jobs:
         args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
-        SSLDOTCOM_USERNAME: ${{ secrets.SSLDOTCOM_USERNAME }}
-        SSLDOTCOM_PASSWORD: ${{ secrets.SSLDOTCOM_PASSWORD }}
-        SSLDOTCOM_CREDENTIAL_ID: ${{ secrets.SSLDOTCOM_CREDENTIAL_ID }}
-        SSLDOTCOM_TOTP_SECRET: ${{ secrets.SSLDOTCOM_TOTP_SECRET }}
         MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
         MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
         MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
         MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
         MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+        SSLDOTCOM_USERNAME: ${{ secrets.SSLDOTCOM_USERNAME }}
+        SSLDOTCOM_PASSWORD: ${{ secrets.SSLDOTCOM_PASSWORD }}
+        SSLDOTCOM_CREDENTIAL_ID: ${{ secrets.SSLDOTCOM_CREDENTIAL_ID }}
+        SSLDOTCOM_TOTP_SECRET: ${{ secrets.SSLDOTCOM_TOTP_SECRET }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,13 +17,15 @@ builds:
       - darwin
     hooks:
       post:
-      - cmd: >-
-          sh -c '{{ if eq .Os "windows" }}echo y | CodeSignTool sign
-          -username="{{ .Env.SSLDOTCOM_USERNAME }}"
-          -password="{{ .Env.SSLDOTCOM_PASSWORD }}"
-          -credential_id="{{ .Env.SSLDOTCOM_CREDENTIAL_ID }}"
-          -totp_secret="{{ .Env.SSLDOTCOM_TOTP_SECRET }}"
-          -input_file_path="{{ .Path }}"{{ else }}true{{ end }}'
+      - cmd: |
+          {{ if eq .Os "windows" }}
+          sh -c 'echo y | CodeSignTool sign \
+            -username="{{ .Env.SSLDOTCOM_USERNAME }}" \
+            -password="{{ .Env.SSLDOTCOM_PASSWORD }}" \
+            -credential_id="{{ .Env.SSLDOTCOM_CREDENTIAL_ID }}" \
+            -totp_secret="{{ .Env.SSLDOTCOM_TOTP_SECRET }}" \
+            -input_file_path="{{ .Path }}"'
+          {{ end }}
 notarize:
   macos:
     - enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'


### PR DESCRIPTION
## What's Changing

The changes here along with Actions Secrets I've added for the repo will make it such that our Windows `super.exe` release binaries going forward will be signed.

## Why

In absence of a proper digital signature, a Windows user running the `super.exe` binary may be presented with a Defender pop-up like this one:

<img width="459" height="429" alt="image" src="https://github.com/user-attachments/assets/2d84bcd7-0a03-4338-ba8f-1aff8c4cbd92" />

## Details

The effect can be observed by downloading the recent GA release tagged [v0.3.0](https://github.com/brimdata/super/releases/tag/v0.3.0) via a browser, unzipping the artifact in Explorer, and double-clicking the `super.exe` binary that's unpacked. While some pure command line usage (e.g., `wget` of the ZIP and unpacking at the shell) may bypass the pop-up, I'm informed that it may still surface in the presence of certain security tools.

We went through this in the past with the desktop app. At the time we got a less expensive "OV" Code Signing Certificate, which unfortunately required months of users having to install despite the scary Defender screen in order for the cert to "build reputation" with Microsoft. Eventually the pop-up went away, only for the cycle to repeat when we later renewed the certificate. To avoid this hassle, this time I opted to sign us up for the more costly "EV" (Extended Validation) Code Signing Certificate from SSL.com, and this allows us to avoid the pop-up altogether from day one.

In addition to adding them as Repository Secrets here in the repo, I've also saved the values of the secrets in our AWS Secrets Manager under `super_repo_build_secrets`.

## Testing

I've tested out the signing and notarizing in a personal fork repo and have made scratch release [v0.11.0](https://github.com/philrz/super/releases/tag/v0.11.0) which, unlike the GA `v0.3.0` release linked above, does not trigger the Defender pop-up. The presence of the certificate info is also visible by right-clicking the binary and selecting **Properties > Digital Signatures**.

<img width="399" height="564" alt="image" src="https://github.com/user-attachments/assets/ef747c7a-9f65-4f7f-a9e7-bc7da298433e" />
