### PR TITLE
preserve top-level named type during upcast to fusion type

### DIFF
--- a/runtime/sam/expr/function/upcast.go
+++ b/runtime/sam/expr/function/upcast.go
@@ -41,8 +41,8 @@ func (u *Upcast) Cast(from super.Value, to super.Type) (super.Value, bool) {
 }
 
 func (u *Upcast) build(b *scode.Builder, typ super.Type, bytes scode.Bytes, to super.Type) bool {
+	typOrig := typ
 	typ = super.TypeUnder(typ)
-	to = super.TypeUnder(to)
 	switch to := to.(type) {
 	case *super.TypeRecord:
 		return u.toRecord(b, typ, bytes, to)
@@ -57,9 +57,9 @@ func (u *Upcast) build(b *scode.Builder, typ super.Type, bytes scode.Bytes, to s
 	case *super.TypeError:
 		return u.toError(b, typ, bytes, to)
 	case *super.TypeNamed:
-		return u.toNamed(b, typ, bytes, to)
+		return u.build(b, typ, bytes, to.Type)
 	case *super.TypeFusion:
-		return u.toFusion(b, typ, bytes, to)
+		return u.toFusion(b, typOrig, bytes, to)
 	default:
 		if typ == to {
 			b.Append(bytes)
@@ -216,13 +216,6 @@ func upcastUnionTag(types []super.Type, out super.Type) int {
 func (u *Upcast) toError(b *scode.Builder, typ super.Type, bytes scode.Bytes, to *super.TypeError) bool {
 	if errorType, ok := typ.(*super.TypeError); ok {
 		return u.build(b, errorType.Type, bytes, to.Type)
-	}
-	return false
-}
-
-func (u *Upcast) toNamed(b *scode.Builder, typ super.Type, bytes scode.Bytes, to *super.TypeNamed) bool {
-	if namedType, ok := typ.(*super.TypeNamed); ok {
-		return u.build(b, namedType.Type, bytes, to.Type)
 	}
 	return false
 }

--- a/runtime/ztests/expr/function/upcast.yaml
+++ b/runtime/ztests/expr/function/upcast.yaml
@@ -6,24 +6,26 @@ vector: true
 input: |
   [[1,"a"],<[int8|string]>]
   [[1::int8,"a"],<[int8|string]>]
-  [1::=n,<n2=int64>]
-  [{a:1::=n1}::=n2,<n3={a:n4=int64}>]
-  [[1::=n1]::=n2,<n3=[n4=int64]>]
-  [|[1::=n1]|::=n2,<n3=|[n4=int64]|>]
+  [1::=n1,<n2=int64>]
+  [{a:{b:1::=n1}::=n2}::=n3,<n4={a:n5={b:n6=int64}}>]
+  [[[1::=n1]::=n2]::=n3,<n4=[n5=[n6=int64]]>]
+  [|[|[1::=n1]|::=n2]|::=n3,<n4=|[n5=|[n6=int64]|]|>]
   [|{1::=n1:2::=n2}|::=n3,<n4=|{n5=int64:n6=int64}|>]
-  [1::(n1=(n2=int64|n3=string)),<n4=(n5=int64|n6=string)>]
+  [1::=n1::(n2=n1|(n3=string)),<n4=(n5=int64)|(n6=string)>]
   ["a"::n1=enum(a,b),<n2=enum(a,b)>]
+  [1::=n1,<fusion(int64|string)>]
 
 output: |
   error({message:"upcast: value not a subtype of [int8|string]",on:[1,"a"]})
   [1::int8,"a"]
   1::=n2
-  {a:1::=n4}::=n3
-  [1::=n4]::=n3
-  |[1::=n4]|::=n3
+  {a:{b:1::=n6}::=n5}::=n4
+  [[1::=n6]::=n5]::=n4
+  |[|[1::=n6]|::=n5]|::=n4
   |{1::=n5:2::=n6}|::=n4
-  1::(n4=(n5=int64|(n6=string)))
+  1::=n5::(n4=n5|(n6=string))
   "a"::(n2=enum(a,b))
+  fusion(1::(int64|string),<n1=int64>)
 
 ---
 

--- a/runtime/ztests/op/blend.yaml
+++ b/runtime/ztests/op/blend.yaml
@@ -102,3 +102,29 @@ output: |
   [1,2]::[int64|string|null]
   ["foo"]::[int64|string|null]
   [null]::[int64|string|null]
+
+---
+
+spq: blend
+
+vector: true
+
+input: |
+  1::=p1
+  {a:1::=r1}::=r2
+  [1::=a1]::=a2
+  |[1::=s1]|::=s2
+  |{1::=m1:2::=m2}|::=m3
+  "a"::en1=enum(a,b)
+  1::u1=(u2=int64|u3=string)
+  error(1::=er1)::=er2
+
+output: |
+  1::(int64|(u3=string)|{a:r1=int64}|[a1=int64]||[s1=int64]|||{m1=int64:m2=int64}||enum(a,b)|error(er1=int64))
+  {a:1::=r1}::(int64|(u3=string)|{a:r1}|[a1=int64]||[s1=int64]|||{m1=int64:m2=int64}||enum(a,b)|error(er1=int64))
+  [1::=a1]::(int64|(u3=string)|{a:r1=int64}|[a1]||[s1=int64]|||{m1=int64:m2=int64}||enum(a,b)|error(er1=int64))
+  |[1::=s1]|::(int64|(u3=string)|{a:r1=int64}|[a1=int64]||[s1]|||{m1=int64:m2=int64}||enum(a,b)|error(er1=int64))
+  |{1::=m1:2::=m2}|::(int64|(u3=string)|{a:r1=int64}|[a1=int64]||[s1=int64]|||{m1:m2}||enum(a,b)|error(er1=int64))
+  "a"::enum(a,b)::(int64|(u3=string)|{a:r1=int64}|[a1=int64]||[s1=int64]|||{m1=int64:m2=int64}||enum(a,b)|error(er1=int64))
+  1::(int64|(u3=string)|{a:r1=int64}|[a1=int64]||[s1=int64]|||{m1=int64:m2=int64}||enum(a,b)|error(er1=int64))
+  error(1::=er1)::(int64|(u3=string)|{a:r1=int64}|[a1=int64]||[s1=int64]|||{m1=int64:m2=int64}||enum(a,b)|error(er1=int64))

--- a/runtime/ztests/op/fuse.yaml
+++ b/runtime/ztests/op/fuse.yaml
@@ -102,3 +102,29 @@ output: |
   fusion([fusion(1::(int64|string|null),<int64>),fusion(2::(int64|string|null),<int64>)],<[int64]>)
   fusion([fusion("foo"::(int64|string|null),<string>)],<[string]>)
   fusion([fusion(null::(int64|string|null),<null>)],<[null]>)
+
+---
+
+spq: fuse
+
+vector: true
+
+input: |
+  1::=p1
+  {a:1::=r1}::=r2
+  [1::=a1]::=a2
+  |[1::=s1]|::=s2
+  |{1::=m1:2::=m2}|::=m3
+  "a"::en1=enum(a,b)
+  1::u1=(u2=int64|u3=string)
+  error(1::=er1)::=er2
+
+output: |
+  fusion(1::(int64|(u3=string)|{a:r1=int64}|[a1=int64]||[s1=int64]|||{m1=int64:m2=int64}||enum(a,b)|error(er1=int64)),<p1=int64>)
+  fusion({a:1::=r1}::(int64|(u3=string)|{a:r1}|[a1=int64]||[s1=int64]|||{m1=int64:m2=int64}||enum(a,b)|error(er1=int64)),<r2={a:r1=int64}>)
+  fusion([1::=a1]::(int64|(u3=string)|{a:r1=int64}|[a1]||[s1=int64]|||{m1=int64:m2=int64}||enum(a,b)|error(er1=int64)),<a2=[a1=int64]>)
+  fusion(|[1::=s1]|::(int64|(u3=string)|{a:r1=int64}|[a1=int64]||[s1]|||{m1=int64:m2=int64}||enum(a,b)|error(er1=int64)),<s2=|[s1=int64]|>)
+  fusion(|{1::=m1:2::=m2}|::(int64|(u3=string)|{a:r1=int64}|[a1=int64]||[s1=int64]|||{m1:m2}||enum(a,b)|error(er1=int64)),<m3=|{m1=int64:m2=int64}|>)
+  fusion("a"::enum(a,b)::(int64|(u3=string)|{a:r1=int64}|[a1=int64]||[s1=int64]|||{m1=int64:m2=int64}||enum(a,b)|error(er1=int64)),<en1=enum(a,b)>)
+  fusion(1::(int64|(u3=string)|{a:r1=int64}|[a1=int64]||[s1=int64]|||{m1=int64:m2=int64}||enum(a,b)|error(er1=int64)),<u1=u2=int64|(u3=string)>)
+  fusion(error(1::=er1)::(int64|(u3=string)|{a:r1=int64}|[a1=int64]||[s1=int64]|||{m1=int64:m2=int64}||enum(a,b)|error(er1=int64)),<er2=error(er1=int64)>)


### PR DESCRIPTION
Casting a value with a named type to a fusion type discards the name. Preseve it in the resulting fusion value instead.

This change affects both upcast() and the fuse operator since it upcasts every value.

This change does not affect the blend operator but I've added the same test cases to both runtime/ztests/op/blend.yaml and runtime/ztests/op/fuse.yaml to keep them in sync.