### PR TITLE
fix nested named types in ztests

### DIFF
--- a/runtime/ztests/op/blend.yaml
+++ b/runtime/ztests/op/blend.yaml
@@ -115,8 +115,8 @@ input: |
   [1::=a1]::=a2
   |[1::=s1]|::=s2
   |{1::=m1:2::=m2}|::=m3
+  1::=u1::(u2=(u1|(u3=string)))
   "a"::en1=enum(a,b)
-  1::u1=(u2=int64|u3=string)
   error(1::=er1)::=er2
 
 output: |
@@ -125,6 +125,6 @@ output: |
   [1::=a1]::(int64|(u3=string)|{a:r1=int64}|[a1]||[s1=int64]|||{m1=int64:m2=int64}||enum(a,b)|error(er1=int64))
   |[1::=s1]|::(int64|(u3=string)|{a:r1=int64}|[a1=int64]||[s1]|||{m1=int64:m2=int64}||enum(a,b)|error(er1=int64))
   |{1::=m1:2::=m2}|::(int64|(u3=string)|{a:r1=int64}|[a1=int64]||[s1=int64]|||{m1:m2}||enum(a,b)|error(er1=int64))
-  "a"::enum(a,b)::(int64|(u3=string)|{a:r1=int64}|[a1=int64]||[s1=int64]|||{m1=int64:m2=int64}||enum(a,b)|error(er1=int64))
   1::(int64|(u3=string)|{a:r1=int64}|[a1=int64]||[s1=int64]|||{m1=int64:m2=int64}||enum(a,b)|error(er1=int64))
+  "a"::enum(a,b)::(int64|(u3=string)|{a:r1=int64}|[a1=int64]||[s1=int64]|||{m1=int64:m2=int64}||enum(a,b)|error(er1=int64))
   error(1::=er1)::(int64|(u3=string)|{a:r1=int64}|[a1=int64]||[s1=int64]|||{m1=int64:m2=int64}||enum(a,b)|error(er1=int64))

--- a/runtime/ztests/op/fuse.yaml
+++ b/runtime/ztests/op/fuse.yaml
@@ -115,8 +115,8 @@ input: |
   [1::=a1]::=a2
   |[1::=s1]|::=s2
   |{1::=m1:2::=m2}|::=m3
+  1::=u1::(u2=(u1|(u3=string)))
   "a"::en1=enum(a,b)
-  1::u1=(u2=int64|u3=string)
   error(1::=er1)::=er2
 
 output: |
@@ -125,6 +125,6 @@ output: |
   fusion([1::=a1]::(int64|(u3=string)|{a:r1=int64}|[a1]||[s1=int64]|||{m1=int64:m2=int64}||enum(a,b)|error(er1=int64)),<a2=[a1=int64]>)
   fusion(|[1::=s1]|::(int64|(u3=string)|{a:r1=int64}|[a1=int64]||[s1]|||{m1=int64:m2=int64}||enum(a,b)|error(er1=int64)),<s2=|[s1=int64]|>)
   fusion(|{1::=m1:2::=m2}|::(int64|(u3=string)|{a:r1=int64}|[a1=int64]||[s1=int64]|||{m1:m2}||enum(a,b)|error(er1=int64)),<m3=|{m1=int64:m2=int64}|>)
+  fusion(1::(int64|(u3=string)|{a:r1=int64}|[a1=int64]||[s1=int64]|||{m1=int64:m2=int64}||enum(a,b)|error(er1=int64)),<u2=(u1=int64)|(u3=string)>)
   fusion("a"::enum(a,b)::(int64|(u3=string)|{a:r1=int64}|[a1=int64]||[s1=int64]|||{m1=int64:m2=int64}||enum(a,b)|error(er1=int64)),<en1=enum(a,b)>)
-  fusion(1::(int64|(u3=string)|{a:r1=int64}|[a1=int64]||[s1=int64]|||{m1=int64:m2=int64}||enum(a,b)|error(er1=int64)),<u1=u2=int64|(u3=string)>)
   fusion(error(1::=er1)::(int64|(u3=string)|{a:r1=int64}|[a1=int64]||[s1=int64]|||{m1=int64:m2=int64}||enum(a,b)|error(er1=int64)),<er2=error(er1=int64)>)


### PR DESCRIPTION
u1=(u2=int64|u3=string) parses as (u1=(u2=int64))|(u3=string), containing a nested named type, instead of the intended named union of named types, u1=((u2=int64)|(u3=string)).