### PR TITLE
unblend() fixes

### DIFF
--- a/runtime/sam/expr/function/unblend.go
+++ b/runtime/sam/expr/function/unblend.go
@@ -48,7 +48,7 @@ func (u *unblend) eval(in super.Value) super.Value {
 	case *super.TypeSet:
 		elems := u.arrayOrSet(typ.Type, in.Bytes())
 		if len(elems) == 0 {
-			typ := u.sctx.LookupTypeArray(super.TypeNull)
+			typ := u.sctx.LookupTypeSet(super.TypeNull)
 			return super.NewValue(typ, nil)
 		}
 		elemType, bytes := u.unify(elems)
@@ -56,21 +56,21 @@ func (u *unblend) eval(in super.Value) super.Value {
 	case *super.TypeMap:
 		var keys, vals []super.Value
 		for it := in.Bytes().Iter(); !it.Done(); {
-			keys = append(keys, super.NewValue(typ, it.Next()))
-			vals = append(vals, super.NewValue(typ, it.Next()))
+			keys = append(keys, super.NewValue(typ.KeyType, it.Next()).Deunion())
+			vals = append(vals, super.NewValue(typ.ValType, it.Next()).Deunion())
 		}
 		keyType := u.unifyType(keys)
 		valType := u.unifyType(vals)
 		var b scode.Builder
 		for k, key := range keys {
 			if u, ok := keyType.(*super.TypeUnion); ok {
-				super.BuildUnion(&b, u.TagOf(u), key.Bytes())
+				super.BuildUnion(&b, u.TagOf(key.Type()), key.Bytes())
 			} else {
 				b.Append(key.Bytes())
 			}
 			val := vals[k]
 			if u, ok := valType.(*super.TypeUnion); ok {
-				super.BuildUnion(&b, u.TagOf(u), val.Bytes())
+				super.BuildUnion(&b, u.TagOf(val.Type()), val.Bytes())
 			} else {
 				b.Append(val.Bytes())
 			}

--- a/runtime/ztests/expr/function/unblend.yaml
+++ b/runtime/ztests/expr/function/unblend.yaml
@@ -1,0 +1,80 @@
+# Test unblend on nested records.
+spq: unblend(this)
+
+input: |
+  {x:{y:2::(int64|bool)},z?:"foo"}
+  {x:{y:true::(int64|bool)},z?:_::string}
+
+output: |
+  {x:{y:2},z:"foo"}
+  {x:{y:true}}
+
+---
+
+# Test unblend on root unions.
+spq: unblend(this)
+
+input: |
+  1::(int64|bool|{x:int64})
+  true::(int64|bool|{x:int64})
+  {x:1}::(int64|bool|{x:int64})
+
+output: |
+  1
+  true
+  {x:1}
+
+---
+
+# Test unblend on arrays.
+spq: unblend(this)
+
+input: |
+  [1::(int64|bool|string),2::(int64|bool|string),"string"::(int64|bool|string)]
+  [1::(int64|bool|string),2::(int64|bool|string),true::(int64|bool|string)]
+  [1::(int64|bool|string),"foo"::(int64|bool|string),false::(int64|bool|string)]
+  ["foo"::(int64|bool|string),"bar"::(int64|bool|string),"baz"::(int64|bool|string)]
+  []::[(int64|bool|string)]
+
+output: |
+  [1,2,"string"]
+  [1,2,true]
+  [1,"foo",false]
+  ["foo","bar","baz"]
+  []
+
+---
+
+# Test unblend on sets.
+spq: unblend(this)
+
+input: |
+  |[1::(int64|bool|string),2::(int64|bool|string),"string"::(int64|bool|string)]|
+  |[1::(int64|bool|string),2::(int64|bool|string),true::(int64|bool|string)]|
+  |[1::(int64|bool|string),"foo"::(int64|bool|string),false::(int64|bool|string)]|
+  |["foo"::(int64|bool|string),"bar"::(int64|bool|string),"baz"::(int64|bool|string)]|
+  |[]|::|[(int64|bool|string)]|
+
+output: |
+  |[1,2,"string"]|
+  |[1,2,true]|
+  |[1,false,"foo"]|
+  |["bar","baz","foo"]|
+  |[]|
+
+---
+
+# Test unblend on maps.
+spq: unblend(this)
+
+input: |
+  |{"k1"::(int64|string):"v1"::(int64|string),"k2"::(int64|string):2::(int64|string)}|
+  |{"k1"::(int64|string):1::(int64|string),"k2"::(int64|string):2::(int64|string)}|
+  |{"k1"::(int64|string):"v1"::(int64|string),2::(int64|string):"v2"::(int64|string)}|
+  |{}|::|{(int64|string):(int64|string)}|
+
+output: |
+  |{"k1":"v1","k2":2}|
+  |{"k1":1,"k2":2}|
+  |{2:"v2","k1":"v1"}|
+  |{}|


### PR DESCRIPTION
This commit fixes a couple of bugs in the unblend function:
- empty sets got returned as array values.
- map values were not working

Also adds more extenstive test coverage.