### PR TITLE
sio/arrowio: fix encoding for union of null and union

### DIFF
--- a/sio/arrowio/writer.go
+++ b/sio/arrowio/writer.go
@@ -504,7 +504,20 @@ func (w *Writer) buildArrowListValue(b array.ListLikeBuilder, typ super.Type, by
 	}
 }
 
+// nullableUnion returns whether typ is a union representing a nullable Arrow
+// type.  More specifically, it returns whether typ is a union of two types, one
+// of which is null and the other of which is not a union.  (Arrow unions are
+// not nullable.)
 func nullableUnion(typ super.Type) (*super.TypeUnion, bool) {
 	u, ok := typ.(*super.TypeUnion)
-	return u, ok && len(u.Types) == 2 && (u.Types[0] == super.TypeNull || u.Types[1] == super.TypeNull)
+	if !ok || len(u.Types) != 2 || u.Types[0] != super.TypeNull && u.Types[1] != super.TypeNull {
+		return nil, false
+	}
+	if _, ok := u.Types[0].(*super.TypeUnion); ok {
+		return nil, false
+	}
+	if _, ok := u.Types[1].(*super.TypeUnion); ok {
+		return nil, false
+	}
+	return u, true
 }

--- a/sio/arrowio/ztests/roundtrip.yaml
+++ b/sio/arrowio/ztests/roundtrip.yaml
@@ -52,7 +52,12 @@ inputs:
         struct: {
           a: 0
         },
-        union: 1::(int64|string),
+        union_int64: 1::(int64|string|null),
+        union_string: "s"::(int64|string|null),
+        union_null: null::(int64|string|null),
+        union_of_null_and_union_int64: 1::(int64|string)::(null|(int64|string)),
+        union_of_null_and_union_string: "s"::(int64|string)::(null|(int64|string)),
+        union_of_null_and_union_null: null::(null|(int64|string)),
         map: |{
           1: "one"
         }|,


### PR DESCRIPTION
The Arrow writer incorrectly encodes a union of null and a nested union, like null|(int64|string), as an Arrow union corresponding to the nested union based on the mistaken assumption that Arrow unions are nullable. They are not so encode such unions verbatim (i.e., as an Arrow union of null and a nested union).