### PR TITLE
Adjust expected error from "dynamicType(a)" call

### DIFF
--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -239,7 +239,7 @@ to get at the underlying type,
 but we can't use that function on the top-level value
 ```sh
 $ clickhouse -q "SELECT dynamicType(a) FROM 'example.json'"
-Code: 43. DB::Exception: First argument for function dynamicType must be Dynamic, got Array(Dynamic) instead: In scope SELECT dynamicType(a) FROM `example.json`. (ILLEGAL_TYPE_OF_ARGUMENT)
+Code: 43. DB::Exception: A value of illegal type was provided as 1st argument 'dynamic' to function 'dynamicType'. Expected: Dynamic, got: Array(Dynamic): In scope SELECT dynamicType(a) FROM `example.json`. (ILLEGAL_TYPE_OF_ARGUMENT)
 ```
 Instead we must ask for the type of the array element
 ```sh


### PR DESCRIPTION
Our nightly job that checks these examples from the docs saw that ClickHouse recently started returning a slightly different error message here, so this brings the text current with that.