### PR TITLE
Fixed enum selector bounds checks to prevent validation bypass and JSON panic(issue #6787 )

### DIFF
--- a/sio/jsonio/writer.go
+++ b/sio/jsonio/writer.go
@@ -186,8 +186,8 @@ func (w *Writer) writeEnum(typ *super.TypeEnum, bytes scode.Bytes) {
 }
 
 func convertEnum(typ *super.TypeEnum, bytes scode.Bytes) string {
-	if k := int(super.DecodeUint(bytes)); k < len(typ.Symbols) {
-		return typ.Symbols[k]
+	if selector := super.DecodeUint(bytes); selector < uint64(len(typ.Symbols)) {
+		return typ.Symbols[selector]
 	}
 	return "<bad enum>"
 }

--- a/sio/jsonio/writer_test.go
+++ b/sio/jsonio/writer_test.go
@@ -1,0 +1,33 @@
+package jsonio
+
+import (
+	"bytes"
+	"math"
+	"testing"
+
+	"github.com/brimdata/super"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type nopWriteCloser struct {
+	*bytes.Buffer
+}
+
+func (n nopWriteCloser) Close() error {
+	return nil
+}
+
+func TestWriteEnumOutOfRangeDoesNotPanic(t *testing.T) {
+	sctx := super.NewContext()
+	enumType := sctx.LookupTypeEnum([]string{"ok"})
+	val := super.NewValue(enumType, super.EncodeUint(math.MaxUint64))
+
+	var out bytes.Buffer
+	w := NewWriter(nopWriteCloser{Buffer: &out}, WriterOpts{})
+
+	require.NotPanics(t, func() {
+		require.NoError(t, w.Write(val))
+	})
+	assert.Equal(t, "\"<bad enum>\"\n", out.String())
+}

--- a/sio/jsupio/reader.go
+++ b/sio/jsupio/reader.go
@@ -296,6 +296,12 @@ func (r *Reader) decodeEnum(b *scode.Builder, typ *super.TypeEnum, body any) err
 	if err != nil {
 		return errors.New("JSUP enum index value is not a string integer")
 	}
+	if index < 0 {
+		return errors.New("JSUP enum index value is negative")
+	}
+	if index >= len(typ.Symbols) {
+		return errors.New("JSUP enum index value out of range")
+	}
 	b.Append(super.EncodeUint(uint64(index)))
 	return nil
 }

--- a/sio/jsupio/reader_test.go
+++ b/sio/jsupio/reader_test.go
@@ -1,0 +1,27 @@
+package jsupio
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/brimdata/super"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeEnumRejectsNegativeIndex(t *testing.T) {
+	input := `{"type":{"kind":"enum","id":30,"symbols":["ok"]},"value":"-1"}` + "\n"
+	r := NewReader(super.NewContext(), strings.NewReader(input))
+
+	val, err := r.Read()
+	require.Nil(t, val)
+	require.EqualError(t, err, "line 1: JSUP enum index value is negative")
+}
+
+func TestDecodeEnumRejectsOutOfRangeIndex(t *testing.T) {
+	input := `{"type":{"kind":"enum","id":30,"symbols":["ok"]},"value":"1"}` + "\n"
+	r := NewReader(super.NewContext(), strings.NewReader(input))
+
+	val, err := r.Read()
+	require.Nil(t, val)
+	require.EqualError(t, err, "line 1: JSUP enum index value out of range")
+}

--- a/value.go
+++ b/value.go
@@ -519,7 +519,7 @@ func checkSet(body scode.Bytes) error {
 }
 
 func checkEnum(typ *TypeEnum, body scode.Bytes) error {
-	if selector := DecodeUint(body); int(selector) >= len(typ.Symbols) {
+	if selector := DecodeUint(body); selector >= uint64(len(typ.Symbols)) {
 		return errors.New("enum selector out of range")
 	}
 	return nil

--- a/value_test.go
+++ b/value_test.go
@@ -1,6 +1,7 @@
 package super_test
 
 import (
+	"math"
 	"testing"
 
 	"github.com/brimdata/super"
@@ -81,5 +82,11 @@ func TestValueValidate(t *testing.T) {
 			}),
 			b.Bytes())
 		assert.NoError(t, r.Validate())
+	})
+	t.Run("enum/error/out-of-range-selector", func(t *testing.T) {
+		sctx := super.NewContext()
+		enumType := sctx.LookupTypeEnum([]string{"ok"})
+		val := super.NewValue(enumType, super.EncodeUint(math.MaxUint64))
+		assert.EqualError(t, val.Validate(), "enum selector out of range")
 	})
 }


### PR DESCRIPTION
## Summary

This PR fixes enum selector validation and conversion paths that could mis-handle large unsigned values after signed conversion.

Specifically, it addresses issue #6787 by:

- fixing enum validation to use unsigned bounds checks,
- fixing JSON enum conversion to avoid negative index panic,
- hardening JSUP enum decode to reject negative and out-of-range indexes.

Closes #6787.

## What Changed

- value.go
  - Updated enum selector bounds check in checkEnum to compare uint64 values directly.
- sio/jsonio/writer.go
  - Updated convertEnum to avoid int conversion before indexing and safely return "<bad enum>" for invalid selectors.
- sio/jsupio/reader.go
  - Added explicit validation in decodeEnum for:
    - negative indexes,
    - out-of-range indexes.

## Tests Added

- value_test.go
  - Added regression test ensuring Validate rejects enum selector math.MaxUint64.
- sio/jsonio/writer_test.go
  - Added regression test ensuring out-of-range enum selector does not panic during JSON write and renders "<bad enum>".
- sio/jsupio/reader_test.go
  - Added tests ensuring JSUP enum decode rejects negative and out-of-range indexes.

## Verification

Commands run:

- go test .
- go test ./sio/jsonio ./sio/jsupio

Results:

- All tests passed.

## Risk / Compatibility

- Low risk: changes are localized to enum selector validation and conversion paths.
- No API surface changes.
- Behavior for malformed enum selectors is now safe and explicit (error or "<bad enum>") instead of panic/acceptance.