### PR TITLE
prohibit nested named types

### DIFF
--- a/context.go
+++ b/context.go
@@ -219,6 +219,9 @@ func (c *Context) LookupByName(name string) *TypeNamed {
 // name to that named type.  LookupTypeNamed returns an error if name is not a
 // valid UTF-8 string or is a primitive type name.
 func (c *Context) LookupTypeNamed(name string, inner Type) (*TypeNamed, error) {
+	if n, ok := inner.(*TypeNamed); ok {
+		return nil, fmt.Errorf("can't create named type %q from existing named type %q", name, n.Name)
+	}
 	if !utf8.ValidString(name) {
 		return nil, fmt.Errorf("bad type name %q: invalid UTF-8", name)
 	}

--- a/context_test.go
+++ b/context_test.go
@@ -17,6 +17,12 @@ func TestContextLookupTypeNamedErrors(t *testing.T) {
 
 	_, err = sctx.LookupTypeNamed("null", super.TypeNull)
 	assert.EqualError(t, err, `bad type name "null": primitive type name`)
+
+	typ, err := sctx.LookupTypeNamed("n1", super.TypeNull)
+	require.NoError(t, err)
+	_, err = sctx.LookupTypeNamed("n2", typ)
+	assert.EqualError(t, err, `can't create named type "n2" from existing named type "n1"`)
+
 }
 
 func TestContextLookupTypeNamedAndLookupTypeDef(t *testing.T) {

--- a/sup/ztests/named.yaml
+++ b/sup/ztests/named.yaml
@@ -1,0 +1,9 @@
+spq: pass
+
+input-flags: -i sup
+
+input: |
+  1::n1=(n2=int64)
+
+error: |
+  can't create named type "n1" from existing named type "n2"


### PR DESCRIPTION
Prohibit creation of a named type that refers to another named type as in 1::n1=(n2=int64).