### PR TITLE
fuse named types by name inside unions

### DIFF
--- a/complex.go
+++ b/complex.go
@@ -183,6 +183,13 @@ func TypeUnder(typ Type) Type {
 	return typ
 }
 
+func NameOf(typ Type) string {
+	if named, ok := typ.(*TypeNamed); ok {
+		return named.Name
+	}
+	return ""
+}
+
 // Field defines the name and type of a field for [TypeRecord].
 type Field struct {
 	Name string

--- a/runtime/sam/expr/agg/fuser.go
+++ b/runtime/sam/expr/agg/fuser.go
@@ -173,16 +173,19 @@ func (f *Fuser) fuseMono(typ super.Type) super.Type {
 // fuseIntoUnionTypes fuses typ into types while maintaining the invariant that
 // types contains at most one type of each complex kind but no unions.
 func (f *Fuser) fuseIntoUnionTypes(types []super.Type, typ super.Type) []super.Type {
-	typUnder := super.TypeUnder(typ)
-	switch typ := typUnder.(type) {
+	switch typ := typ.(type) {
 	case *super.TypeUnion:
+		// Nested unions are flatted by fusion
 		for _, t := range typ.Types {
 			types = f.fuseIntoUnionTypes(types, t)
 		}
 		return types
 	case *super.TypeFusion:
+		// Recursively created fusion types are not part of the union as the
+		// union type is instead the fusion with subtypes identifying the original types.
 		return f.fuseIntoUnionTypes(types, typ.Type)
 	}
+	name := super.NameOf(typ)
 	typKind := typ.Kind()
 	for i, t := range types {
 		switch {
@@ -190,19 +193,23 @@ func (f *Fuser) fuseIntoUnionTypes(types []super.Type, typ super.Type) []super.T
 			// This is already in the union.
 			return types
 
-		case super.TypeUnder(t) == typUnder:
-			types[i] = typUnder
+		case name != "" && name == super.NameOf(t):
+			types[i] = f.fuseWithoutFusion(t, typ)
 			return types
 		case typKind != super.PrimitiveKind && typKind == t.Kind():
-			typ := f.fuse(t, typ)
-			if s, ok := typ.(*super.TypeFusion); ok {
-				typ = s.Type
-			}
-			types[i] = typ
+			types[i] = f.fuseWithoutFusion(t, typ)
 			return types
 		}
 	}
 	return append(types, typ)
+}
+
+func (f *Fuser) fuseWithoutFusion(t1, t2 super.Type) super.Type {
+	typ := f.fuse(t1, t2)
+	if s, ok := typ.(*super.TypeFusion); ok {
+		return s.Type
+	}
+	return typ
 }
 
 func (f *Fuser) fusion(typ super.Type) super.Type {

--- a/runtime/ztests/op/blend.yaml
+++ b/runtime/ztests/op/blend.yaml
@@ -136,11 +136,11 @@ input: |
   error(1::=er1)::=er2
 
 output: |
-  1::(int64|(u3=string)|{a:r1=int64}|(a2=[a1=int64])|(s2=|[s1=int64]|)|(m3=|{m1=int64:m2=int64}|)|(en1=enum(a,b))|(er2=error(er1=int64)))
-  {a:1::=r1}::(int64|(u3=string)|{a:r1}|(a2=[a1=int64])|(s2=|[s1=int64]|)|(m3=|{m1=int64:m2=int64}|)|(en1=enum(a,b))|(er2=error(er1=int64)))
-  [1::=a1]::=a2::(int64|(u3=string)|{a:r1=int64}|a2|(s2=|[s1=int64]|)|(m3=|{m1=int64:m2=int64}|)|(en1=enum(a,b))|(er2=error(er1=int64)))
-  |[1::=s1]|::=s2::(int64|(u3=string)|{a:r1=int64}|(a2=[a1=int64])|s2|(m3=|{m1=int64:m2=int64}|)|(en1=enum(a,b))|(er2=error(er1=int64)))
-  |{1::=m1:2::=m2}|::=m3::(int64|(u3=string)|{a:r1=int64}|(a2=[a1=int64])|(s2=|[s1=int64]|)|m3|(en1=enum(a,b))|(er2=error(er1=int64)))
-  1::(int64|(u3=string)|{a:r1=int64}|(a2=[a1=int64])|(s2=|[s1=int64]|)|(m3=|{m1=int64:m2=int64}|)|(en1=enum(a,b))|(er2=error(er1=int64)))
-  "a"::(en1=enum(a,b))::(int64|(u3=string)|{a:r1=int64}|(a2=[a1=int64])|(s2=|[s1=int64]|)|(m3=|{m1=int64:m2=int64}|)|en1|(er2=error(er1=int64)))
-  error(1::=er1)::=er2::(int64|(u3=string)|{a:r1=int64}|(a2=[a1=int64])|(s2=|[s1=int64]|)|(m3=|{m1=int64:m2=int64}|)|(en1=enum(a,b))|er2)
+  1::(int64|{a:r1=int64}|(a2=[a1=int64])|(s2=|[s1=int64]|)|(m3=|{m1=int64:m2=int64}|)|(u2=(u1=int64)|(u3=string))|(en1=enum(a,b))|(er2=error(er1=int64)))
+  {a:1::=r1}::(int64|{a:r1}|(a2=[a1=int64])|(s2=|[s1=int64]|)|(m3=|{m1=int64:m2=int64}|)|(u2=(u1=int64)|(u3=string))|(en1=enum(a,b))|(er2=error(er1=int64)))
+  [1::=a1]::=a2::(int64|{a:r1=int64}|a2|(s2=|[s1=int64]|)|(m3=|{m1=int64:m2=int64}|)|(u2=(u1=int64)|(u3=string))|(en1=enum(a,b))|(er2=error(er1=int64)))
+  |[1::=s1]|::=s2::(int64|{a:r1=int64}|(a2=[a1=int64])|s2|(m3=|{m1=int64:m2=int64}|)|(u2=(u1=int64)|(u3=string))|(en1=enum(a,b))|(er2=error(er1=int64)))
+  |{1::=m1:2::=m2}|::=m3::(int64|{a:r1=int64}|(a2=[a1=int64])|(s2=|[s1=int64]|)|m3|(u2=(u1=int64)|(u3=string))|(en1=enum(a,b))|(er2=error(er1=int64)))
+  1::(int64|{a:r1=int64}|(a2=[a1=int64])|(s2=|[s1=int64]|)|(m3=|{m1=int64:m2=int64}|)|(u2=(u1=int64)|(u3=string))|(en1=enum(a,b))|(er2=error(er1=int64)))
+  "a"::(en1=enum(a,b))::(int64|{a:r1=int64}|(a2=[a1=int64])|(s2=|[s1=int64]|)|(m3=|{m1=int64:m2=int64}|)|(u2=(u1=int64)|(u3=string))|en1|(er2=error(er1=int64)))
+  error(1::=er1)::=er2::(int64|{a:r1=int64}|(a2=[a1=int64])|(s2=|[s1=int64]|)|(m3=|{m1=int64:m2=int64}|)|(u2=(u1=int64)|(u3=string))|(en1=enum(a,b))|er2)

--- a/runtime/ztests/op/fuse.yaml
+++ b/runtime/ztests/op/fuse.yaml
@@ -136,11 +136,11 @@ input: |
   error(1::=er1)::=er2
 
 output: |
-  fusion(1::(int64|(u3=string)|{a:r1=int64}|(a2=[a1=int64])|(s2=|[s1=int64]|)|(m3=|{m1=int64:m2=int64}|)|(en1=enum(a,b))|(er2=error(er1=int64))),<p1=int64>)
-  fusion({a:1::=r1}::(int64|(u3=string)|{a:r1}|(a2=[a1=int64])|(s2=|[s1=int64]|)|(m3=|{m1=int64:m2=int64}|)|(en1=enum(a,b))|(er2=error(er1=int64))),<r2={a:r1=int64}>)
-  fusion([1::=a1]::=a2::(int64|(u3=string)|{a:r1=int64}|a2|(s2=|[s1=int64]|)|(m3=|{m1=int64:m2=int64}|)|(en1=enum(a,b))|(er2=error(er1=int64))),<a2=[a1=int64]>)
-  fusion(|[1::=s1]|::=s2::(int64|(u3=string)|{a:r1=int64}|(a2=[a1=int64])|s2|(m3=|{m1=int64:m2=int64}|)|(en1=enum(a,b))|(er2=error(er1=int64))),<s2=|[s1=int64]|>)
-  fusion(|{1::=m1:2::=m2}|::=m3::(int64|(u3=string)|{a:r1=int64}|(a2=[a1=int64])|(s2=|[s1=int64]|)|m3|(en1=enum(a,b))|(er2=error(er1=int64))),<m3=|{m1=int64:m2=int64}|>)
-  fusion(1::(int64|(u3=string)|{a:r1=int64}|(a2=[a1=int64])|(s2=|[s1=int64]|)|(m3=|{m1=int64:m2=int64}|)|(en1=enum(a,b))|(er2=error(er1=int64))),<u2=(u1=int64)|(u3=string)>)
-  fusion("a"::(en1=enum(a,b))::(int64|(u3=string)|{a:r1=int64}|(a2=[a1=int64])|(s2=|[s1=int64]|)|(m3=|{m1=int64:m2=int64}|)|en1|(er2=error(er1=int64))),<en1=enum(a,b)>)
-  fusion(error(1::=er1)::=er2::(int64|(u3=string)|{a:r1=int64}|(a2=[a1=int64])|(s2=|[s1=int64]|)|(m3=|{m1=int64:m2=int64}|)|(en1=enum(a,b))|er2),<er2=error(er1=int64)>)
+  fusion(1::(int64|{a:r1=int64}|(a2=[a1=int64])|(s2=|[s1=int64]|)|(m3=|{m1=int64:m2=int64}|)|(u2=(u1=int64)|(u3=string))|(en1=enum(a,b))|(er2=error(er1=int64))),<p1=int64>)
+  fusion({a:1::=r1}::(int64|{a:r1}|(a2=[a1=int64])|(s2=|[s1=int64]|)|(m3=|{m1=int64:m2=int64}|)|(u2=(u1=int64)|(u3=string))|(en1=enum(a,b))|(er2=error(er1=int64))),<r2={a:r1=int64}>)
+  fusion([1::=a1]::=a2::(int64|{a:r1=int64}|a2|(s2=|[s1=int64]|)|(m3=|{m1=int64:m2=int64}|)|(u2=(u1=int64)|(u3=string))|(en1=enum(a,b))|(er2=error(er1=int64))),<a2=[a1=int64]>)
+  fusion(|[1::=s1]|::=s2::(int64|{a:r1=int64}|(a2=[a1=int64])|s2|(m3=|{m1=int64:m2=int64}|)|(u2=(u1=int64)|(u3=string))|(en1=enum(a,b))|(er2=error(er1=int64))),<s2=|[s1=int64]|>)
+  fusion(|{1::=m1:2::=m2}|::=m3::(int64|{a:r1=int64}|(a2=[a1=int64])|(s2=|[s1=int64]|)|m3|(u2=(u1=int64)|(u3=string))|(en1=enum(a,b))|(er2=error(er1=int64))),<m3=|{m1=int64:m2=int64}|>)
+  fusion(1::(int64|{a:r1=int64}|(a2=[a1=int64])|(s2=|[s1=int64]|)|(m3=|{m1=int64:m2=int64}|)|(u2=(u1=int64)|(u3=string))|(en1=enum(a,b))|(er2=error(er1=int64))),<u2=(u1=int64)|(u3=string)>)
+  fusion("a"::(en1=enum(a,b))::(int64|{a:r1=int64}|(a2=[a1=int64])|(s2=|[s1=int64]|)|(m3=|{m1=int64:m2=int64}|)|(u2=(u1=int64)|(u3=string))|en1|(er2=error(er1=int64))),<en1=enum(a,b)>)
+  fusion(error(1::=er1)::=er2::(int64|{a:r1=int64}|(a2=[a1=int64])|(s2=|[s1=int64]|)|(m3=|{m1=int64:m2=int64}|)|(u2=(u1=int64)|(u3=string))|(en1=enum(a,b))|er2),<er2=error(er1=int64)>)


### PR DESCRIPTION
This commit changes how named types inside of unions are handled by type fusion where we now fuse named types by name.  This will allow for improvements to the type checker to enhance soundness and when we add recursive types, this will allow for the fusion of the underlying concrete types of a recursive sum type to be fused without changing the type signature of that named type.