### PR TITLE
Show simpler "brew install super" installation in docs

### DIFF
--- a/book/src/getting-started/install.md
+++ b/book/src/getting-started/install.md
@@ -20,7 +20,7 @@ To install the SuperDB Python client, see the
 On macOS and Linux, you can use [Homebrew](https://brew.sh/) to install `super`:
 
 ```bash
-brew install --cask brimdata/tap/super
+brew install super
 ```
 
 ## Building From Source


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-cask/pull/257207 has made `super` available via the central Homebrew set of Casks, so recommend this to users for installation.