### PR TITLE
Handle UTF-8 BOM in CSV input

### DIFF
--- a/sio/csvio/reader.go
+++ b/sio/csvio/reader.go
@@ -8,6 +8,9 @@ import (
 	"strconv"
 	"unicode"
 
+	utext "golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
+
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/sup"
 )
@@ -35,7 +38,8 @@ type ReaderOpts struct {
 //}
 
 func NewReader(sctx *super.Context, r io.Reader, opts ReaderOpts) *Reader {
-	preprocess := newPreprocess(r, opts.Delim)
+	utf8Reader := transform.NewReader(r, utext.UTF8BOM.NewDecoder())
+	preprocess := newPreprocess(utf8Reader, opts.Delim)
 	reader := csv.NewReader(preprocess)
 	if opts.Delim != 0 {
 		reader.Comma = opts.Delim

--- a/sio/csvio/ztests/bom.yaml
+++ b/sio/csvio/ztests/bom.yaml
@@ -1,0 +1,15 @@
+# The input data leads with the UTF-8 representation of byte-order mark (BOM).
+# See https://en.wikipedia.org/wiki/Byte_order_mark
+
+script: |
+  head -c 3 with-bom.csv | xxd
+  super -s -i csv -c "cut a" with-bom.csv
+
+inputs:
+  - name: with-bom.csv
+
+outputs:
+  - name: stdout
+    data: |
+      00000000: efbb bf                                  ...
+      {a:"foo"}

--- a/sio/csvio/ztests/with-bom.csv
+++ b/sio/csvio/ztests/with-bom.csv
@@ -1,0 +1,2 @@
+﻿a,b
+foo,bar


### PR DESCRIPTION
This is a prototype of detecting and skipping over the UTF-8 [byte-order mark (BOM)](https://en.wikipedia.org/wiki/Byte_order_mark) when present in CSV input, as described in https://github.com/brimdata/super/issues/5268#issuecomment-4189646824.