### PR TITLE
don't run boomerangs twice

### DIFF
--- a/spq_test.go
+++ b/spq_test.go
@@ -33,6 +33,9 @@ func TestSPQ(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("boomerang", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping boomerang in short mode")
+		}
 		t.Parallel()
 		data, err := loadZTestInputsAndOutputs(dirs)
 		require.NoError(t, err)


### PR DESCRIPTION
Previously the boomerang format tests were run in both test-system and test-unit.  This change arranges for them to run only in test-system (when the -short flag is not specified to go test).