### PR TITLE
catch boomerang isValid panics

### DIFF
--- a/spq_test.go
+++ b/spq_test.go
@@ -109,10 +109,6 @@ func isValid(t *testing.T, name, s string) bool {
 			t.Fatalf("boomerang panic reading test input: %s: %+v\n%s\n", name, r, debug.Stack())
 		}
 	}()
-	return isValidBare(s)
-}
-
-func isValidBare(s string) bool {
 	zrc, err := anyio.NewReader(super.NewContext(), strings.NewReader(s), anyio.ReaderOpts{})
 	if err != nil {
 		return false


### PR DESCRIPTION
Previously, there was a problem with panics that occured during the boomerang test building phase where isValid reads input data outside of a go test name tied to the file being read.  This caused cryptic backtraces with little hint as to what input caused the panic to occur.

This commit introduces logic to catch the panic and report a fatal testing error with the test name included along with the stack trace.