### PR TITLE
replace fusion subtypes with TypeDefs table and IDs

### DIFF
--- a/cmd/super/dev/csup/command.go
+++ b/cmd/super/dev/csup/command.go
@@ -16,7 +16,6 @@ import (
 	"github.com/brimdata/super/csup"
 	"github.com/brimdata/super/pkg/charm"
 	"github.com/brimdata/super/pkg/storage"
-	"github.com/brimdata/super/sio"
 	"github.com/brimdata/super/sio/bsupio"
 	"github.com/brimdata/super/sup"
 )
@@ -68,64 +67,72 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	meta := newReader(r)
-	err = vio.Copy(writer, sbuf.NewDematerializer(meta.sctx, sbuf.NewPuller(meta)))
+	sctx := super.NewContext()
+	reader := bufio.NewReader(r)
+	vals, err := readMeta(sctx, reader)
+	if err == nil {
+		err = vio.Copy(writer, sbuf.NewDematerializer(sctx, sbuf.NewPuller(vals)))
+	}
 	if err2 := writer.Close(); err == nil {
 		err = err2
 	}
 	return err
 }
 
-type reader struct {
-	sctx      *super.Context
-	reader    *bufio.Reader
-	meta      *bsupio.Reader
-	marshaler *sup.MarshalBSUPContext
-	typeSize  int
-	dataSize  int
-}
-
-var _ sio.Reader = (*reader)(nil)
-
-func newReader(r io.Reader) *reader {
-	sctx := super.NewContext()
-	return &reader{
-		sctx:      sctx,
-		reader:    bufio.NewReader(r),
-		marshaler: sup.NewBSUPMarshalerWithContext(sctx),
+func readMeta(sctx *super.Context, r *bufio.Reader) (*sbuf.Array, error) {
+	marshaler := sup.NewBSUPMarshalerWithContext(sctx)
+	hdr, err := readHeader(r)
+	if err != nil && err != io.EOF {
+		return nil, err
 	}
-}
-
-func (r *reader) Read() (*super.Value, error) {
+	metaReader := bsupio.NewReader(sctx, io.LimitReader(r, int64(hdr.MetaSize)))
+	val, err := marshaler.Marshal(hdr)
+	if err != nil {
+		return nil, err
+	}
+	var vals []super.Value
+	vals = append(vals, val)
 	for {
-		if r.meta == nil {
-			hdr, err := r.readHeader()
-			if err != nil {
-				if err == io.EOF {
-					err = nil
-				}
-				return nil, err
+		val, err := metaReader.Read()
+		if err != nil {
+			if err == io.EOF {
+				break
 			}
-			r.meta = bsupio.NewReader(r.sctx, io.LimitReader(r.reader, int64(hdr.MetaSize)))
-			r.dataSize = int(hdr.DataSize) + int(hdr.TypeSize) //XXX should read types
-			val, err := r.marshaler.Marshal(hdr)
-			return val.Ptr(), err
-		}
-		val, err := r.meta.Read()
-		if val != nil || err != nil {
-			return val, err
-		}
-		if err := r.meta.Close(); err != nil {
 			return nil, err
 		}
-		r.meta = nil
-		r.skip(r.dataSize)
+		if val == nil {
+			break
+		}
+		vals = append(vals, val.Copy())
 	}
+	if err := metaReader.Close(); err != nil {
+		return nil, err
+	}
+	typedefsReader := bsupio.NewReader(sctx, io.LimitReader(r, int64(hdr.TypeSize)))
+	valp, err := typedefsReader.Read()
+	if err != nil {
+		return nil, err
+	}
+	if valp.Type() != super.TypeBytes {
+		return nil, errors.New("CSUP type section is not a bytes value")
+	}
+	vals, err = marshalTypeDefs(marshaler, vals, valp.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	valp, err = typedefsReader.Read()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if valp != nil {
+		return nil, errors.New("CSUP type section has more than one value")
+	}
+	return sbuf.NewArray(vals), skip(r, int(hdr.DataSize))
 }
 
-func (r *reader) readHeader() (csup.Header, error) {
+func readHeader(r io.Reader) (csup.Header, error) {
 	var bytes [csup.HeaderSize]byte
-	cc, err := r.reader.Read(bytes[:])
+	cc, err := r.Read(bytes[:])
 	if err != nil {
 		return csup.Header{}, err
 	}
@@ -139,10 +146,216 @@ func (r *reader) readHeader() (csup.Header, error) {
 	return h, nil
 }
 
-func (r *reader) skip(n int) error {
-	got, err := r.reader.Discard(n)
+func skip(r *bufio.Reader, n int) error {
+	got, err := r.Discard(n)
 	if n != got {
 		return fmt.Errorf("truncated CSUP data: data section %d but read only %d", n, got)
 	}
 	return err
+}
+
+func marshalTypeDefs(marshaler *sup.MarshalBSUPContext, vals []super.Value, bytes []byte) ([]super.Value, error) {
+	id := uint32(super.IDTypeComplex)
+	for len(bytes) > 0 {
+		var desc any
+		bytes, desc = decodeTypeDef(id, bytes)
+		if desc != nil {
+			val, err := marshaler.Marshal(desc)
+			if err != nil {
+				return nil, err
+			}
+			vals = append(vals, val)
+		}
+		id++
+	}
+	return vals, nil
+}
+
+func decodeTypeDef(slot uint32, bytes []byte) ([]byte, any) {
+	var out any
+	typedef := bytes[0]
+	bytes = bytes[1:]
+	var n int
+	var name string
+	var id uint32
+	switch typedef {
+	case super.TypeDefNamed:
+		name, bytes = super.DecodeName(bytes)
+		if bytes == nil {
+			return nil, errInfo(slot, "TypeDefNamed", "at name field")
+		}
+		id, bytes = super.DecodeID(bytes)
+		if bytes == nil {
+			return nil, errInfo(slot, "TypeDefNamed", "at ID field")
+		}
+		out = &struct {
+			Kind string
+			Slot uint32
+			Name string
+			ID   uint32
+		}{
+			Kind: "TypeDefNamed",
+			Slot: slot,
+			Name: name,
+			ID:   id,
+		}
+	case super.TypeDefRecord:
+		type Field struct {
+			Name string
+			ID   uint32
+			Opt  bool
+		}
+		n, bytes = super.DecodeLength(bytes)
+		if bytes == nil {
+			return nil, errInfo(slot, "TypeDefRecord", "at length field")
+		}
+		var fields []Field
+		for range n {
+			name, bytes = super.DecodeName(bytes)
+			if bytes == nil {
+				return nil, errInfo(slot, "TypeDefRecord", "at field name field")
+			}
+			id, bytes = super.DecodeID(bytes)
+			if bytes == nil {
+				return nil, errInfo(slot, "TypeDefRecord", "at field ID field")
+			}
+			var opt bool
+			if bytes[0] != 0 {
+				opt = true
+			}
+			bytes = bytes[1:]
+			fields = append(fields, Field{name, id, opt})
+		}
+		out = &struct {
+			Kind   string
+			Slot   uint32
+			Fields []Field
+		}{
+			Kind:   "TypeDefRecord",
+			Slot:   slot,
+			Fields: fields,
+		}
+	case super.TypeDefArray:
+		bytes, out = wrapped(bytes, "TypeDefArray", slot)
+	case super.TypeDefSet:
+		bytes, out = wrapped(bytes, "TypeDefSet", slot)
+	case super.TypeDefError:
+		bytes, out = wrapped(bytes, "TypeDefError", slot)
+	case super.TypeDefFusion:
+		bytes, out = wrapped(bytes, "TypeDefFusion", slot)
+	case super.TypeDefMap:
+		var keyID, valID uint32
+		keyID, bytes = super.DecodeID(bytes)
+		if bytes == nil {
+			return nil, errInfo(slot, "TypeDefMap", "at key ID")
+		}
+		valID, bytes = super.DecodeID(bytes)
+		if bytes == nil {
+			return nil, errInfo(slot, "TypeDefMap", "at value ID")
+		}
+		out = &struct {
+			Kind  string
+			Slot  uint32
+			KeyID uint32
+			ValID uint32
+		}{
+			Kind:  "TypeDefMap",
+			Slot:  slot,
+			KeyID: keyID,
+			ValID: valID,
+		}
+	case super.TypeDefUnion:
+		n, bytes = super.DecodeLength(bytes)
+		if bytes == nil {
+			return nil, errInfo(slot, "TypeDefUnion", "at length field")
+		}
+		if n > super.MaxUnionTypes {
+			return nil, errInfo(slot, "TypeDefUnion", "at length field (size exceed)")
+		}
+		var ids []uint32
+		for range n {
+			id, bytes = super.DecodeID(bytes)
+			if bytes == nil {
+				return nil, errInfo(slot, "TypeDefUnion", "in type ID list")
+			}
+			ids = append(ids, id)
+		}
+		out = &struct {
+			Kind string
+			Slot uint32
+			IDs  []uint32
+		}{
+			Kind: "TypeDefUnion",
+			Slot: slot,
+			IDs:  ids,
+		}
+	case super.TypeDefEnum:
+		n, bytes = super.DecodeLength(bytes)
+		if bytes == nil {
+			return nil, errInfo(slot, "TypeDefEnum", "at length field")
+		}
+		if n > super.MaxEnumSymbols {
+			return nil, errInfo(slot, "TypeDefEnum", "at length field (size exceed)")
+		}
+		var names []string
+		for range n {
+			name, bytes = super.DecodeName(bytes)
+			if bytes == nil {
+				return nil, errInfo(slot, "TypeDefEnum", "at enum symbol")
+			}
+			names = append(names, name)
+		}
+		out = &struct {
+			Kind  string
+			Slot  uint32
+			Names []string
+		}{
+			Kind:  "TypeDefEnum",
+			Slot:  slot,
+			Names: names,
+		}
+	default:
+		out = &struct {
+			Kind string
+			Slot uint32
+			Code int
+		}{
+			Kind: "Bad TypeDef code",
+			Slot: slot,
+			Code: int(typedef),
+		}
+		bytes = nil
+	}
+	return bytes, out
+}
+
+func wrapped(bytes []byte, kind string, slot uint32) ([]byte, any) {
+	var id uint32
+	id, bytes = super.DecodeID(bytes)
+	if bytes == nil {
+		return nil, errInfo(slot, kind, "at ID field")
+	}
+	return bytes, &struct {
+		Kind string
+		Slot uint32
+		ID   uint32
+	}{
+		Kind: kind,
+		Slot: slot,
+		ID:   id,
+	}
+}
+
+func errInfo(slot uint32, typedef, message string) any {
+	return &struct {
+		Kind    string
+		Slot    uint32
+		TypeDef string
+		Where   string
+	}{
+		Kind:    "Decode Error",
+		Slot:    slot,
+		TypeDef: typedef,
+		Where:   message,
+	}
 }

--- a/context.go
+++ b/context.go
@@ -58,6 +58,10 @@ func (c *Context) Reset() {
 	c.named = nil
 }
 
+func (c *Context) TypeDefs() *TypeDefs {
+	return c.typedefs
+}
+
 func (c *Context) LookupType(id int) (Type, error) {
 	if id < 0 {
 		return nil, fmt.Errorf("type id (%d) cannot be negative", id)
@@ -498,6 +502,11 @@ func DecodeName(tv scode.Bytes) (string, scode.Bytes) {
 	return string(tv[:namelen]), tv[namelen:]
 }
 
+func MustDecodeName(tv scode.Bytes) (string, scode.Bytes) {
+	namelen, tv := MustDecodeLength(tv)
+	return string(tv[:namelen]), tv[namelen:]
+}
+
 func DecodeLength(tv scode.Bytes) (int, scode.Bytes) {
 	namelen, n := binary.Uvarint(tv)
 	if n <= 0 {
@@ -506,10 +515,26 @@ func DecodeLength(tv scode.Bytes) (int, scode.Bytes) {
 	return int(namelen), tv[n:]
 }
 
+func MustDecodeLength(tv scode.Bytes) (int, scode.Bytes) {
+	namelen, n := binary.Uvarint(tv)
+	if n <= 0 {
+		panic(tv)
+	}
+	return int(namelen), tv[n:]
+}
+
 func DecodeID(b []byte) (uint32, []byte) {
 	v, n := binary.Uvarint(b)
 	if n <= 0 {
 		return 0, nil
+	}
+	return uint32(v), b[n:]
+}
+
+func MustDecodeID(b []byte) (uint32, []byte) {
+	v, n := binary.Uvarint(b)
+	if n <= 0 {
+		panic(b)
 	}
 	return uint32(v), b[n:]
 }
@@ -651,17 +676,17 @@ func (t *TypeDefs) Reset() {
 	t.lut = make(map[string]uint32)
 }
 
-func (t *TypeDefs) Len() int {
-	return len(t.bytes)
-}
-
 func (t *TypeDefs) Bytes() []byte {
 	return t.bytes
 }
 
-func (t *TypeDefs) Value(id uint32) []byte {
+func (t *TypeDefs) Serialization(id uint32) []byte {
 	slot := id - IDTypeComplex
 	return t.bytes[t.offsets[slot]:t.offsets[slot+1]]
+}
+
+func (t *TypeDefs) NTypes() int {
+	return len(t.offsets) - 1
 }
 
 func (t *TypeDefs) Append(bytes []byte) uint32 {
@@ -851,7 +876,7 @@ func (t *TypeDefsMapper) lookupType(id uint32) Type {
 		t, _ := LookupPrimitiveByID(int(id))
 		return t
 	}
-	b := t.Value(id)
+	b := t.Serialization(id)
 	typedef := b[0]
 	b = b[1:]
 	switch typedef {
@@ -988,4 +1013,219 @@ func (t *TypeDefsMapper) lookupType(id uint32) Type {
 	default:
 		panic(id)
 	}
+}
+
+// A TypeDefsMerger recodes typedefs from an external table to a shared table
+// on demand as external ID are looked up and converted to shared IDs.  This is
+// used, for example, by the CSUP writer to collapse multiple typedefs tables
+// into one table to be written to the CSUP metadata and copying only the typedefs
+// that are used by subtypes in the serialized fusion vectors.  LookupID panics if any
+// malformed data is encountered.
+type TypeDefsMerger struct {
+	*TypeDefs
+	ext   *TypeDefs
+	idmap map[uint32]uint32
+}
+
+func NewTypeDefsMerger(defs, ext *TypeDefs) *TypeDefsMerger {
+	return &TypeDefsMerger{
+		TypeDefs: defs,
+		ext:      ext,
+		idmap:    make(map[uint32]uint32),
+	}
+}
+
+func (t *TypeDefsMerger) LookupID(extID uint32) uint32 {
+	if extID < IDTypeComplex {
+		return extID
+	}
+	if id, ok := t.idmap[extID]; ok {
+		return id
+	}
+	bytes := t.ext.Serialization(extID)
+	typedef := bytes[0]
+	bytes = bytes[1:]
+	var id uint32
+	var n, at int
+	var name string
+	switch typedef {
+	case TypeDefNamed:
+		name, bytes = MustDecodeName(bytes)
+		id, bytes = MustDecodeID(bytes)
+		id = t.LookupID(id)
+		at = len(t.bytes)
+		t.bytes = append(t.bytes, TypeDefNamed)
+		t.bytes = binary.AppendUvarint(t.bytes, uint64(len(name)))
+		t.bytes = append(t.bytes, name...)
+		t.bytes = binary.AppendUvarint(t.bytes, uint64(id))
+	case TypeDefRecord:
+		// extra alloc and copy due to recursion.  XXX put this in a pool.
+		var out []byte
+		n, bytes = MustDecodeLength(bytes)
+		if n > MaxRecordFields {
+			panic(n)
+		}
+		out = append(out, TypeDefRecord)
+		out = binary.AppendUvarint(out, uint64(n))
+		for range n {
+			var name string
+			name, bytes = MustDecodeName(bytes)
+			id, bytes = MustDecodeID(bytes)
+			opt := bytes[0]
+			bytes = bytes[1:]
+			out = binary.AppendUvarint(out, uint64(len(name)))
+			out = append(out, name...)
+			out = binary.AppendUvarint(out, uint64(t.LookupID(id)))
+			out = append(out, opt)
+		}
+		at = len(t.bytes)
+		t.bytes = append(t.bytes, out...)
+	case TypeDefArray:
+		id, bytes = MustDecodeID(bytes)
+		id = t.LookupID(id)
+		at = len(t.bytes)
+		t.bytes = append(t.bytes, TypeDefArray)
+		t.bytes = binary.AppendUvarint(t.bytes, uint64(id))
+	case TypeDefSet:
+		id, bytes = MustDecodeID(bytes)
+		id = t.LookupID(id)
+		at = len(t.bytes)
+		t.bytes = append(t.bytes, TypeDefSet)
+		t.bytes = binary.AppendUvarint(t.bytes, uint64(id))
+	case TypeDefMap:
+		id, bytes = MustDecodeID(bytes)
+		keyID := t.LookupID(id)
+		id, bytes = MustDecodeID(bytes)
+		valID := t.LookupID(id)
+		at = len(t.bytes)
+		t.bytes = append(t.bytes, TypeDefMap)
+		t.bytes = binary.AppendUvarint(t.bytes, uint64(keyID))
+		t.bytes = binary.AppendUvarint(t.bytes, uint64(valID))
+	case TypeDefUnion:
+		// extra alloc and copy due to recursion.  XXX put this in a pool.
+		var out []byte
+		n, bytes = MustDecodeLength(bytes)
+		if n > MaxUnionTypes {
+			panic(n)
+		}
+		out = append(out, TypeDefUnion)
+		out = binary.AppendUvarint(out, uint64(n))
+		for range n {
+			id, bytes = MustDecodeID(bytes)
+			out = binary.AppendUvarint(out, uint64(t.LookupID(id)))
+		}
+		at = len(t.bytes)
+		t.bytes = append(t.bytes, out...)
+	case TypeDefEnum:
+		n, bytes = MustDecodeLength(bytes)
+		at = len(t.bytes)
+		t.bytes = append(t.bytes, TypeDefEnum)
+		t.bytes = binary.AppendUvarint(t.bytes, uint64(n))
+		for range n {
+			name, bytes = MustDecodeName(bytes)
+			t.bytes = binary.AppendUvarint(t.bytes, uint64(len(name)))
+			t.bytes = append(t.bytes, name...)
+		}
+	case TypeDefError:
+		id, bytes = MustDecodeID(bytes)
+		id = t.LookupID(id)
+		at = len(t.bytes)
+		t.bytes = append(t.bytes, TypeDefError)
+		t.bytes = binary.AppendUvarint(t.bytes, uint64(id))
+	case TypeDefFusion:
+		id, bytes = MustDecodeID(bytes)
+		id = t.LookupID(id)
+		at = len(t.bytes)
+		t.bytes = append(t.bytes, TypeDefFusion)
+		t.bytes = binary.AppendUvarint(t.bytes, uint64(id))
+	default:
+		panic(id)
+	}
+	id = t.Lookup(at)
+	t.idmap[extID] = id
+	return id
+}
+
+// NewTypeDefsFromBytes takes a serialized representation of a typedefs table
+// and computes the lookup table and offsets of each typedef in the table, returning
+// a new TypeDefs table.  It checks that all referenced IDs in the table maintain
+// the invariant that they are defined before use in the scan order of the table.
+// It panics if malformed data is encountered.
+func NewTypeDefsFromBytes(bytes []byte) *TypeDefs {
+	defs := NewTypeDefs()
+	defs.bytes = bytes
+	localID := uint32(IDTypeComplex)
+	var off uint32
+	for len(bytes) > 0 {
+		before := bytes
+		typedef := bytes[0]
+		bytes = bytes[1:]
+		var id uint32
+		var n int
+		switch typedef {
+		case TypeDefNamed:
+			_, bytes = MustDecodeName(bytes)
+			id, bytes = MustDecodeID(bytes)
+			if id >= localID {
+				panic(id)
+			}
+		case TypeDefRecord:
+			n, bytes = MustDecodeLength(bytes)
+			if n > MaxRecordFields {
+				panic(n)
+			}
+			for range n {
+				_, bytes = MustDecodeName(bytes)
+				id, bytes = MustDecodeID(bytes)
+				if id >= localID {
+					panic(id)
+				}
+				// field opt
+				bytes = bytes[1:]
+			}
+		case TypeDefArray, TypeDefSet, TypeDefError, TypeDefFusion:
+			id, bytes = MustDecodeID(bytes)
+			if id >= localID {
+				panic(id)
+			}
+		case TypeDefMap:
+			// key ID
+			id, bytes = MustDecodeID(bytes)
+			if id >= localID {
+				panic(id)
+			}
+			// val ID
+			id, bytes = MustDecodeID(bytes)
+			if id >= localID {
+				panic(id)
+			}
+		case TypeDefUnion:
+			n, bytes = MustDecodeLength(bytes)
+			if n > MaxUnionTypes {
+				panic(n)
+			}
+			for range n {
+				id, bytes = MustDecodeID(bytes)
+				if id >= localID {
+					panic(id)
+				}
+			}
+		case TypeDefEnum:
+			n, bytes = MustDecodeLength(bytes)
+			if n > MaxEnumSymbols {
+				panic(n)
+			}
+			for range n {
+				_, bytes = MustDecodeName(bytes)
+			}
+		default:
+			panic(typedef)
+		}
+		size := len(before) - len(bytes)
+		off += uint32(size)
+		defs.lut[string(before[:size])] = localID
+		defs.offsets = append(defs.offsets, off)
+		localID++
+	}
+	return defs
 }

--- a/csup/context.go
+++ b/csup/context.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/sbuf"
-	"github.com/brimdata/super/scode"
 	"github.com/brimdata/super/sio/bsupio"
 	"github.com/brimdata/super/sup"
 )
@@ -20,18 +19,15 @@ type Context struct {
 	metas  []Metadata     // id to Metadata
 	values []super.Value  // id to unmarshaled Metadata
 	uctx   *sup.UnmarshalBSUPContext
-	// On the encode path, the subtypes of all fusion types are stored
-	// in a table that maps the type to a local id.  These IDs are then
-	// used on the decode path via the subtypes array to map back to
-	// the type value.  A future version of this logic will use a fully
-	// interned typedef table like BSUP serialization does.
-	subcache map[string]uint32
+	// The typedefs table is a merge of all the fusion vector subtypes.
+	// Only the typedefs needed are recorded in this table and different vectors
+	// are merged into this shared table by mapping each vector's IDs to the
+	// shared IDs.  This is used by both the read path and write path.
 	smu      sync.Mutex
-	subtypes []scode.Bytes
-	// We store a reader to read the types on demand for the decode path.
-	// If we never need the subtypes for fusion values, then they are
-	// never read.  If we do read them, we read them once into the
-	// subtypes table under lock smu and clear this reader value to
+	typedefs *super.TypeDefs
+	// The subtypesReader holds a pointer to a reader to load the typedefs
+	// bytes if they are ever needed.  If we do read them, we read them once
+	// into the subtypes table under lock smu and clear this reader value to
 	// mark the table loaded.
 	subtypesReader io.Reader
 }
@@ -46,6 +42,15 @@ func (c *Context) enter(meta Metadata) ID {
 	id := ID(len(c.metas))
 	c.metas = append(c.metas, meta)
 	return id
+}
+
+func (c *Context) TypeDefs() *super.TypeDefs {
+	c.smu.Lock()
+	defer c.smu.Unlock()
+	if c.typedefs == nil {
+		c.typedefs = super.NewTypeDefs()
+	}
+	return c.typedefs
 }
 
 func (c *Context) Lookup(id ID) Metadata {
@@ -72,39 +77,6 @@ func (c *Context) unmarshal(id ID) error {
 		return nil
 	}
 	return c.uctx.Unmarshal(c.values[id], &c.metas[id])
-}
-
-func (c *Context) lookupTypeID(sctx *super.Context, typ super.Type) uint32 {
-	if c.subcache == nil {
-		c.subcache = make(map[string]uint32)
-	}
-	// This could be more efficient by having a slice lookup on input
-	// ID to output ID, but we will do that when we convert to a fully
-	// interned typedef table.
-	tv := sctx.LookupTypeValue(typ)
-	tvBytes := tv.Bytes()
-	id, ok := c.subcache[string(tvBytes)]
-	if !ok {
-		id = uint32(len(c.subcache))
-		c.subcache[string(tvBytes)] = id
-	}
-	return id
-}
-
-// LookupTypeVal callable only from vcache after LoadSubtypes is called.
-func (c *Context) LookupTypeVal(id uint32) scode.Bytes {
-	return c.subtypes[id]
-}
-
-func (c *Context) types() []super.Value {
-	if len(c.subcache) == 0 {
-		return nil
-	}
-	types := make([]super.Value, len(c.subcache))
-	for tv, id := range c.subcache {
-		types[id] = super.NewValue(super.TypeType, scode.Bytes(tv))
-	}
-	return types
 }
 
 func (c *Context) readMeta(r io.Reader) error {
@@ -135,37 +107,42 @@ func (c *Context) readMeta(r io.Reader) error {
 
 // LoadSubtypes is called to load the subtypes table on demand,
 // only when needed.  It must be called before calling LookupTypeVal.
-func (c *Context) LoadSubtypes() {
+func (c *Context) LoadSubtypes() *super.TypeDefs {
 	c.smu.Lock()
 	defer c.smu.Unlock()
 	if c.subtypesReader != nil {
-		if err := c.readTypes(c.subtypesReader); err != nil {
+		if err := c.readSubTypes(c.subtypesReader); err != nil {
 			// Panic for now but we should handle this more gracefully
 			// when an IO error causes failure of a running query.
 			panic(err)
 		}
 		c.subtypesReader = nil
 	}
+	return c.typedefs
 }
 
-func (c *Context) readTypes(r io.Reader) error {
+func (c *Context) readSubTypes(r io.Reader) error {
 	scanner, err := bsupio.NewReader(c.local, r).NewScanner(context.TODO(), nil)
 	if err != nil {
 		return err
 	}
 	defer scanner.Pull(true)
-	var vals []scode.Bytes
+	var vals []super.Value
 	for {
 		batch, err := scanner.Pull(false)
 		if batch == nil || err != nil {
-			c.subtypes = vals
+			if len(vals) != 1 {
+				return errors.New("CSUP metadata typedefs section must be a single bytes value")
+			}
+			val := vals[0]
+			if val.Type() != super.TypeBytes {
+				return errors.New("CSUP metadata typedefs section must be a bytes type")
+			}
+			c.typedefs = super.NewTypeDefsFromBytes(val.Bytes())
 			return err
 		}
 		for _, val := range batch.Values() {
-			if val.Type() != super.TypeType {
-				return errors.New("CSUP metadata type is not a type")
-			}
-			vals = append(vals, val.Bytes())
+			vals = append(vals, val)
 		}
 	}
 }

--- a/csup/fusion.go
+++ b/csup/fusion.go
@@ -32,13 +32,16 @@ func (f *FusionEncoder) Write(vec vector.Any) {
 	}
 	fusion := vec.(*vector.Fusion)
 	f.values.Write(fusion.Values)
-	//XXX calling SubTypes is a slow path... we should have another
-	// method on vector.TypeLoader that can just return the type IDs
-	// as a slice and lookup the interned CSUP type table and copy
-	// what is needed.
-	for _, typ := range fusion.Subtypes() {
-		f.subtypes = append(f.subtypes, f.cctx.lookupTypeID(fusion.Sctx, typ))
+	// We map the IDs local to the fusion vector onto to the fusion subtype IDs
+	// of the shared CSUP typedefs table.  The TypeDefsMerger takes care of this by
+	// mapping the ids relative to defs to the typedefs table in f.cctx.typedefs.
+	defs, ids := fusion.SubtypeIDs()
+	merger := super.NewTypeDefsMerger(f.cctx.TypeDefs(), defs)
+	mapped := make([]uint32, 0, len(ids))
+	for _, localID := range ids {
+		mapped = append(mapped, merger.LookupID(localID))
 	}
+	f.subtypes = append(f.subtypes, mapped...)
 }
 
 func (f *FusionEncoder) Emit(w io.Writer) error {

--- a/csup/header.go
+++ b/csup/header.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	Version     = 16
+	Version     = 17
 	HeaderSize  = 36
 	MaxMetaSize = 100 * 1024 * 1024
 	MaxTypeSize = 100 * 1024 * 1024

--- a/csup/writer.go
+++ b/csup/writer.go
@@ -73,10 +73,8 @@ func (w *Serializer) finalizeObject() error {
 	}
 	zw.EndStream()
 	metaSize := zw.Position()
-	for _, val := range cctx.types() {
-		if err := zw.Write(val); err != nil {
-			return fmt.Errorf("could not write CSUP metadata: %w", err)
-		}
+	if err := zw.Write(buildTypeDefsValue(cctx)); err != nil {
+		return fmt.Errorf("could not write CSUP metadata: %w", err)
 	}
 	zw.EndStream()
 	typeSize := zw.Position() - metaSize
@@ -96,6 +94,14 @@ func (w *Serializer) finalizeObject() error {
 	// Set new dynamic so we can write the next object.
 	w.dynamic = NewDynamicEncoder()
 	return nil
+}
+
+func buildTypeDefsValue(cctx *Context) super.Value {
+	var bytes []byte
+	if cctx.typedefs != nil {
+		bytes = cctx.typedefs.Bytes()
+	}
+	return super.NewValue(super.TypeBytes, super.EncodeBytes(bytes))
 }
 
 // XXX ValWriter provides a temporary interface to support writing super.Values

--- a/csup/writer.go
+++ b/csup/writer.go
@@ -101,7 +101,7 @@ func buildTypeDefsValue(cctx *Context) super.Value {
 	if cctx.typedefs != nil {
 		bytes = cctx.typedefs.Bytes()
 	}
-	return super.NewValue(super.TypeBytes, super.EncodeBytes(bytes))
+	return super.NewBytes(super.EncodeBytes(bytes))
 }
 
 // XXX ValWriter provides a temporary interface to support writing super.Values

--- a/csup/ztests/const.yaml
+++ b/csup/ztests/const.yaml
@@ -12,5 +12,5 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      {Version:16::uint32,MetaSize:39::uint64,TypeSize:0::uint64,DataSize:0::uint64,Root:0::uint32}
+      {Version:17::uint32,MetaSize:39::uint64,TypeSize:6::uint64,DataSize:0::uint64,Root:0::uint32}
       {Value:1,Count:3::uint32}::=Const

--- a/runtime/vcache/fusion.go
+++ b/runtime/vcache/fusion.go
@@ -80,20 +80,10 @@ type subtypesLoader struct {
 	subtypes *subtypes
 }
 
-var _ vector.TypeLoader = (*subtypesLoader)(nil)
+var _ vector.TypesLoader = (*subtypesLoader)(nil)
 
-func (s *subtypesLoader) Load() []super.Type {
+func (s *subtypesLoader) Load() (*super.TypeDefs, []uint32) {
 	ids := s.subtypes.loadIDs(s.loader.r)
-	s.cctx.LoadSubtypes()
-	subtypes := make([]super.Type, 0, len(ids))
-	sctx := s.loader.sctx
-	for _, id := range ids {
-		typeVal := s.cctx.LookupTypeVal(id)
-		typ, err := sctx.LookupByValue(typeVal)
-		if err != nil {
-			panic(err)
-		}
-		subtypes = append(subtypes, typ)
-	}
-	return subtypes
+	defs := s.cctx.LoadSubtypes()
+	return defs, ids
 }

--- a/sio/bsupio/types.go
+++ b/sio/bsupio/types.go
@@ -25,16 +25,17 @@ func (e *Encoder) Reset() {
 }
 
 func (e *Encoder) Flush() {
-	e.off = e.defs.Len()
+	e.off = len(e.defs.Bytes())
 }
 
 func (e *Encoder) Len() int {
-	return e.defs.Len() - e.off
+	return len(e.defs.Bytes()) - e.off
 }
 
 func (e *Encoder) nextBuffer() []byte {
-	b := e.defs.Bytes()[e.off:]
-	e.off = e.defs.Len()
+	bytes := e.defs.Bytes()
+	b := bytes[e.off:]
+	e.off = len(bytes)
 	return b
 }
 

--- a/sio/fjsonio/jsonvec/materialize.go
+++ b/sio/fjsonio/jsonvec/materialize.go
@@ -78,8 +78,8 @@ func (m *materializer) union(u *Union, fuse bool) (vector.Any, []uint32) {
 	}
 	subtypes := m.makeUnionSubtypes(u.Tags, dynamic, fixed)
 	typ := m.sctx.LookupTypeFusion(utyp)
-	loader := &subtypeLoader{
-		mapper:   super.NewTypeDefsMapper(m.sctx, m.defs),
+	loader := &subtypesLoader{
+		defs:     m.defs,
 		subtypes: subtypes,
 	}
 	vec := vector.NewUnion(utyp, u.Tags, vecs)
@@ -163,8 +163,8 @@ func (m *materializer) record(r *Record, fuse bool) (vector.Any, []uint32) {
 	subtypes := m.makeRecordSubtypes(r.perm, allFields, dynamic, fixed, r.tags)
 	if fuseHere {
 		typ := m.sctx.LookupTypeFusion(rtyp)
-		loader := &subtypeLoader{
-			mapper:   super.NewTypeDefsMapper(m.sctx, m.defs),
+		loader := &subtypesLoader{
+			defs:     m.defs,
 			subtypes: subtypes,
 		}
 		if !fuse {
@@ -222,22 +222,11 @@ func (m *materializer) makeRecordSubtypes(perm map[string]uint32, fields []super
 	return subtypes
 }
 
-// XXX we will move subtypeLoader to package vector so it can be
-// shared by the CSUP typedefs table when we change CSUP to use
-// typedefs instead of type values.
-type subtypeLoader struct {
-	mapper   *super.TypeDefsMapper
+type subtypesLoader struct {
+	defs     *super.TypeDefs
 	subtypes []uint32
 }
 
-func (s *subtypeLoader) Load() []super.Type {
-	types := make([]super.Type, 0, len(s.subtypes))
-	for _, id := range s.subtypes {
-		typ := s.mapper.LookupType(id)
-		if typ == nil {
-			panic(id)
-		}
-		types = append(types, typ)
-	}
-	return types
+func (s *subtypesLoader) Load() (*super.TypeDefs, []uint32) {
+	return s.defs, s.subtypes
 }

--- a/vector/fusion.go
+++ b/vector/fusion.go
@@ -11,27 +11,34 @@ type Fusion struct {
 	Sctx   *super.Context
 	Typ    *super.TypeFusion
 	Values Any
-	// We materialize the the subtypes of the supertype
-	// only when needed to build a Dynamic from the fused type.
-	// This is typically not required for many operations, in which
-	// case the type IDs are never read from storage and the types
-	// are never built and entered into the context.
+	// The fusion subtypes are always created as typedefs, whether
+	// loaded from CSUP, built from a fuse operation, built from FJSON
+	// etc.  They are only materialized into the query context when
+	// absoluately necessary to perform less common operations that require
+	// detailed types.  When coming from CSUP, the typedefs are lazily loaded
+	// and often never even read from storage.
 	mu       sync.Mutex
-	loader   TypeLoader
+	loader   TypesLoader
 	subtypes []super.Type
 }
 
-type TypeLoader interface {
-	Load() []super.Type
+// TypesLoader is an interface to load types as IDs and a TypeDefs table so
+// they do not pollute the query type context and are converted only when
+// needed.  For example, the CSUP reader reads the typedefs table only when
+// there is a runtime call to do so, and the CSUP writer loads types as
+// TypeDefs for merging and writing to metadata without ever needing to
+// create any super.Types.
+type TypesLoader interface {
+	Load() (*super.TypeDefs, []uint32)
 }
 
-var _ Any = (*Union)(nil)
+var _ Any = (*Fusion)(nil)
 
 func NewFusion(sctx *super.Context, typ *super.TypeFusion, vals Any, subtypes []super.Type) *Fusion {
 	return &Fusion{Sctx: sctx, Typ: typ, Values: vals, subtypes: subtypes}
 }
 
-func NewFusionWithLoader(sctx *super.Context, typ *super.TypeFusion, loader TypeLoader, vals Any) *Fusion {
+func NewFusionWithLoader(sctx *super.Context, typ *super.TypeFusion, loader TypesLoader, vals Any) *Fusion {
 	return &Fusion{Sctx: sctx, Typ: typ, loader: loader, Values: vals}
 }
 
@@ -56,11 +63,54 @@ func (f *Fusion) Serialize(b *scode.Builder, slot uint32) {
 	b.EndContainer()
 }
 
+// SubtypeIDs returns the typedefs table local to the fusion vector (e.g., not
+// with respect to the query context).  These IDs are then mappable into
+// the query context with a super.TypeDefsMapper or into a common typedefs
+// table with a super.TypeDefsMerger as is done in the CSUP write path.
+func (f *Fusion) SubtypeIDs() (*super.TypeDefs, []uint32) {
+	if f.loader == nil {
+		// If there's no loader, there must be a set of super.Types in the
+		// subtypes array.  This currently only happens when building vector.Fusion
+		// from the sam.
+		f.loader = f.buildTypeDefs()
+	}
+	return f.loader.Load()
+}
+
+type loaderShim struct {
+	defs *super.TypeDefs
+	ids  []uint32
+}
+
+var _ TypesLoader = (*loaderShim)(nil)
+
+func (l *loaderShim) Load() (*super.TypeDefs, []uint32) {
+	return l.defs, l.ids
+}
+
+func (f *Fusion) buildTypeDefs() *loaderShim {
+	defs := super.NewTypeDefs()
+	ids := make([]uint32, 0, len(f.subtypes))
+	for _, typ := range f.subtypes {
+		// This lookup has the side effect of installing each needed typedef
+		// in the defs table
+		ids = append(ids, defs.LookupType(typ))
+	}
+	return &loaderShim{defs, ids}
+}
+
 func (f *Fusion) Subtypes() []super.Type {
+	// XXX holding look during I/O
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.subtypes == nil {
-		f.subtypes = f.loader.Load()
+		defs, ids := f.SubtypeIDs()
+		subtypes := make([]super.Type, 0, f.Values.Len())
+		mapper := super.NewTypeDefsMapper(f.Sctx, defs)
+		for _, id := range ids {
+			subtypes = append(subtypes, mapper.LookupType(id))
+		}
+		f.subtypes = subtypes
 	}
 	return f.subtypes
 }


### PR DESCRIPTION
This commit changes the vector.TypesLoader interface to deal in TypeDefs tables and type IDs instead of super.Types, creating more efficient pathways for fusion vectors.  Subtypes are materialized to super.Types only when needed by the runtime.

Also, the subtypes in the CSUP metadata section are stored as a raw typedefs table (inside of a single super.Bytes value) instead of a sequence of fully-encoded type values.  The CSUP write path can now merge fusion subtypes efficiently with hash lookups on the TypeDefs types table.

The fjson read path is also more effiicent now since subtypes are stored as IDs and when written straight to CSUP, never go through the query context.