### PR TITLE
fjson.stream: Use done channel to close stream

### DIFF
--- a/sio/fjsonio/stream.go
+++ b/sio/fjsonio/stream.go
@@ -11,20 +11,19 @@ import (
 )
 
 type stream struct {
-	r      io.Reader
-	ch     chan result
-	once   sync.Once
-	ctx    context.Context
-	cancel context.CancelFunc
+	r    io.Reader
+	ch   chan result
+	done chan struct{}
+	once sync.Once
+	ctx  context.Context
 }
 
 func newStream(ctx context.Context, r io.Reader, n int) *stream {
-	ctx, cancel := context.WithCancel(ctx)
 	return &stream{
-		r:      r,
-		ch:     make(chan result, n),
-		ctx:    ctx,
-		cancel: cancel,
+		r:    r,
+		ch:   make(chan result, n),
+		ctx:  ctx,
+		done: make(chan struct{}),
 	}
 }
 
@@ -49,6 +48,8 @@ func (s *stream) next() (*vector.BytesTable, error) {
 		return r.bytes, nil
 	case <-s.ctx.Done():
 		return nil, s.ctx.Err()
+	case <-s.done:
+		return nil, nil
 	}
 }
 
@@ -69,7 +70,7 @@ func (s *stream) run() {
 }
 
 func (s *stream) close() error {
-	s.cancel()
+	close(s.done)
 	// drain channel
 	for range s.ch {
 	}

--- a/sio/fjsonio/vectorreader.go
+++ b/sio/fjsonio/vectorreader.go
@@ -60,7 +60,7 @@ func (v *VectorReader) ConcurrentPull(done bool, _ int) (vector.Any, error) {
 
 func (v *VectorReader) close() error {
 	if v.hasClosed.CompareAndSwap(false, true) {
-		return nil
+		return v.stream.close()
 	}
-	return v.stream.close()
+	return nil
 }


### PR DESCRIPTION
The commit fixes an issue where a context canceled error would sometimes
get returned from the fjson reader. Use a done channel to signal closure
instead of context.WithCancel.
