### PR TITLE
Skip the What Goes Around paper in link checker

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -14,3 +14,4 @@ ignorePatterns:
 # Presumably these research-oriented sites don't like being crawled.
   - pattern: '^https://dl.acm.org/doi/pdf/10.1145/984549.984551$'
   - pattern: '^https://www.researchgate.net/publication/221325979_Union_Types_for_Semistructured_Data$'
+  - pattern: '^https://db.cs.cmu.edu/papers/2024/whatgoesaround-sigmodrec2024.pdf$'


### PR DESCRIPTION
This has been failing consistently in the link checker lately, so I suspect that like other research paper links it's going to remain fussy, so we should skip checking it.