### PR TITLE
vector.TypeValue: Use native types

### DIFF
--- a/compiler/rungen/vexpr.go
+++ b/compiler/rungen/vexpr.go
@@ -46,7 +46,7 @@ func (b *Builder) compileVamExpr(e dag.Expr) (vamexpr.Evaluator, error) {
 		if err != nil {
 			return nil, err
 		}
-		return vamexpr.NewLiteral(val), nil
+		return vamexpr.NewLiteral(b.sctx(), val), nil
 	case *dag.RecordExpr:
 		return b.compileVamRecordExpr(e)
 	case *dag.RegexpMatchExpr:

--- a/csup/bytes.go
+++ b/csup/bytes.go
@@ -38,8 +38,6 @@ func (b *BytesEncoder) Write(vec vector.Any) {
 		b.writeTable(vec.Table())
 	case *vector.String:
 		b.writeTable(vec.Table())
-	case *vector.TypeValue:
-		b.writeTable(vec.Table())
 	default:
 		panic(vec)
 	}

--- a/csup/encoder.go
+++ b/csup/encoder.go
@@ -55,16 +55,16 @@ func NewEncoder(cctx *Context, typ super.Type) Encoder {
 	case *super.TypeFusion:
 		return NewFusionEncoder(cctx, typ)
 	case *super.TypeEnum:
-		return NewPrimitiveEncoder(typ)
+		return NewPrimitiveEncoder(cctx, typ)
 	default:
 		if !super.IsPrimitiveType(typ) {
 			panic(fmt.Sprintf("unsupported type in CSUP file: %T", typ))
 		}
-		return NewDictEncoder(typ, NewPrimitiveEncoder(typ))
+		return NewDictEncoder(typ, NewPrimitiveEncoder(cctx, typ))
 	}
 }
 
-func NewPrimitiveEncoder(typ super.Type) PrimitiveEncoder {
+func NewPrimitiveEncoder(cctx *Context, typ super.Type) PrimitiveEncoder {
 	switch id := typ.ID(); {
 	case super.IsSigned(id):
 		return NewIntEncoder(typ)
@@ -72,8 +72,10 @@ func NewPrimitiveEncoder(typ super.Type) PrimitiveEncoder {
 		return NewUintEncoder(typ)
 	case super.IsFloat(id):
 		return NewFloatEncoder(typ)
-	case id == super.IDBytes || id == super.IDString || id == super.IDType:
+	case id == super.IDBytes || id == super.IDString:
 		return NewBytesEncoder(typ)
+	case id == super.IDType:
+		return NewTypeValueEncoder(cctx)
 	default:
 		return NewScodeEncoder(typ)
 	}

--- a/csup/fusion.go
+++ b/csup/fusion.go
@@ -9,20 +9,20 @@ import (
 )
 
 type FusionEncoder struct {
-	cctx        *Context
-	typ         *super.TypeFusion
-	values      Encoder
-	subtypes    []uint32
-	subtypesEnc *Uint32Encoder
+	typ      *super.TypeFusion
+	values   Encoder
+	subtypes Encoder
 }
 
 var _ Encoder = (*FusionEncoder)(nil)
 
 func NewFusionEncoder(cctx *Context, typ *super.TypeFusion) *FusionEncoder {
 	return &FusionEncoder{
-		cctx:   cctx,
 		typ:    typ,
 		values: NewEncoder(cctx, typ.Type),
+		// Call NewTypeValueEncoder directly because we do not want subtypes
+		// wrapped in a dict / const.
+		subtypes: NewTypeValueEncoder(cctx),
 	}
 }
 
@@ -32,34 +32,24 @@ func (f *FusionEncoder) Write(vec vector.Any) {
 	}
 	fusion := vec.(*vector.Fusion)
 	f.values.Write(fusion.Values)
-	// We map the IDs local to the fusion vector onto to the fusion subtype IDs
-	// of the shared CSUP typedefs table.  The TypeDefsMerger takes care of this by
-	// mapping the ids relative to defs to the typedefs table in f.cctx.typedefs.
-	defs, ids := fusion.SubtypeIDs()
-	merger := super.NewTypeDefsMerger(f.cctx.TypeDefs(), defs)
-	mapped := make([]uint32, 0, len(ids))
-	for _, localID := range ids {
-		mapped = append(mapped, merger.LookupID(localID))
-	}
-	f.subtypes = append(f.subtypes, mapped...)
+	f.subtypes.Write(fusion.Subtypes)
 }
 
 func (f *FusionEncoder) Emit(w io.Writer) error {
 	if err := f.values.Emit(w); err != nil {
 		return err
 	}
-	return f.subtypesEnc.Emit(w)
+	return f.subtypes.Emit(w)
 }
 
 func (f *FusionEncoder) Encode(group *errgroup.Group) {
 	f.values.Encode(group)
-	f.subtypesEnc = &Uint32Encoder{vals: f.subtypes}
-	f.subtypesEnc.Encode(group)
+	f.subtypes.Encode(group)
 }
 
 func (f *FusionEncoder) Metadata(cctx *Context, off uint64) (uint64, ID) {
 	off, values := f.values.Metadata(cctx, off)
-	off, subtypes := f.subtypesEnc.Segment(off)
+	off, subtypes := f.subtypes.Metadata(cctx, off)
 	return off, cctx.enter(&Fusion{
 		Values:   values,
 		Subtypes: subtypes,

--- a/csup/header.go
+++ b/csup/header.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	Version     = 17
+	Version     = 18
 	HeaderSize  = 36
 	MaxMetaSize = 100 * 1024 * 1024
 	MaxTypeSize = 100 * 1024 * 1024

--- a/csup/int.go
+++ b/csup/int.go
@@ -90,7 +90,6 @@ func (i *IntEncoder) Dict() (PrimitiveEncoder, []byte, []uint32) {
 }
 
 func (i *IntEncoder) ConstValue() super.Value {
-
 	return super.NewInt(i.typ, i.vals[0])
 }
 

--- a/csup/int.go
+++ b/csup/int.go
@@ -90,6 +90,7 @@ func (i *IntEncoder) Dict() (PrimitiveEncoder, []byte, []uint32) {
 }
 
 func (i *IntEncoder) ConstValue() super.Value {
+
 	return super.NewInt(i.typ, i.vals[0])
 }
 

--- a/csup/metadata.go
+++ b/csup/metadata.go
@@ -103,11 +103,8 @@ func (e *Error) Len(cctx *Context) uint32 {
 }
 
 type Fusion struct {
-	Values ID
-	// Subtypes are stored as type IDs in the local context of
-	// the CSUP object in which the type appears.  vcache translates
-	// these local types to the query sctx.
-	Subtypes Segment
+	Values   ID
+	Subtypes ID
 }
 
 func (f *Fusion) Len(cctx *Context) uint32 {
@@ -177,6 +174,15 @@ func (b *Bytes) Type(*Context, *super.Context) super.Type {
 
 func (b *Bytes) Len(*Context) uint32 {
 	return b.Count
+}
+
+type TypeValue struct {
+	Location Segment
+	Length   uint32
+}
+
+func (t *TypeValue) Len(*Context) uint32 {
+	return t.Length
 }
 
 type Primitive struct {
@@ -309,6 +315,7 @@ var Template = []any{
 	Float{},
 	Bytes{},
 	Primitive{},
+	TypeValue{},
 	Named{},
 	Error{},
 	Const{},

--- a/csup/type.go
+++ b/csup/type.go
@@ -1,0 +1,61 @@
+package csup
+
+import (
+	"io"
+
+	"github.com/brimdata/super"
+	"github.com/brimdata/super/vector"
+	"golang.org/x/sync/errgroup"
+)
+
+type TypeValueEncoder struct {
+	cctx    *Context
+	ids     []uint32
+	encoder *Uint32Encoder
+}
+
+func NewTypeValueEncoder(cctx *Context) PrimitiveEncoder {
+	return &TypeValueEncoder{cctx: cctx}
+}
+
+func (t *TypeValueEncoder) Write(vec vector.Any) {
+	types := vec.(*vector.TypeValue)
+	defs, ids := types.TypeIDs()
+	merger := super.NewTypeDefsMerger(t.cctx.TypeDefs(), defs)
+	mapped := make([]uint32, 0, len(ids))
+	for _, localID := range ids {
+		mapped = append(mapped, merger.LookupID(localID))
+	}
+	t.ids = append(t.ids, mapped...)
+}
+
+func (t *TypeValueEncoder) Emit(w io.Writer) error {
+	return t.encoder.Emit(w)
+}
+
+func (t *TypeValueEncoder) Encode(group *errgroup.Group) {
+	t.encoder = &Uint32Encoder{vals: t.ids}
+	t.encoder.Encode(group)
+}
+
+func (t *TypeValueEncoder) Metadata(cctx *Context, off uint64) (uint64, ID) {
+	off, loc := t.encoder.Segment(off)
+	return off, cctx.enter(&TypeValue{
+		Location: loc,
+	})
+}
+
+func (t *TypeValueEncoder) Dict() (PrimitiveEncoder, []byte, []uint32) {
+	entries, index, counts := comparableDict(t.ids)
+	if entries == nil {
+		return nil, nil, nil
+	}
+	return &TypeValueEncoder{
+		ids: entries,
+	}, index, counts
+}
+
+func (t *TypeValueEncoder) ConstValue() super.Value {
+	typ := super.NewTypeDefsMapper(t.cctx.local, t.cctx.typedefs).LookupType(t.ids[0])
+	return super.NewValue(super.TypeType, super.EncodeTypeValue(typ))
+}

--- a/csup/ztests/const.yaml
+++ b/csup/ztests/const.yaml
@@ -12,5 +12,5 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      {Version:17::uint32,MetaSize:44::uint64,TypeSize:6::uint64,DataSize:0::uint64,Root:0::uint32}
+      {Version:18::uint32,MetaSize:44::uint64,TypeSize:6::uint64,DataSize:0::uint64,Root:0::uint32}
       {Value:fusion(0x02::all,<int64>),Count:3::uint32}::=Const

--- a/runtime/vam/expr/agg/fuse.go
+++ b/runtime/vam/expr/agg/fuse.go
@@ -63,9 +63,7 @@ func (f *fuse) Result(sctx *super.Context) vector.Any {
 	for _, typ := range f.types {
 		fuser.Fuse(typ)
 	}
-	table := vector.NewBytesTableEmpty(0)
-	table.Append(super.EncodeTypeValue(fuser.Type()))
-	return vector.NewTypeValue(table)
+	return vector.NewTypeValue(sctx, []super.Type{fuser.Type()})
 }
 
 func (f *fuse) ConsumeAsPartial(partial vector.Any) {
@@ -77,8 +75,8 @@ func (f *fuse) ConsumeAsPartial(partial vector.Any) {
 		panic("fuse: partial not a type value")
 	}
 	for i := range partial.Len() {
-		b := vector.TypeValueValue(partial, i)
-		f.partials = append(f.partials, super.NewValue(super.TypeType, b))
+		typ := vector.TypeValueValue(partial, i)
+		f.partials = append(f.partials, super.NewValue(super.TypeType, super.EncodeTypeValue(typ)))
 	}
 }
 

--- a/runtime/vam/expr/aggregator.go
+++ b/runtime/vam/expr/aggregator.go
@@ -22,7 +22,7 @@ func NewAggregator(name string, distinct bool, expr Evaluator, where Evaluator) 
 	if expr == nil {
 		// Count is the only that has no argument so we just return
 		// true so it counts each value encountered.
-		expr = NewLiteral(super.True)
+		expr = NewLiteral(nil, super.True)
 	}
 	return &Aggregator{
 		Pattern:  pattern,

--- a/runtime/vam/expr/cast/type.go
+++ b/runtime/vam/expr/cast/type.go
@@ -24,7 +24,11 @@ func castToType(sctx *super.Context, vec vector.Any, index []uint32) (vector.Any
 				errs = append(errs, i)
 				continue
 			}
-			typ, _ := sctx.DecodeTypeValue(val.Bytes())
+			typ, tv := sctx.DecodeTypeValue(val.Bytes())
+			if tv == nil {
+				errs = append(errs, i)
+				continue
+			}
 			out.Append(typ)
 		}
 		return out, errs, "", true

--- a/runtime/vam/expr/cast/type.go
+++ b/runtime/vam/expr/cast/type.go
@@ -12,20 +12,20 @@ func castToType(sctx *super.Context, vec vector.Any, index []uint32) (vector.Any
 		return vec, nil, "", true
 	case *vector.String:
 		n := lengthOf(vec, index)
-		out := vector.NewTypeValueEmpty(0)
+		out := vector.NewTypeValueEmpty(sctx)
 		var errs []uint32
 		for i := range n {
 			idx := i
 			if index != nil {
 				idx = index[i]
 			}
-			s := vec.Value(idx)
-			val, err := sup.ParseValue(sctx, s)
+			val, err := sup.ParseValue(sctx, vec.Value(idx))
 			if err != nil || val.Type().ID() != super.IDType {
 				errs = append(errs, i)
 				continue
 			}
-			out.Append(val.Bytes())
+			typ, _ := sctx.DecodeTypeValue(val.Bytes())
+			out.Append(typ)
 		}
 		return out, errs, "", true
 	default:

--- a/runtime/vam/expr/compare.go
+++ b/runtime/vam/expr/compare.go
@@ -3,7 +3,6 @@ package expr
 //go:generate go run gencomparefuncs.go
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/brimdata/super"
@@ -134,7 +133,7 @@ func (c *Compare) compareTypeVals(lhs, rhs vector.Any) vector.Any {
 	for i := range lhs.Len() {
 		l := vector.TypeValueValue(lhs, i)
 		r := vector.TypeValueValue(rhs, i)
-		v := bytes.Equal(l, r)
+		v := l == r
 		if c.opCode == vector.CompNE {
 			v = !v
 		}

--- a/runtime/vam/expr/dot.go
+++ b/runtime/vam/expr/dot.go
@@ -48,12 +48,12 @@ func (d *DotExpr) eval(vecs ...vector.Any) vector.Any {
 		return val.Fields[i]
 	case *vector.TypeValue:
 		var errs []uint32
-		typvals := vector.NewTypeValueEmpty(0)
+		typvals := vector.NewTypeValueEmpty(d.sctx)
 		for i := range val.Len() {
-			typ, _ := d.sctx.DecodeTypeValue(val.Value(i))
+			typ := val.Value(i)
 			if typ, ok := super.TypeUnder(typ).(*super.TypeRecord); ok {
 				if typ, ok := typ.TypeOfField(d.field); ok {
-					typvals.Append(super.EncodeTypeValue(typ))
+					typvals.Append(typ)
 					continue
 				}
 			}

--- a/runtime/vam/expr/function/fields.go
+++ b/runtime/vam/expr/function/fields.go
@@ -41,9 +41,8 @@ func (f *Fields) Call(args ...vector.Any) vector.Any {
 		s := vector.NewStringEmpty(val.Len())
 		inOffs, outOffs := []uint32{0}, []uint32{0}
 		for i := uint32(0); i < val.Len(); i++ {
-			b := vector.TypeValueValue(val, i)
-			rtyp := f.recordType(b)
-			if rtyp == nil {
+			rtyp, ok := vector.TypeValueValue(val, i).(*super.TypeRecord)
+			if !ok {
 				errs = append(errs, i)
 				continue
 			}

--- a/runtime/vam/expr/function/len.go
+++ b/runtime/vam/expr/function/len.go
@@ -50,12 +50,8 @@ func (l *Len) Call(args ...vector.Any) vector.Any {
 		return vector.NewWrappedError(l.sctx, "len()", val)
 	case *super.TypeOfType:
 		for i := uint32(0); i < val.Len(); i++ {
-			b := vector.TypeValueValue(val, i)
-			t, err := l.sctx.LookupByValue(b)
-			if err != nil {
-				panic(err)
-			}
-			out.Append(int64(function.TypeLength(t)))
+			typ := vector.TypeValueValue(val, i)
+			out.Append(int64(function.TypeLength(typ)))
 		}
 	default:
 		return vector.NewWrappedError(l.sctx, "len: bad type", val)

--- a/runtime/vam/expr/function/types.go
+++ b/runtime/vam/expr/function/types.go
@@ -97,17 +97,15 @@ func (i *Is) Call(args ...vector.Any) vector.Any {
 		return vector.NewWrappedError(i.sctx, "is: type value argument expected", typeVal)
 	}
 	if _, ok := typeVal.(*vector.Const); ok {
-		b := vector.TypeValueValue(typeVal, 0)
-		typ, err := i.sctx.LookupByValue(b)
-		v := err == nil && typ == vec.Type()
+		typ := vector.TypeValueValue(typeVal, 0)
+		v := typ == vec.Type()
 		return vector.NewConstBool(v, vec.Len())
 	}
 	inTyp := vec.Type()
 	out := vector.NewFalse(vec.Len())
 	for k := range vec.Len() {
-		b := vector.TypeValueValue(typeVal, k)
-		typ, err := i.sctx.LookupByValue(b)
-		if err == nil && typ == inTyp {
+		typ := vector.TypeValueValue(typeVal, k)
+		if typ == inTyp {
 			out.Set(k)
 		}
 	}
@@ -137,11 +135,7 @@ func (n *NameOf) Call(args ...vector.Any) vector.Any {
 	out := vector.NewStringEmpty(vec.Len())
 	var errs []uint32
 	for i := range vec.Len() {
-		b := vector.TypeValueValue(vec, i)
-		var err error
-		if typ, err = n.sctx.LookupByValue(b); err != nil {
-			panic(err)
-		}
+		typ := vector.TypeValueValue(vec, i)
 		if named, ok := typ.(*super.TypeNamed); ok {
 			out.Append(named.Name)
 		} else {
@@ -159,8 +153,7 @@ type TypeOf struct {
 }
 
 func (t *TypeOf) Call(args ...vector.Any) vector.Any {
-	val := t.sctx.LookupTypeValue(args[0].Type())
-	return vector.NewConstType(val.Bytes(), args[0].Len())
+	return vector.NewConstType(t.sctx, args[0].Type(), args[0].Len())
 }
 
 type TypeName struct {
@@ -173,13 +166,13 @@ func (t *TypeName) Call(args ...vector.Any) vector.Any {
 		return vector.NewWrappedError(t.sctx, "typename: argument must be a string", args[0])
 	}
 	var errs []uint32
-	out := vector.NewTypeValueEmpty(0)
+	out := vector.NewTypeValueEmpty(t.sctx)
 	for i := range vec.Len() {
 		s := vector.StringValue(vec, i)
 		if typ := t.sctx.LookupByName(s); typ == nil {
 			errs = append(errs, i)
 		} else {
-			out.Append(t.sctx.LookupTypeValue(typ).Bytes())
+			out.Append(typ)
 		}
 	}
 	if len(errs) > 0 {
@@ -213,11 +206,7 @@ func (k *Kind) Call(args ...vector.Any) vector.Any {
 	}
 	out := vector.NewStringEmpty(vec.Len())
 	for i, n := uint32(0), vec.Len(); i < n; i++ {
-		bytes := vector.TypeValueValue(vec, i)
-		typ, err := k.sctx.LookupByValue(bytes)
-		if err != nil {
-			panic(err)
-		}
+		typ := vector.TypeValueValue(vec, i)
 		out.Append(typ.Kind().String())
 	}
 	return out

--- a/runtime/vam/expr/function/under.go
+++ b/runtime/vam/expr/function/under.go
@@ -26,7 +26,7 @@ func (u *Under) Call(args ...vector.Any) vector.Any {
 	case *vector.Const:
 		val := vector.ValueAt(nil, vec, 0)
 		val = u.samunder.Call([]super.Value{val})
-		out = vector.NewConstFromValue(val, vec.Len())
+		out = vector.NewConstFromValue(u.sctx, val, vec.Len())
 	case *vector.Named:
 		out = vec.Any
 	case *vector.Error:
@@ -34,14 +34,9 @@ func (u *Under) Call(args ...vector.Any) vector.Any {
 	case *vector.Union:
 		return vec.Dynamic
 	case *vector.TypeValue:
-		typs := vector.NewTypeValueEmpty(0)
+		typs := vector.NewTypeValueEmpty(u.sctx)
 		for i := range vec.Len() {
-			t, err := u.sctx.LookupByValue(vec.Value(i))
-			if err != nil {
-				panic(err)
-			}
-			v := u.sctx.LookupTypeValue(super.TypeUnder(t))
-			typs.Append(v.Bytes())
+			typs.Append(super.TypeUnder(vec.Value(i)))
 		}
 		out = typs
 	default:

--- a/runtime/vam/expr/literal.go
+++ b/runtime/vam/expr/literal.go
@@ -6,18 +6,19 @@ import (
 )
 
 type Literal struct {
-	val super.Value
+	sctx *super.Context
+	val  super.Value
 }
 
 var _ Evaluator = (*Literal)(nil)
 
-func NewLiteral(val super.Value) *Literal {
-	return &Literal{val: val}
+func NewLiteral(sctx *super.Context, val super.Value) *Literal {
+	return &Literal{sctx: sctx, val: val}
 }
 
 func (l Literal) Eval(val vector.Any) vector.Any {
 	if l.val.IsNull() {
 		return vector.NewNull(val.Len())
 	}
-	return vector.NewConstFromValue(l.val, val.Len())
+	return vector.NewConstFromValue(l.sctx, l.val, val.Len())
 }

--- a/runtime/vam/expr/search.go
+++ b/runtime/vam/expr/search.go
@@ -41,7 +41,7 @@ func NewSearch(sctx *super.Context, s string, val super.Value, e Evaluator) Eval
 		if val.IsNull() {
 			return vector.NewNull(vec.Len())
 		}
-		return eq.eval(vec, vector.NewConstFromValue(val, vec.Len()))
+		return eq.eval(vec, vector.NewConstFromValue(sctx, val, vec.Len()))
 	}
 	return &search{sctx, e, vectorPred, stringPred, nil}
 }

--- a/runtime/vcache/bytes.go
+++ b/runtime/vcache/bytes.go
@@ -36,8 +36,6 @@ func (b *bytes) project(loader *loader, projection field.Projection) vector.Any 
 		return vector.NewString(table)
 	case super.IDBytes:
 		return vector.NewBytes(table)
-	case super.IDType:
-		return vector.NewTypeValue(table)
 	default:
 		panic(b.meta.Typ)
 	}

--- a/runtime/vcache/const.go
+++ b/runtime/vcache/const.go
@@ -36,5 +36,5 @@ func (c *const_) project(loader *loader, projection field.Projection) vector.Any
 	if err != nil {
 		panic(err)
 	}
-	return vector.NewConstFromValue(super.NewValue(typ, val.Bytes()), c.length())
+	return vector.NewConstFromValue(loader.sctx, super.NewValue(typ, val.Bytes()), c.length())
 }

--- a/runtime/vcache/fusion.go
+++ b/runtime/vcache/fusion.go
@@ -36,7 +36,6 @@ func (f *fusion) unmarshal(cctx *csup.Context, projection field.Projection) {
 		f.values = newShadow(cctx, f.meta.Values)
 	}
 	if f.subtypes == nil {
-		f.subtypes = newShadow(cctx, f.meta.Subtypes).(*typevalue)
 		f.subtypes = newTypeValue(cctx, cctx.Lookup(f.meta.Subtypes).(*csup.TypeValue))
 	}
 	f.values.unmarshal(cctx, projection)

--- a/runtime/vcache/fusion.go
+++ b/runtime/vcache/fusion.go
@@ -1,31 +1,27 @@
 package vcache
 
 import (
-	"io"
 	"sync"
 
-	"github.com/brimdata/super"
 	"github.com/brimdata/super/csup"
 	"github.com/brimdata/super/pkg/field"
 	"github.com/brimdata/super/vector"
 )
 
 type fusion struct {
-	mu     sync.Mutex
-	cctx   *csup.Context
-	meta   *csup.Fusion
-	len    uint32
-	values shadow
-	// the ids are loaded on-demand from the runtime
-	subtypes subtypes
+	mu       sync.Mutex
+	cctx     *csup.Context
+	meta     *csup.Fusion
+	len      uint32
+	values   shadow
+	subtypes *typevalue
 }
 
 func newFusion(cctx *csup.Context, meta *csup.Fusion) *fusion {
 	return &fusion{
-		cctx:     cctx,
-		meta:     meta,
-		len:      meta.Len(cctx),
-		subtypes: subtypes{segment: meta.Subtypes},
+		cctx: cctx,
+		meta: meta,
+		len:  meta.Len(cctx),
 	}
 }
 
@@ -39,51 +35,15 @@ func (f *fusion) unmarshal(cctx *csup.Context, projection field.Projection) {
 	if f.values == nil {
 		f.values = newShadow(cctx, f.meta.Values)
 	}
+	if f.subtypes == nil {
+		f.subtypes = newShadow(cctx, f.meta.Subtypes).(*typevalue)
+		f.subtypes = newTypeValue(cctx, cctx.Lookup(f.meta.Subtypes).(*csup.TypeValue))
+	}
 	f.values.unmarshal(cctx, projection)
 }
 
 func (f *fusion) project(loader *loader, projection field.Projection) vector.Any {
 	vec := f.values.project(loader, projection)
 	typ := loader.sctx.LookupTypeFusion(vec.Type())
-	l := &subtypesLoader{
-		loader:   loader,
-		cctx:     f.cctx,
-		subtypes: &f.subtypes,
-	}
-	return vector.NewFusionWithLoader(loader.sctx, typ, l, vec)
-}
-
-type subtypes struct {
-	// We load the IDs separately from the types so that a shadow
-	// of ids may be shared by multipe contexts.
-	segment csup.Segment
-	mu      sync.Mutex
-	ids     []uint32
-}
-
-func (s *subtypes) loadIDs(r io.ReaderAt) []uint32 {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.ids == nil {
-		ids, err := csup.ReadUint32s(s.segment, r)
-		if err != nil {
-			panic(err)
-		}
-		s.ids = ids
-	}
-	return s.ids
-}
-
-type subtypesLoader struct {
-	loader   *loader
-	cctx     *csup.Context
-	subtypes *subtypes
-}
-
-var _ vector.TypesLoader = (*subtypesLoader)(nil)
-
-func (s *subtypesLoader) Load() (*super.TypeDefs, []uint32) {
-	ids := s.subtypes.loadIDs(s.loader.r)
-	defs := s.cctx.LoadSubtypes()
-	return defs, ids
+	return vector.NewFusionWithLoader(loader.sctx, typ, f.subtypes.newLoader(loader), vec)
 }

--- a/runtime/vcache/primitive.go
+++ b/runtime/vcache/primitive.go
@@ -80,7 +80,7 @@ func (p *primitive) loadAnyWithLock(loader *loader) any {
 			}
 		}
 		return bits
-	case *super.TypeOfBytes, *super.TypeOfString, *super.TypeOfType:
+	case *super.TypeOfBytes, *super.TypeOfString:
 		var bytes []byte
 		// First offset is always zero.
 		offs := make([]uint32, 1, length+1)
@@ -125,8 +125,6 @@ func (p *primitive) newVector(loader *loader) vector.Any {
 		return vector.NewIP(p.load(loader).([]netip.Addr))
 	case *super.TypeOfNet:
 		return vector.NewNet(p.load(loader).([]netip.Prefix))
-	case *super.TypeOfType:
-		return vector.NewTypeValue(p.load(loader).(vector.BytesTable))
 	case *super.TypeEnum:
 		// Despite being coded as a primitive, enums have complex types that
 		// must live in the query context so we can't use the type in the

--- a/runtime/vcache/shadow.go
+++ b/runtime/vcache/shadow.go
@@ -75,6 +75,8 @@ func newShadow(cctx *csup.Context, id csup.ID) shadow {
 		return newBytes(cctx, meta)
 	case *csup.Primitive:
 		return newPrimitive(cctx, meta)
+	case *csup.TypeValue:
+		return newTypeValue(cctx, meta)
 	case *csup.Const:
 		return newConst(cctx, meta)
 	default:

--- a/runtime/vcache/type.go
+++ b/runtime/vcache/type.go
@@ -1,0 +1,69 @@
+package vcache
+
+import (
+	"io"
+	"sync"
+
+	"github.com/brimdata/super"
+	"github.com/brimdata/super/csup"
+	"github.com/brimdata/super/pkg/field"
+	"github.com/brimdata/super/vector"
+)
+
+type typevalue struct {
+	// We load the IDs separately from the types so that a shadow
+	// of ids may be shared by multipe contexts.
+	meta *csup.TypeValue
+	mu   sync.Mutex
+	ids  []uint32
+	len  uint32
+}
+
+func newTypeValue(cctx *csup.Context, meta *csup.TypeValue) *typevalue {
+	return &typevalue{
+		meta: meta,
+		len:  meta.Len(cctx),
+	}
+}
+
+func (t *typevalue) length() uint32 {
+	return t.len
+}
+
+func (*typevalue) unmarshal(*csup.Context, field.Projection) {}
+
+func (t *typevalue) project(loader *loader, projection field.Projection) vector.Any {
+	if len(projection) > 0 {
+		return vector.NewMissing(loader.sctx, t.length())
+	}
+	return vector.NewTypeValueWithLoader(loader.sctx, t.newLoader(loader))
+}
+
+func (t *typevalue) newLoader(loader *loader) *typesLoader {
+	return &typesLoader{loader, t}
+}
+
+func (s *typevalue) loadIDs(r io.ReaderAt) []uint32 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.ids == nil {
+		ids, err := csup.ReadUint32s(s.meta.Location, r)
+		if err != nil {
+			panic(err)
+		}
+		s.ids = ids
+	}
+	return s.ids
+}
+
+type typesLoader struct {
+	loader *loader
+	type_  *typevalue
+}
+
+var _ vector.TypesLoader = (*typesLoader)(nil)
+
+func (s *typesLoader) Load() (*super.TypeDefs, []uint32) {
+	return s.loader.cctx.LoadSubtypes(), s.type_.loadIDs(s.loader.r)
+
+}

--- a/vector/builder.go
+++ b/vector/builder.go
@@ -79,7 +79,7 @@ func NewBuilder(typ super.Type) Builder {
 		return &genericBuilder[uint64]{
 			typ:      typ,
 			valuesOf: func(vec Any) []uint64 { return vec.(*Uint).Values },
-			build: func(typ super.Type, vals []uint64) Any {
+			build: func(_ *super.Context, typ super.Type, vals []uint64) Any {
 				return NewUint(typ, vals)
 			},
 		}
@@ -92,7 +92,7 @@ func NewBuilder(typ super.Type) Builder {
 		return &genericBuilder[int64]{
 			typ:      typ,
 			valuesOf: func(vec Any) []int64 { return vec.(*Int).Values },
-			build: func(typ super.Type, vals []int64) Any {
+			build: func(_ *super.Context, typ super.Type, vals []int64) Any {
 				return NewInt(typ, vals)
 			},
 		}
@@ -102,21 +102,20 @@ func NewBuilder(typ super.Type) Builder {
 		return &genericBuilder[float64]{
 			typ:      typ,
 			valuesOf: func(vec Any) []float64 { return vec.(*Float).Values },
-			build: func(typ super.Type, vals []float64) Any {
+			build: func(_ *super.Context, typ super.Type, vals []float64) Any {
 				return NewFloat(typ, vals)
 			},
 		}
 	case *super.TypeOfBool:
 		return &boolBuilder{}
 	case *super.TypeOfString,
-		*super.TypeOfBytes,
-		*super.TypeOfType:
-		return newStringBytesTypeBuilder(typ)
+		*super.TypeOfBytes:
+		return newStringBytesBuilder(typ)
 	case *super.TypeOfIP:
 		return &genericBuilder[netip.Addr]{
 			typ:      typ,
 			valuesOf: func(vec Any) []netip.Addr { return vec.(*IP).Values },
-			build: func(_ super.Type, vals []netip.Addr) Any {
+			build: func(_ *super.Context, _ super.Type, vals []netip.Addr) Any {
 				return NewIP(vals)
 			},
 		}
@@ -124,8 +123,15 @@ func NewBuilder(typ super.Type) Builder {
 		return &genericBuilder[netip.Prefix]{
 			typ:      typ,
 			valuesOf: func(vec Any) []netip.Prefix { return vec.(*Net).Values },
-			build: func(_ super.Type, vals []netip.Prefix) Any {
+			build: func(_ *super.Context, _ super.Type, vals []netip.Prefix) Any {
 				return NewNet(vals)
+			},
+		}
+	case *super.TypeOfType:
+		return &genericBuilder[super.Type]{
+			valuesOf: func(vec Any) []super.Type { return vec.(*TypeValue).types },
+			build: func(sctx *super.Context, _ super.Type, vals []super.Type) Any {
+				return NewTypeValue(sctx, vals)
 			},
 		}
 	case *super.TypeOfNull:
@@ -156,7 +162,7 @@ type genericBuilder[E any] struct {
 	typ      super.Type
 	vals     []E
 	valuesOf func(Any) []E
-	build    func(super.Type, []E) Any
+	build    func(*super.Context, super.Type, []E) Any
 }
 
 func (b *genericBuilder[E]) Write(vec Any) {
@@ -181,8 +187,8 @@ func (b *genericBuilder[E]) Write(vec Any) {
 	}
 }
 
-func (b *genericBuilder[E]) Build(*super.Context) Any {
-	return b.build(b.typ, b.vals)
+func (b *genericBuilder[E]) Build(sctx *super.Context) Any {
+	return b.build(sctx, b.typ, b.vals)
 }
 
 type boolBuilder struct {
@@ -209,16 +215,16 @@ func (b *boolBuilder) Build(*super.Context) Any {
 	return NewBool(b.bits)
 }
 
-type stringBytesTypeBuilder struct {
+type stringBytesBuilder struct {
 	typ   super.Type
 	table BytesTable
 }
 
-func newStringBytesTypeBuilder(typ super.Type) Builder {
-	return &stringBytesTypeBuilder{typ: typ, table: NewBytesTableEmpty(0)}
+func newStringBytesBuilder(typ super.Type) Builder {
+	return &stringBytesBuilder{typ: typ, table: NewBytesTableEmpty(0)}
 }
 
-func (s *stringBytesTypeBuilder) Write(vec Any) {
+func (s *stringBytesBuilder) Write(vec Any) {
 	switch vec := vec.(type) {
 	case *View:
 		table := bytesTableOf(vec.Any)
@@ -235,7 +241,7 @@ func (s *stringBytesTypeBuilder) Write(vec Any) {
 		for _, slot := range vec.Index {
 			s.table.Append(table.Bytes(uint32(slot)))
 		}
-	case *String, *Bytes, *TypeValue:
+	case *String, *Bytes:
 		table := bytesTableOf(vec)
 		for i := range vec.Len() {
 			s.table.Append(table.Bytes(i))
@@ -251,21 +257,17 @@ func bytesTableOf(vec Any) BytesTable {
 		return vec.table
 	case *Bytes:
 		return vec.table
-	case *TypeValue:
-		return vec.table
 	default:
 		panic(vec)
 	}
 }
 
-func (s *stringBytesTypeBuilder) Build(*super.Context) Any {
+func (s *stringBytesBuilder) Build(*super.Context) Any {
 	switch s.typ.ID() {
 	case super.IDString:
 		return NewString(s.table)
 	case super.IDBytes:
 		return NewBytes(s.table)
-	case super.IDType:
-		return NewTypeValue(s.table)
 	default:
 		panic(s.typ)
 	}

--- a/vector/const.go
+++ b/vector/const.go
@@ -90,7 +90,10 @@ func NewConstFromValue(sctx *super.Context, val super.Value, length uint32) *Con
 	case id == super.IDNet:
 		return NewConstNet(super.DecodeNet(val.Bytes()), length)
 	case id == super.IDType:
-		typ, _ := sctx.DecodeTypeValue(val.Bytes())
+		typ, tv := sctx.DecodeTypeValue(val.Bytes())
+		if tv == nil {
+			panic("bad type value")
+		}
 		return NewConstType(sctx, typ, length)
 	}
 	panic(fmt.Sprintf("%#v\n", super.TypeUnder(val.Type())))

--- a/vector/const.go
+++ b/vector/const.go
@@ -66,12 +66,12 @@ func NewConstNet(v netip.Prefix, length uint32) *Const {
 	vec := NewNet([]netip.Prefix{v})
 	return &Const{vec, length}
 }
-func NewConstType(v []byte, length uint32) *Const {
-	vec := NewTypeValue(newBytesTableWithValue(v))
+func NewConstType(sctx *super.Context, typ super.Type, length uint32) *Const {
+	vec := NewTypeValue(sctx, []super.Type{typ})
 	return &Const{vec, length}
 }
 
-func NewConstFromValue(val super.Value, length uint32) *Const {
+func NewConstFromValue(sctx *super.Context, val super.Value, length uint32) *Const {
 	switch id := val.Type().ID(); {
 	case super.IsUnsigned(id):
 		return NewConstUint(val.Type(), val.Uint(), length)
@@ -90,7 +90,8 @@ func NewConstFromValue(val super.Value, length uint32) *Const {
 	case id == super.IDNet:
 		return NewConstNet(super.DecodeNet(val.Bytes()), length)
 	case id == super.IDType:
-		return NewConstType(val.Bytes(), length)
+		typ, _ := sctx.DecodeTypeValue(val.Bytes())
+		return NewConstType(sctx, typ, length)
 	}
 	panic(fmt.Sprintf("%#v\n", super.TypeUnder(val.Type())))
 }

--- a/vector/fusion.go
+++ b/vector/fusion.go
@@ -1,8 +1,6 @@
 package vector
 
 import (
-	"sync"
-
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/scode"
 )
@@ -11,35 +9,23 @@ type Fusion struct {
 	Sctx   *super.Context
 	Typ    *super.TypeFusion
 	Values Any
-	// The fusion subtypes are always created as typedefs, whether
+	// The TypeValue vectors are always created as typedefs, whether
 	// loaded from CSUP, built from a fuse operation, built from FJSON
 	// etc.  They are only materialized into the query context when
 	// absoluately necessary to perform less common operations that require
 	// detailed types.  When coming from CSUP, the typedefs are lazily loaded
 	// and often never even read from storage.
-	mu       sync.Mutex
-	loader   TypesLoader
-	subtypes []super.Type
-}
-
-// TypesLoader is an interface to load types as IDs and a TypeDefs table so
-// they do not pollute the query type context and are converted only when
-// needed.  For example, the CSUP reader reads the typedefs table only when
-// there is a runtime call to do so, and the CSUP writer loads types as
-// TypeDefs for merging and writing to metadata without ever needing to
-// create any super.Types.
-type TypesLoader interface {
-	Load() (*super.TypeDefs, []uint32)
+	Subtypes *TypeValue
 }
 
 var _ Any = (*Fusion)(nil)
 
 func NewFusion(sctx *super.Context, typ *super.TypeFusion, vals Any, subtypes []super.Type) *Fusion {
-	return &Fusion{Sctx: sctx, Typ: typ, Values: vals, subtypes: subtypes}
+	return &Fusion{Sctx: sctx, Typ: typ, Values: vals, Subtypes: NewTypeValue(sctx, subtypes)}
 }
 
 func NewFusionWithLoader(sctx *super.Context, typ *super.TypeFusion, loader TypesLoader, vals Any) *Fusion {
-	return &Fusion{Sctx: sctx, Typ: typ, loader: loader, Values: vals}
+	return &Fusion{Sctx: sctx, Typ: typ, Values: vals, Subtypes: NewTypeValueWithLoader(sctx, loader)}
 }
 
 func (*Fusion) Kind() Kind {
@@ -57,65 +43,6 @@ func (f *Fusion) Len() uint32 {
 func (f *Fusion) Serialize(b *scode.Builder, slot uint32) {
 	b.BeginContainer()
 	f.Values.Serialize(b, slot)
-	// XXX this is a slow path
-	typeVal := f.Sctx.LookupTypeValue(f.Subtypes()[slot])
-	b.Append(typeVal.Bytes())
+	f.Subtypes.Serialize(b, slot)
 	b.EndContainer()
-}
-
-// SubtypeIDs returns the typedefs table local to the fusion vector (e.g., not
-// with respect to the query context).  These IDs are then mappable into
-// the query context with a super.TypeDefsMapper or into a common typedefs
-// table with a super.TypeDefsMerger as is done in the CSUP write path.
-func (f *Fusion) SubtypeIDs() (*super.TypeDefs, []uint32) {
-	if f.loader == nil {
-		// If there's no loader, there must be a set of super.Types in the
-		// subtypes array.  This currently only happens when building vector.Fusion
-		// from the sam.
-		f.loader = f.buildTypeDefs()
-	}
-	return f.loader.Load()
-}
-
-type loaderShim struct {
-	defs *super.TypeDefs
-	ids  []uint32
-}
-
-var _ TypesLoader = (*loaderShim)(nil)
-
-func (l *loaderShim) Load() (*super.TypeDefs, []uint32) {
-	return l.defs, l.ids
-}
-
-func (f *Fusion) buildTypeDefs() *loaderShim {
-	defs := super.NewTypeDefs()
-	ids := make([]uint32, 0, len(f.subtypes))
-	for _, typ := range f.subtypes {
-		// This lookup has the side effect of installing each needed typedef
-		// in the defs table
-		ids = append(ids, defs.LookupType(typ))
-	}
-	return &loaderShim{defs, ids}
-}
-
-func (f *Fusion) Subtypes() []super.Type {
-	// XXX holding look during I/O
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	if f.subtypes == nil {
-		defs, ids := f.SubtypeIDs()
-		subtypes := make([]super.Type, 0, f.Values.Len())
-		mapper := super.NewTypeDefsMapper(f.Sctx, defs)
-		for _, id := range ids {
-			typ := mapper.LookupType(id)
-			if typ == nil {
-				// Panic here, not downstream, if there's a type problem.
-				panic(f)
-			}
-			subtypes = append(subtypes, typ)
-		}
-		f.subtypes = subtypes
-	}
-	return f.subtypes
 }

--- a/vector/type.go
+++ b/vector/type.go
@@ -1,26 +1,45 @@
 package vector
 
 import (
+	"sync"
+
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/scode"
 )
 
 type TypeValue struct {
-	table BytesTable
+	Sctx   *super.Context
+	mu     sync.Mutex
+	loader TypesLoader
+	types  []super.Type
+}
+
+// TypesLoader is an interface to load types as IDs and a TypeDefs table so
+// they do not pollute the query type context and are converted only when
+// needed.  For example, the CSUP reader reads the typedefs table only when
+// there is a runtime call to do so, and the CSUP writer loads types as
+// TypeDefs for merging and writing to metadata without ever needing to
+// create any super.Types.
+type TypesLoader interface {
+	Load() (*super.TypeDefs, []uint32)
 }
 
 var _ Any = (*TypeValue)(nil)
 
-func NewTypeValue(table BytesTable) *TypeValue {
-	return &TypeValue{table}
+func NewTypeValue(sctx *super.Context, types []super.Type) *TypeValue {
+	return &TypeValue{Sctx: sctx, types: types}
 }
 
-func NewTypeValueEmpty(cap uint32) *TypeValue {
-	return NewTypeValue(NewBytesTableEmpty(cap))
+func NewTypeValueWithLoader(sctx *super.Context, loader TypesLoader) *TypeValue {
+	return &TypeValue{Sctx: sctx, loader: loader}
 }
 
-func (t *TypeValue) Append(v []byte) {
-	t.table.Append(v)
+func NewTypeValueEmpty(sctx *super.Context) *TypeValue {
+	return &TypeValue{Sctx: sctx}
+}
+
+func (t *TypeValue) Append(typ super.Type) {
+	t.types = append(t.types, typ)
 }
 
 func (*TypeValue) Kind() Kind {
@@ -32,22 +51,71 @@ func (t *TypeValue) Type() super.Type {
 }
 
 func (t *TypeValue) Len() uint32 {
-	return t.table.Len()
+	return uint32(len(t.Types()))
 }
 
-func (t *TypeValue) Value(slot uint32) []byte {
-	return t.table.Bytes(slot)
+func (t *TypeValue) Value(slot uint32) super.Type {
+	return t.Types()[slot]
 }
 
-func (t *TypeValue) Table() BytesTable {
-	return t.table
+func (t *TypeValue) TypeIDs() (*super.TypeDefs, []uint32) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.typeIDs()
+}
+
+func (t *TypeValue) typeIDs() (*super.TypeDefs, []uint32) {
+	if t.loader == nil {
+		t.loader = t.buildTypeDefs()
+	}
+	return t.loader.Load()
+}
+
+type loaderShim struct {
+	defs *super.TypeDefs
+	ids  []uint32
+}
+
+var _ TypesLoader = (*loaderShim)(nil)
+
+func (l *loaderShim) Load() (*super.TypeDefs, []uint32) {
+	return l.defs, l.ids
+}
+
+func (t *TypeValue) buildTypeDefs() *loaderShim {
+	defs := super.NewTypeDefs()
+	ids := make([]uint32, 0, len(t.types))
+	for _, typ := range t.types {
+		// This lookup has the side effect of installing each needed typedef
+		// in the defs table
+		ids = append(ids, defs.LookupType(typ))
+	}
+	return &loaderShim{defs, ids}
+}
+
+func (t *TypeValue) Types() []super.Type {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.types == nil {
+		defs, ids := t.typeIDs()
+		t.types = make([]super.Type, len(ids))
+		mapper := super.NewTypeDefsMapper(t.Sctx, defs)
+		for i, id := range ids {
+			t.types[i] = mapper.LookupType(id)
+			if t.types[i] == nil {
+				// Panic here, not downstream, if there's a type problem.
+				panic(t.types[i])
+			}
+		}
+	}
+	return t.types
 }
 
 func (t *TypeValue) Serialize(b *scode.Builder, slot uint32) {
-	b.Append(t.Value(slot))
+	b.Append(super.EncodeTypeValue(t.Value(slot)))
 }
 
-func TypeValueValue(val Any, slot uint32) []byte {
+func TypeValueValue(val Any, slot uint32) super.Type {
 	switch val := val.(type) {
 	case *TypeValue:
 		return val.Value(slot)

--- a/vector/valuebuilder.go
+++ b/vector/valuebuilder.go
@@ -72,13 +72,13 @@ func NewValueBuilder(typ super.Type) ValueBuilder {
 	case *super.TypeOfBytes,
 		*super.TypeOfString,
 		*super.TypeOfAll:
-		return newBytesStringTypeValueBuilder(typ)
+		return newBytesStringValueBuilder(typ)
 	case *super.TypeOfIP:
 		return &ipValueBuilder{}
 	case *super.TypeOfNet:
 		return &netValueBuilder{}
 	case *super.TypeOfType:
-		return newBytesStringTypeValueBuilder(typ)
+		return newTypeValueValueBuilder()
 	case *super.TypeOfNone:
 		return &noneValueBuilder{}
 	case *super.TypeOfNull:
@@ -367,30 +367,48 @@ func (b *boolValueBuilder) Build(sctx *super.Context) Any {
 	return NewBool(bitvec.New(bits, b.n))
 }
 
-type bytesStringTypeValueBuilder struct {
+type typeValueValueBuilder struct {
+	table BytesTable
+}
+
+func newTypeValueValueBuilder() *typeValueValueBuilder {
+	return &typeValueValueBuilder{table: NewBytesTableEmpty(0)}
+}
+
+func (t *typeValueValueBuilder) Write(bytes scode.Bytes) {
+	t.table.Append(bytes)
+}
+
+func (t *typeValueValueBuilder) Build(sctx *super.Context) Any {
+	types := make([]super.Type, t.table.Len())
+	for i := range t.table.Len() {
+		types[i], _ = sctx.DecodeTypeValue(t.table.Bytes(i))
+	}
+	return NewTypeValue(sctx, types)
+}
+
+type bytesStringValueBuilder struct {
 	typ   super.Type
 	offs  []uint32
 	bytes []byte
 }
 
-func newBytesStringTypeValueBuilder(typ super.Type) ValueBuilder {
-	return &bytesStringTypeValueBuilder{typ: typ, bytes: []byte{}, offs: []uint32{0}}
+func newBytesStringValueBuilder(typ super.Type) ValueBuilder {
+	return &bytesStringValueBuilder{typ: typ, bytes: []byte{}, offs: []uint32{0}}
 }
 
-func (b *bytesStringTypeValueBuilder) Write(bytes scode.Bytes) {
+func (b *bytesStringValueBuilder) Write(bytes scode.Bytes) {
 	b.bytes = append(b.bytes, bytes...)
 	b.offs = append(b.offs, uint32(len(b.bytes)))
 }
 
-func (b *bytesStringTypeValueBuilder) Build(sctx *super.Context) Any {
+func (b *bytesStringValueBuilder) Build(sctx *super.Context) Any {
 	table := NewBytesTable(b.offs, b.bytes)
 	switch b.typ.ID() {
 	case super.IDString:
 		return NewString(table)
 	case super.IDBytes, super.IDAll:
 		return NewBytes(table)
-	case super.IDType:
-		return NewTypeValue(table)
 	default:
 		panic(b.typ)
 	}

--- a/vector/valuebuilder.go
+++ b/vector/valuebuilder.go
@@ -382,7 +382,11 @@ func (t *typeValueValueBuilder) Write(bytes scode.Bytes) {
 func (t *typeValueValueBuilder) Build(sctx *super.Context) Any {
 	types := make([]super.Type, t.table.Len())
 	for i := range t.table.Len() {
-		types[i], _ = sctx.DecodeTypeValue(t.table.Bytes(i))
+		var tv scode.Bytes
+		types[i], tv = sctx.DecodeTypeValue(t.table.Bytes(i))
+		if tv == nil {
+			panic("bad type value")
+		}
 	}
 	return NewTypeValue(sctx, types)
 }


### PR DESCRIPTION
This commit changes the TypeValue vector to use native super.Types stored in CSUP (and lazily loaded) as super.TypeDefs and a list of local type ids.

It also changes the fusion vector to use the new TypeValue vector for retrieving subtypes.