### PR TITLE
fix: replace panic() with proper error handling in NewTypeDefsFromBytes

### DIFF
--- a/compiler/rungen/op.go
+++ b/compiler/rungen/op.go
@@ -91,7 +91,10 @@ func (b *Builder) Build(main *dag.Main, readers ...sio.Reader) (map[string]vio.P
 	}
 	b.readers = readers
 	if len(main.Types) != 0 {
-		defs := super.NewTypeDefsFromBytes(main.Types)
+		defs, err := super.NewTypeDefsFromBytes(main.Types)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid type defs: %w", err)
+		}
 		b.mapper = super.NewTypeDefsMapper(b.rctx.Sctx, defs)
 	}
 	if b.env.UseVAM() {
@@ -673,7 +676,10 @@ func EvalAtCompileTime(sctx *super.Context, main *dag.MainExpr) (val super.Value
 		b.funcs[f.Tag] = f
 	}
 	if len(main.Types) != 0 {
-		defs := super.NewTypeDefsFromBytes(main.Types)
+		defs, err := super.NewTypeDefsFromBytes(main.Types)
+		if err != nil {
+			return super.NewValue(sctx, super.StringError("invalid type defs")), err
+		}
 		b.mapper = super.NewTypeDefsMapper(b.rctx.Sctx, defs)
 	}
 	return b.evalAtCompileTime(main.Expr)

--- a/context.go
+++ b/context.go
@@ -512,12 +512,31 @@ func MustDecodeName(tv scode.Bytes) (string, scode.Bytes) {
 	return string(tv[:namelen]), tv[namelen:]
 }
 
-func DecodeLength(tv scode.Bytes) (int, scode.Bytes) {
+func DecodeNameSafe(tv scode.Bytes) (string, []byte, error) {
+	namelen, n := binary.Uvarint(tv)
+	if n <= 0 {
+		return "", nil, errors.New("truncated name")
+	}
+	if namelen > len(tv[n:]) {
+		return "", nil, errors.New("truncated name")
+	}
+	return string(tv[n:n+namelen]), tv[n+namelen:], nil
+}
+
+func DecodeLength(tv scode.Bytes) (int, []byte) {
 	namelen, n := binary.Uvarint(tv)
 	if n <= 0 {
 		return 0, nil
 	}
 	return int(namelen), tv[n:]
+}
+
+func DecodeLengthSafe(tv scode.Bytes) (int, []byte, error) {
+	namelen, n := binary.Uvarint(tv)
+	if n <= 0 {
+		return 0, nil, errors.New("truncated length")
+	}
+	return int(namelen), tv[n:], nil
 }
 
 func MustDecodeLength(tv scode.Bytes) (int, scode.Bytes) {
@@ -534,6 +553,14 @@ func DecodeID(b []byte) (uint32, []byte) {
 		return 0, nil
 	}
 	return uint32(v), b[n:]
+}
+
+func DecodeIDSafe(b []byte) (uint32, []byte, error) {
+	v, n := binary.Uvarint(b)
+	if n <= 0 {
+		return 0, nil, errors.New("truncated ID")
+	}
+	return uint32(v), b[n:], nil
 }
 
 func MustDecodeID(b []byte) (uint32, []byte) {
@@ -1155,76 +1182,119 @@ func (t *TypeDefsMerger) LookupID(extID uint32) uint32 {
 // and computes the lookup table and offsets of each typedef in the table, returning
 // a new TypeDefs table.  It checks that all referenced IDs in the table maintain
 // the invariant that they are defined before use in the scan order of the table.
-// It panics if malformed data is encountered.
-func NewTypeDefsFromBytes(bytes []byte) *TypeDefs {
+// It returns an error if malformed data is encountered.
+func NewTypeDefsFromBytes(bytes []byte) (*TypeDefs, error) {
 	defs := NewTypeDefs()
 	defs.bytes = bytes
 	localID := uint32(IDTypeComplex)
 	var off uint32
 	for len(bytes) > 0 {
 		before := bytes
+		if len(bytes) < 1 {
+			return nil, errors.New("truncated typedef")
+		}
 		typedef := bytes[0]
 		bytes = bytes[1:]
 		var id uint32
 		var n int
+		var err error
 		switch typedef {
 		case TypeDefNamed:
-			_, bytes = MustDecodeName(bytes)
-			id, bytes = MustDecodeID(bytes)
+			_, bytes, err = DecodeNameSafe(bytes)
+			if err != nil {
+				return nil, err
+			}
+			id, bytes, err = DecodeIDSafe(bytes)
+			if err != nil {
+				return nil, err
+			}
 			if id >= localID {
-				panic(id)
+				return nil, fmt.Errorf("bad forward reference in named type: %d >= %d", id, localID)
 			}
 		case TypeDefRecord:
-			n, bytes = MustDecodeLength(bytes)
+			n, bytes, err = DecodeLengthSafe(bytes)
+			if err != nil {
+				return nil, err
+			}
 			if n > MaxRecordFields {
-				panic(n)
+				return nil, fmt.Errorf("too many record fields: %d", n)
 			}
 			for range n {
-				_, bytes = MustDecodeName(bytes)
-				id, bytes = MustDecodeID(bytes)
+				_, bytes, err = DecodeNameSafe(bytes)
+				if err != nil {
+					return nil, err
+				}
+				id, bytes, err = DecodeIDSafe(bytes)
+				if err != nil {
+					return nil, err
+				}
 				if id >= localID {
-					panic(id)
+					return nil, fmt.Errorf("bad forward reference in record field: %d >= %d", id, localID)
 				}
 				// field opt
+				if len(bytes) < 1 {
+					return nil, errors.New("truncated record: missing field opts")
+				}
 				bytes = bytes[1:]
 			}
 		case TypeDefArray, TypeDefSet, TypeDefError, TypeDefFusion:
-			id, bytes = MustDecodeID(bytes)
+			id, bytes, err = DecodeIDSafe(bytes)
+			if err != nil {
+				return nil, err
+			}
 			if id >= localID {
-				panic(id)
+				return nil, fmt.Errorf("bad forward reference in container type: %d >= %d", id, localID)
 			}
 		case TypeDefMap:
 			// key ID
-			id, bytes = MustDecodeID(bytes)
+			id, bytes, err = DecodeIDSafe(bytes)
+			if err != nil {
+				return nil, err
+			}
 			if id >= localID {
-				panic(id)
+				return nil, fmt.Errorf("bad forward reference in map key: %d >= %d", id, localID)
 			}
 			// val ID
-			id, bytes = MustDecodeID(bytes)
+			id, bytes, err = DecodeIDSafe(bytes)
+			if err != nil {
+				return nil, err
+			}
 			if id >= localID {
-				panic(id)
+				return nil, fmt.Errorf("bad forward reference in map value: %d >= %d", id, localID)
 			}
 		case TypeDefUnion:
-			n, bytes = MustDecodeLength(bytes)
+			n, bytes, err = DecodeLengthSafe(bytes)
+			if err != nil {
+				return nil, err
+			}
 			if n > MaxUnionTypes {
-				panic(n)
+				return nil, fmt.Errorf("too many union types: %d", n)
 			}
 			for range n {
-				id, bytes = MustDecodeID(bytes)
+				id, bytes, err = DecodeIDSafe(bytes)
+				if err != nil {
+					return nil, err
+				}
 				if id >= localID {
-					panic(id)
+					return nil, fmt.Errorf("bad forward reference in union type: %d >= %d", id, localID)
 				}
 			}
 		case TypeDefEnum:
-			n, bytes = MustDecodeLength(bytes)
+			n, bytes, err = DecodeLengthSafe(bytes)
+			if err != nil {
+				return nil, err
+			}
 			if n > MaxEnumSymbols {
-				panic(n)
+				return nil, fmt.Errorf("too many enum symbols: %d", n)
 			}
 			for range n {
-				_, bytes = MustDecodeName(bytes)
+				_, bytes, err = DecodeNameSafe(bytes)
+				if err != nil {
+					return nil, err
+				}
 			}
 		default:
-			panic(typedef)
+			return nil, fmt.Errorf("unknown typedef type: %d", typedef)
 		}
 		size := len(before) - len(bytes)
 		off += uint32(size)
@@ -1232,5 +1302,5 @@ func NewTypeDefsFromBytes(bytes []byte) *TypeDefs {
 		defs.offsets = append(defs.offsets, off)
 		localID++
 	}
-	return defs
+	return defs, nil
 }

--- a/context_test.go
+++ b/context_test.go
@@ -27,3 +27,20 @@ func TestContextLookupTypeNamedAndLookupTypeDef(t *testing.T) {
 	require.NoError(t, err)
 	assert.Same(t, named1, sctx.LookupByName("x"))
 }
+
+func TestNewTypeDefsFromBytesInvalid(t *testing.T) {
+	// Empty bytes should return error
+	_, err := super.NewTypeDefsFromBytes(nil)
+	require.Error(t, err)
+	
+	// Truncated typedef (just type byte, no data)
+	_, err = super.NewTypeDefsFromBytes([]byte{0})
+	require.Error(t, err)
+	
+	// Unknown typedef type
+	_, err = super.NewTypeDefsFromBytes([]byte{99})
+	require.Error(t, err)
+	
+	// Forward reference (type ID >= localID)
+	// This is harder to construct without encoding utilities
+}

--- a/csup/context.go
+++ b/csup/context.go
@@ -138,7 +138,10 @@ func (c *Context) readSubTypes(r io.Reader) error {
 			if val.Type() != super.TypeBytes {
 				return errors.New("CSUP metadata typedefs section must be a bytes type")
 			}
-			c.typedefs = super.NewTypeDefsFromBytes(val.Bytes())
+			c.typedefs, err = super.NewTypeDefsFromBytes(val.Bytes())
+			if err != nil {
+				return fmt.Errorf("invalid type defs: %w", err)
+			}
 			return err
 		}
 		for _, val := range batch.Values() {

--- a/sio/bsupio/types.go
+++ b/sio/bsupio/types.go
@@ -63,7 +63,10 @@ func NewDecoder(sctx *super.Context) *Decoder {
 }
 
 func (d *Decoder) decode(b *buffer) error {
-	defs := super.NewTypeDefsFromBytes(b.data)
+	defs, err := super.NewTypeDefsFromBytes(b.data)
+	if err != nil {
+		return fmt.Errorf("invalid type defs: %w", err)
+	}
 	mapper := super.NewTypeDefsMapper(d.sctx, defs)
 	for id := range defs.NTypes() {
 		typ := mapper.LookupType(uint32(id + super.IDTypeComplex))


### PR DESCRIPTION
Fixes panic in `super.NewTypeDefsFromBytes` when parsing malformed type definition bytes.

## Root Cause
The function called `panic()` for various error conditions instead of returning proper errors.

## Fix
- Changed to return `(*TypeDefs, error)`
- Added safe decoder helpers
- Replaced panic() calls with descriptive errors
- Updated all call sites