### PR TITLE
Use linkspector 1.4.2

### DIFF
--- a/.github/workflows/markdown-lint.yaml
+++ b/.github/workflows/markdown-lint.yaml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Lint
       run: make markdown-lint
-    - uses: umbrelladocs/action-linkspector@v1.4.0
+    - uses: umbrelladocs/action-linkspector@v1.4.2
       with:
         fail_on_error: true
         filter_mode: nofilter


### PR DESCRIPTION
https://github.com/UmbrellaDocs/action-linkspector/issues/54 has been fixed, so bumping us up to the latest version of the link checker.