### PR TITLE
Stop creating our own Homebrew Cask with releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,15 +50,6 @@ archives:
 release:
   header: |
     View [change log](CHANGELOG.md#{{ replace .Tag "." "" }}).
-homebrew_casks:
-  - repository:
-      owner: brimdata
-      name: homebrew-tap
-    commit_author:
-      name: brim-bot
-      email: bot@brimdata.io
-    homepage: https://github.com/brimdata/super
-    description: An analytics database that fuses structured and semi-structured data
 checksum:
   name_template: 'super-checksums.txt'
 snapshot:


### PR DESCRIPTION
## What's Changing

We'll no longer be creating our own Homebrew Cask as part of our workflow for tagging new releases.

## Why

As described in https://github.com/brimdata/homebrew-tap/pull/15, there's config now in place such that users that previously did `brew install --cask brimdata/tap/super` will now be automatically migrated to the central Cask a new user would get by doing `brew install super` as shown in the [docs](https://superdb.org/getting-started/install.html). With this all in place, now we can drop the Cask-creation portion of our GoReleaser config.