### PR TITLE
vam: fix coalesce() handling of null and error in union

### DIFF
--- a/runtime/vam/expr/function/coalesce.go
+++ b/runtime/vam/expr/function/coalesce.go
@@ -1,6 +1,9 @@
 package function
 
 import (
+	"math"
+	"slices"
+
 	"github.com/brimdata/super/vector"
 )
 
@@ -9,10 +12,100 @@ type Coalesce struct{}
 func (*Coalesce) RipUnions() bool { return false }
 
 func (c *Coalesce) Call(vecs ...vector.Any) vector.Any {
-	for _, vec := range vecs {
-		if k := vec.Kind(); k != vector.KindNull && k != vector.KindError {
+	for i, vec := range vecs {
+		if !containsNullOrError(vec) {
 			return vec
+		}
+		if k := vec.Kind(); k == vector.KindUnion || k == vector.KindFusion {
+			return c.slow(vecs[i:])
 		}
 	}
 	return vector.NewNull(vecs[0].Len())
+}
+
+func (c *Coalesce) slow(vecs []vector.Any) vector.Any {
+	var indexes [][]uint32
+	var numNulls uint32
+	vecsIndexToTag := map[int]uint32{}
+	tags := make([]uint32, vecs[0].Len())
+Loop:
+	for i := range tags {
+		i := uint32(i)
+		for j, vec := range vecs {
+			if !slotIsNullOrError(vec, i) {
+				tag, ok := vecsIndexToTag[j]
+				if !ok {
+					tag = uint32(len(vecsIndexToTag))
+					indexes = append(indexes, nil)
+					vecsIndexToTag[j] = tag
+				}
+				indexes[tag] = append(indexes[tag], i)
+				tags[i] = tag
+				continue Loop
+			}
+		}
+		numNulls++
+		tags[i] = math.MaxUint32
+	}
+	outvecs := make([]vector.Any, len(vecsIndexToTag))
+	for from, tag := range vecsIndexToTag {
+		outvecs[tag] = vector.Pick(vecs[from], indexes[tag])
+	}
+	if numNulls > 0 {
+		outvecs = append(outvecs, vector.NewNull(numNulls))
+		nullTag := uint32(len(outvecs) - 1)
+		for i, tag := range tags {
+			if tag == math.MaxUint32 {
+				tags[i] = nullTag
+			}
+		}
+	}
+	return vector.NewDynamic(tags, outvecs)
+}
+
+func containsNullOrError(vec vector.Any) bool {
+	switch vec := vector.Under(vec).(type) {
+	case *vector.Null:
+		return true
+	case *vector.Union:
+		return slices.ContainsFunc(vec.Values, containsNullOrError)
+	case *vector.Error:
+		return true
+	case *vector.Fusion:
+		return containsNullOrError(vec.Values)
+	case *vector.Named:
+		return containsNullOrError(vec.Any)
+	case *vector.Const:
+		return containsNullOrError(vec.Any)
+	case *vector.Dict:
+		return containsNullOrError(vec.Any)
+	case *vector.Dynamic:
+		return slices.ContainsFunc(vec.Values, containsNullOrError)
+	case *vector.View:
+		return containsNullOrError(vec.Any)
+	}
+	return false
+}
+
+func slotIsNullOrError(vec vector.Any, slot uint32) bool {
+	switch vec := vec.(type) {
+	case *vector.Null:
+		return true
+	case *vector.Union:
+		return slotIsNullOrError(vec.Dynamic, slot)
+	case *vector.Error:
+		return true
+	case *vector.Named:
+		return slotIsNullOrError(vec.Any, slot)
+	case *vector.Const:
+		return slotIsNullOrError(vec.Any, 0)
+	case *vector.Dict:
+		return slotIsNullOrError(vec.Any, uint32(vec.Index[slot]))
+	case *vector.Dynamic:
+		tag := vec.Tags[slot]
+		return slotIsNullOrError(vec.Values[tag], vec.ForwardTagMap()[slot])
+	case *vector.View:
+		return slotIsNullOrError(vec.Any, vec.Index[slot])
+	}
+	return false
 }

--- a/runtime/ztests/expr/function/coalesce.yaml
+++ b/runtime/ztests/expr/function/coalesce.yaml
@@ -1,22 +1,24 @@
-spq: coalesce(this[0], this[1], this[2])
+spq: coalesce(a, b, c)
 
 vector: true
 
 input: |
-  [null, error("quiet"), "foo"::(uint64|string)]
-  ["bar"::string, error("quiet"), 1::uint64::(uint64|string)]
+  {a:null, b:error("quiet"), c:"foo"::(uint64|string)}
+  {a:"bar"::string, b:error("quiet"), c:1::uint64::(uint64|string)}
   type port=int64
   type missing=error("string")
-  [error("missing")::missing, 2020::port, null]
-  [null, error("missing"), error("quiet")]
-  [null, "gotme", "ted sando"]
-  [null, error({x:1}), "foo"]
+  {a:error("missing")::missing, b:2020::port, c:null}
+  {a:null, b:error("missing"), c:error("quiet")}
+  {a:null, b:"gotme", c:"ted sando"}
+  {a:null, b:error({x:1}), c:"foo"}
+  {a:null::(string|null), b:error(0)::(error(int64)|null), c:"foo"::(string|null)}
 
 output: |
-  "foo"
+  "foo"::(uint64|string)
   "bar"
   type port=int64
   2020::port
   null
   "gotme"
   "foo"
+  "foo"::(string|null)


### PR DESCRIPTION
The changes to the vam coalesce() implementation in #6633 do not correctly handle unions containing a null or error value.  Fix by looking inside unions that may contain a null or error value.

Fixes #6802.