### PR TITLE
sam: fix union handling in min(), max(), and sum()

### DIFF
--- a/runtime/sam/expr/agg/math.go
+++ b/runtime/sam/expr/agg/math.go
@@ -44,6 +44,7 @@ func (m *mathReducer) Consume(val super.Value) {
 }
 
 func (m *mathReducer) consumeVal(val super.Value) {
+	val = val.Under()
 	if val.IsString() || (m.math != nil && m.math.typ() == super.TypeString) {
 		m.consumeString(val)
 		return

--- a/runtime/ztests/op/aggregate/reducers.yaml
+++ b/runtime/ztests/op/aggregate/reducers.yaml
@@ -13,3 +13,18 @@ output: |
   {key1:"a",any:1::int32,sum:3,avg:1.5,min:1,max:2}
   {key1:"b",any:1::int32,sum:1,avg:1.,min:1,max:1}
   {key1:"c",any:error("missing"),sum:null,avg:null,min:null,max:null}
+
+---
+
+# Issue #6799
+spq: min(this), max(this), sum(this)
+
+vector: true
+
+input: |
+  1::(int64|null)
+  2::(int64|null)
+  3::(int64|null)
+
+output: |
+  {min:1,max:3,sum:6}


### PR DESCRIPTION
The sam min(), max(), and sum() aggregate functions return null if their input consists entirely of unions.  Fix by adding a call to super.Value.Under.

Fixes #6799.