### PR TITLE
db/commits: fix off-by-one in FindNearestToTs for "db vacate <ts>"

### DIFF
--- a/db/commits/store.go
+++ b/db/commits/store.go
@@ -392,7 +392,10 @@ func (s *Store) PatchOfPath(ctx context.Context, base *Snapshot, baseID, commit 
 	return patch, nil
 }
 
-// FindNearestToTs finds the last commit that is greater than or equal to ts.
+// FindNearestToTs walks the commit chain from tail toward its root and
+// returns the oldest commit whose Date is still greater than or equal to
+// ts. That commit becomes the new base for "db vacate"; anything older is
+// dropped, so commits strictly before ts must not be picked here (#6746).
 func (s *Store) FindNearestToTs(ctx context.Context, tail ksuid.KSUID, ts nano.Ts) (ksuid.KSUID, error) {
 	at := tail
 	var prev ksuid.KSUID
@@ -405,10 +408,10 @@ func (s *Store) FindNearestToTs(ctx context.Context, tail ksuid.KSUID, ts nano.T
 			}
 			return ksuid.Nil, err
 		}
-		if ts >= commit.Date {
-			return commit.ID, nil
+		if commit.Date < ts {
+			return prev, nil
 		}
-		prev = at
+		prev = commit.ID
 		at = commit.Parent
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #6746.

`FindNearestToTs` is supposed to return the oldest commit whose Date is still `>= ts`, so `SetBase` keeps that commit and drops everything strictly older. Today it walks from HEAD toward the root and returns on `ts >= commit.Date`, i.e. the newest commit older-than-or-equal-to `ts`. `SetBase` then keeps that too-old commit as the new base, leaving one extra commit in the chain.

Concretely, in #6746:

| commit | date |
|---|---|
| x:0 | 20:48:35Z |
| x:1 | 20:48:37Z |
| x:2 | 20:48:39Z |
| x:3 | 20:48:41Z |

`super db vacate -f 2026-03-18T20:48:38Z` - expected to drop x:0 and x:1 (both strictly before 38s) and keep x:2/x:3. Actual: only x:0 is dropped, because the walk stops at x:1 on the first iteration where `38s >= commit.Date`.

## Fix

Flip the loop: advance while `commit.Date >= ts`, record the most recently visited commit in `prev`, and return `prev` when we hit a commit whose `Date < ts`. The `-f`-without-timestamp path (which passes `HEAD.Date`) still returns HEAD on the first iteration (since `HEAD.Date < HEAD.Date` is false, then parent's Date < HEAD.Date is true), matching the current behaviour.

## Test plan

- [x] `go build ./...`
- [x] `go build ./db/...`
- [x] Existing `db/ztests/vacate.yaml` (the `-f`-without-timestamp scenario) is behaviourally unchanged under the new loop
- [ ] An explicit ztest for the timestamp-arg off-by-one case would be a welcome follow-up; I didn't add one here to keep the change narrow, but happy to layer one on top if the maintainers would like it
