### PR TITLE
fix bug processing typedefs frames in BSUP

### DIFF
--- a/cmd/super/dev/bsup/typedefs/command.go
+++ b/cmd/super/dev/bsup/typedefs/command.go
@@ -84,6 +84,7 @@ type metaReader struct {
 	reader    *reader
 	marshaler *sup.MarshalBSUPContext
 	metas     []any
+	off       int
 }
 
 var _ sio.Reader = (*metaReader)(nil)
@@ -101,11 +102,12 @@ func (m *metaReader) Read() (*super.Value, error) {
 		if bytes == nil || err != nil {
 			return nil, err
 		}
-		metas, err := csup.DecodeTypeDefs(bytes)
+		metas, err := csup.DecodeTypeDefs(bytes, m.off)
 		if err != nil {
 			return nil, err
 		}
 		m.metas = metas
+		m.off += len(metas)
 	}
 	meta := m.metas[0]
 	m.metas = m.metas[1:]
@@ -122,6 +124,7 @@ func (m *metaReader) nextFrame() ([]byte, error) {
 		}
 		if version == 0xff {
 			// EOS
+			m.off = 0
 			continue
 		}
 		if err := bsupio.CheckVersion(version); err != nil {
@@ -181,7 +184,7 @@ func (r *reader) readUncomp(code byte) ([]byte, error) {
 		return nil, errors.New("BSUP frame too big")
 	}
 	out := make([]byte, size)
-	n, err := r.reader.Read(out)
+	n, err := io.ReadFull(r.reader, out)
 	if err != nil {
 		return nil, err
 	}
@@ -213,12 +216,12 @@ func (r *reader) readComp(code byte) ([]byte, error) {
 		return nil, fmt.Errorf("bsupio: unknown compression format 0x%x", format)
 	}
 	compressed := make([]byte, zlen)
-	n, err := r.reader.Read(compressed)
+	n, err := io.ReadFull(r.reader, compressed)
 	if err != nil {
 		return nil, err
 	}
 	if n != len(compressed) {
-		return nil, errors.New("bsupio: short read compression buffer")
+		return nil, fmt.Errorf("bsupio: short read compression buffer (%d of %d)", n, zlen)
 	}
 	uncompressed := make([]byte, size)
 	n, err = lz4.UncompressBlock(compressed, uncompressed)

--- a/cmd/super/dev/csup/command.go
+++ b/cmd/super/dev/csup/command.go
@@ -171,8 +171,8 @@ func marshalTypeDefs(marshaler *sup.MarshalBSUPContext, vals []super.Value, byte
 	return vals, nil
 }
 
-func DecodeTypeDefs(bytes []byte) ([]any, error) {
-	id := uint32(super.IDTypeComplex)
+func DecodeTypeDefs(bytes []byte, offset int) ([]any, error) {
+	id := uint32(offset + super.IDTypeComplex)
 	var out []any
 	for len(bytes) > 0 {
 		var desc any

--- a/context.go
+++ b/context.go
@@ -1095,6 +1095,96 @@ func (t *TypeDefs) loops(id uint32, scoreboard map[string]comp) {
 	}
 }
 
+func (d *TypeDefs) AppendBytes(bytes []byte) bool {
+	off := uint32(len(d.bytes))
+	d.bytes = append(d.bytes, bytes...)
+	localID := uint32(d.NTypes() + IDTypeComplex)
+	for len(bytes) > 0 {
+		before := bytes
+		typedef := bytes[0]
+		bytes = bytes[1:]
+		var id uint32
+		var n int
+		switch typedef {
+		case TypeDefNamed:
+			_, bytes = MustDecodeName(bytes)
+			if bytes == nil {
+				return false
+			}
+			id, bytes = DecodeFixedID(bytes)
+			if bytes == nil {
+				return false
+			}
+		case TypeDefRecord:
+			n, bytes = DecodeLength(bytes)
+			if bytes == nil || n > MaxRecordFields {
+				return false
+			}
+			for range n {
+				_, bytes = DecodeName(bytes)
+				if bytes == nil {
+					return false
+				}
+				id, bytes = DecodeID(bytes)
+				if bytes == nil || id >= localID {
+					return false
+				}
+				// field opt
+				bytes = bytes[1:]
+			}
+		case TypeDefArray, TypeDefSet, TypeDefError, TypeDefFusion:
+			id, bytes = DecodeID(bytes)
+			if bytes == nil || id >= localID {
+				return false
+			}
+		case TypeDefMap:
+			// key ID
+			id, bytes = DecodeID(bytes)
+			if bytes == nil || id >= localID {
+				return false
+			}
+			// val ID
+			id, bytes = DecodeID(bytes)
+			if bytes == nil || id >= localID {
+				return false
+			}
+		case TypeDefUnion:
+			n, bytes = DecodeLength(bytes)
+			if bytes == nil || n > MaxUnionTypes {
+				return false
+			}
+			for range n {
+				id, bytes = DecodeID(bytes)
+				if bytes == nil || id >= localID {
+					return false
+				}
+			}
+		case TypeDefEnum:
+			n, bytes = DecodeLength(bytes)
+			if bytes == nil || n > MaxEnumSymbols {
+				return false
+			}
+			for range n {
+				_, bytes = DecodeName(bytes)
+				if bytes == nil {
+					return false
+				}
+			}
+		default:
+			return false
+		}
+		size := len(before) - len(bytes)
+		off += uint32(size)
+		if before[0] == TypeDefNamed {
+			size -= 4
+		}
+		d.lut[string(before[:size])] = localID
+		d.offsets = append(d.offsets, off)
+		localID++
+	}
+	return true
+}
+
 func AppendFixedID(b []byte, id uint32) []byte {
 	b = append(b, byte(id>>24))
 	b = append(b, byte(id>>16))
@@ -1482,91 +1572,5 @@ func (t *TypeDefsMerger) LookupID(extID uint32) uint32 {
 // It panics if malformed data is encountered.
 func NewTypeDefsFromBytes(bytes []byte) (*TypeDefs, bool) {
 	defs := NewTypeDefs()
-	defs.bytes = bytes
-	localID := uint32(IDTypeComplex)
-	var off uint32
-	for len(bytes) > 0 {
-		before := bytes
-		typedef := bytes[0]
-		bytes = bytes[1:]
-		var id uint32
-		var n int
-		switch typedef {
-		case TypeDefNamed:
-			_, bytes = MustDecodeName(bytes)
-			if bytes == nil {
-				return nil, false
-			}
-			id, bytes = DecodeFixedID(bytes)
-			if bytes == nil {
-				return nil, false
-			}
-		case TypeDefRecord:
-			n, bytes = DecodeLength(bytes)
-			if bytes == nil || n > MaxRecordFields {
-				return nil, false
-			}
-			for range n {
-				_, bytes = DecodeName(bytes)
-				if bytes == nil {
-					return nil, false
-				}
-				id, bytes = DecodeID(bytes)
-				if bytes == nil || id >= localID {
-					return nil, false
-				}
-				// field opt
-				bytes = bytes[1:]
-			}
-		case TypeDefArray, TypeDefSet, TypeDefError, TypeDefFusion:
-			id, bytes = DecodeID(bytes)
-			if bytes == nil || id >= localID {
-				return nil, false
-			}
-		case TypeDefMap:
-			// key ID
-			id, bytes = DecodeID(bytes)
-			if bytes == nil || id >= localID {
-				return nil, false
-			}
-			// val ID
-			id, bytes = DecodeID(bytes)
-			if bytes == nil || id >= localID {
-				return nil, false
-			}
-		case TypeDefUnion:
-			n, bytes = DecodeLength(bytes)
-			if bytes == nil || n > MaxUnionTypes {
-				return nil, false
-			}
-			for range n {
-				id, bytes = DecodeID(bytes)
-				if bytes == nil || id >= localID {
-					return nil, false
-				}
-			}
-		case TypeDefEnum:
-			n, bytes = DecodeLength(bytes)
-			if bytes == nil || n > MaxEnumSymbols {
-				return nil, false
-			}
-			for range n {
-				_, bytes = DecodeName(bytes)
-				if bytes == nil {
-					return nil, false
-				}
-			}
-		default:
-			return nil, false
-		}
-		size := len(before) - len(bytes)
-		off += uint32(size)
-		if before[0] == TypeDefNamed {
-			size -= 4
-		}
-		defs.lut[string(before[:size])] = localID
-		defs.offsets = append(defs.offsets, off)
-		localID++
-	}
-	return defs, true
+	return defs, defs.AppendBytes(bytes)
 }

--- a/sio/bsupio/types.go
+++ b/sio/bsupio/types.go
@@ -52,8 +52,9 @@ func (e *Encoder) Encode(external super.Type) uint32 {
 }
 
 type Decoder struct {
-	// shared/output context
-	sctx *super.Context
+	sctx   *super.Context
+	defs   *super.TypeDefs
+	mapper *super.TypeDefsMapper
 	// Local type IDs are mapped to the shared-context types with the types array.
 	// The types slice is protected with mutex as the slice can be expanded while
 	// worker threads are scanning earlier batches.
@@ -64,17 +65,22 @@ type Decoder struct {
 var _ super.TypeFetcher = (*Decoder)(nil)
 
 func NewDecoder(sctx *super.Context) *Decoder {
-	return &Decoder{sctx: sctx}
+	defs := super.NewTypeDefs()
+	return &Decoder{
+		sctx:   sctx,
+		defs:   defs,
+		mapper: super.NewTypeDefsMapper(sctx, defs),
+	}
 }
 
 func (d *Decoder) decode(b *buffer) error {
-	defs, ok := super.NewTypeDefsFromBytes(b.data)
-	if !ok {
+	before := d.defs.NTypes()
+	if ok := d.defs.AppendBytes(b.Bytes()); !ok {
 		return errors.New("corrupt BSUP types frame")
 	}
-	mapper := super.NewTypeDefsMapper(d.sctx, defs)
-	for id := range defs.NTypes() {
-		typ := mapper.LookupType(uint32(id + super.IDTypeComplex))
+	after := d.defs.NTypes()
+	for id := before; id < after; id++ {
+		typ := d.mapper.LookupType(uint32(id + super.IDTypeComplex))
 		if typ == nil {
 			return errors.New("corrupt BSUP types frame")
 		}

--- a/sio/bsupio/ztests/typedefs.yaml
+++ b/sio/bsupio/ztests/typedefs.yaml
@@ -1,0 +1,12 @@
+script: |
+  super -bsup.framethresh=100 -f bsup in.sup | super -i bsup -s -
+
+inputs:
+  - name: in.sup
+    data: &input |
+      {did:"did:plc:yj3sjq3blzpynh27cumnp5ks",time_us:1732206349000167,kind:"commit",commit:{rev:"3lbhtytnn2k2f",operation:"create",collection:"app.bsky.feed.post",rkey:"3lbhtyteurk2y",record:{$type:"app.bsky.feed.post",createdAt:"2024-11-21T16:09:27.095Z",langs:["en"],reply:{parent:{cid:"bafyreibfglofvqou2yiqvwzk4rcgkhhxrbunyemshdjledgwymimqkg24e",uri:"at://did:plc:6tr6tuzlx2db3rduzr2d6r24/app.bsky.feed.post/3lbhqo2rtys2z"},root:{cid:"bafyreibfglofvqou2yiqvwzk4rcgkhhxrbunyemshdjledgwymimqkg24e",uri:"at://did:plc:6tr6tuzlx2db3rduzr2d6r24/app.bsky.feed.post/3lbhqo2rtys2z"}},text:"aaaaah.  LIght shines in a corner of WTF...."},cid:"bafyreidblutgvj75o4q4akzyyejedjj6l3it6hgqwee6jpwv2wqph5fsgm"}}
+      {did:"did:plc:3i4xf2v4wcnyktgv6satke64",time_us:1732206349000644,kind:"commit",commit:{rev:"3lbhuvzds6d2a",operation:"create",collection:"app.bsky.feed.like",rkey:"3lbhuvzdked2a",record:{$type:"app.bsky.feed.like",createdAt:"2024-11-21T16:25:46.221Z",subject:{cid:"bafyreidjvrcmckkm765mct5fph36x7kupkfo35rjklbf2k76xkzwyiauge",uri:"at://did:plc:azrv4rcbws6kmcga4fsbphg2/app.bsky.feed.post/3lbgjdpbiec2l"}},cid:"bafyreia5l5vrkh5oj4cjyhcqby2dprhyvcyofo2q5562tijlae2pzih23m"}}
+
+outputs:
+  - name: stdout
+    data: *input


### PR DESCRIPTION
This commit fixes a bug introduced in PR #6830 where we were decoding and mapping each types frames independently instead of decoding types frames as subsequent additions to the typedefs state until EOS.

This commit fixes the bug by converting NewBytesFromTypeDefs to an AppendBytes method on the TypeDefs object.  We also fixed some problems with the "dev bsup" command.

Closes #6831