### PR TITLE
fix bug in type fusion with named element type

### DIFF
--- a/runtime/sam/expr/agg/fuser.go
+++ b/runtime/sam/expr/agg/fuser.go
@@ -219,7 +219,7 @@ func (f *Fuser) fuseIntoUnionTypes(types []super.Type, typ super.Type) []super.T
 		case t == typ:
 			// This is already in the union.
 			return types
-		case typKind != super.PrimitiveKind && typKind == t.Kind():
+		case typKind != super.PrimitiveKind && typKind == t.Kind() && !super.IsNamedType(t):
 			types[i] = noFusion(f.fuse(t, typ))
 			return types
 		}

--- a/runtime/sam/expr/agg/fuser.go
+++ b/runtime/sam/expr/agg/fuser.go
@@ -219,7 +219,7 @@ func (f *Fuser) fuseIntoUnionTypes(types []super.Type, typ super.Type) []super.T
 		case t == typ:
 			// This is already in the union.
 			return types
-		case typKind != super.PrimitiveKind && typKind == t.Kind() && !super.IsNamedType(t):
+		case typKind != super.PrimitiveKind && typKind == t.Kind() && !super.IsTypeNamed(t):
 			types[i] = noFusion(f.fuse(t, typ))
 			return types
 		}

--- a/runtime/ztests/op/aggregate/fuse.yaml
+++ b/runtime/ztests/op/aggregate/fuse.yaml
@@ -74,3 +74,21 @@ output: |
   type u1=int64
   type u2=u1
   {x:1,fuse:<u2>}
+
+---
+
+spq: fuse(this)
+
+vector: true
+
+input: |
+  type n1=[int64]
+  type n2=int64
+  [1]::n1
+  [2::n2]
+  [3]
+
+output: |
+  type n1=[int64]
+  type n2=int64
+  <fusion(n1|[fusion(n2|int64)])>

--- a/type.go
+++ b/type.go
@@ -358,7 +358,7 @@ func IsRecordType(typ Type) bool {
 	return ok
 }
 
-func IsNamedType(typ Type) bool {
+func IsTypeNamed(typ Type) bool {
 	_, ok := typ.(*TypeNamed)
 	return ok
 }

--- a/type.go
+++ b/type.go
@@ -358,6 +358,11 @@ func IsRecordType(typ Type) bool {
 	return ok
 }
 
+func IsNamedType(typ Type) bool {
+	_, ok := typ.(*TypeNamed)
+	return ok
+}
+
 func TypeRecordOf(typ Type) *TypeRecord {
 	t, _ := TypeUnder(typ).(*TypeRecord)
 	return t


### PR DESCRIPTION
Type fusion on

    type n1=[int64]
    type n2=int64
    [1]::n1
    [2::n2]
    [3]

produces an incorrect type:

    <fusion(n1|[n2]|[int64])>

Fix it to produce the correct type:

    <fusion(n1|[fusion(n2|int64)])>