### PR TITLE
fix fuser for empty array and union invariant

### DIFF
--- a/runtime/sam/expr/agg/fuser.go
+++ b/runtime/sam/expr/agg/fuser.go
@@ -27,8 +27,9 @@ func (f *Fuser) Fuse(t super.Type) {
 		return
 	}
 	f.types[t] = struct{}{}
+	t = f.fuseInternal(t)
 	if f.typ == nil {
-		f.typ = f.fuseMono(t)
+		f.typ = t
 	} else {
 		f.typ = f.fuse(f.typ, t)
 	}
@@ -53,8 +54,6 @@ func (f *Fuser) fuse(a, b super.Type) super.Type {
 		return super.TypeAll
 	}
 	switch a := a.(type) {
-	case *super.TypeOfNone:
-		return b
 	case *super.TypeRecord:
 		if b, ok := b.(*super.TypeRecord); ok {
 			fields := slices.Clone(a.Fields)
@@ -157,24 +156,24 @@ func (f *Fuser) redefPanic(named *super.TypeNamed) {
 	panic(fmt.Sprintf("type %s redefined: %s to %s", named.Name, sup.String(previous), sup.String(named.Type)))
 }
 
-func (f *Fuser) fuseMono(typ super.Type) super.Type {
+func (f *Fuser) fuseInternal(typ super.Type) super.Type {
 	if typ, ok := typ.(*super.TypeFusion); ok {
-		return f.fusion(f.fuseMono(typ.Type))
+		return f.fusion(f.fuseInternal(typ.Type))
 	}
 	var out super.Type
 	switch typ := typ.(type) {
 	case *super.TypeRecord:
 		fields := slices.Clone(typ.Fields)
 		for i, field := range fields {
-			fields[i].Type = f.fuseMono(field.Type)
+			fields[i].Type = f.fuseInternal(field.Type)
 		}
 		out = f.sctx.MustLookupTypeRecord(fields)
 	case *super.TypeArray:
-		out = f.sctx.LookupTypeArray(f.fuseMono(typ.Type))
+		out = f.sctx.LookupTypeArray(f.fuseInternal(typ.Type))
 	case *super.TypeSet:
-		out = f.sctx.LookupTypeSet(f.fuseMono(typ.Type))
+		out = f.sctx.LookupTypeSet(f.fuseInternal(typ.Type))
 	case *super.TypeMap:
-		out = f.fusion(f.sctx.LookupTypeMap(f.fuseMono(typ.KeyType), f.fuseMono(typ.ValType)))
+		out = f.fusion(f.sctx.LookupTypeMap(f.fuseInternal(typ.KeyType), f.fuseInternal(typ.ValType)))
 	case *super.TypeUnion:
 		types := f.fuseIntoUnionTypes(nil, typ)
 		if len(types) == 1 {
@@ -189,7 +188,7 @@ func (f *Fuser) fuseMono(typ super.Type) super.Type {
 	case *super.TypeEnum:
 		return typ
 	case *super.TypeError:
-		out = f.sctx.LookupTypeError(f.fuseMono(typ.Type))
+		out = f.sctx.LookupTypeError(f.fuseInternal(typ.Type))
 	default:
 		out = typ
 	}

--- a/runtime/ztests/expr/fuser.yaml
+++ b/runtime/ztests/expr/fuser.yaml
@@ -17,3 +17,45 @@ input: &input |
   "foo"::named2
 
 output: *input
+
+---
+
+spq: fuse(this)
+
+input: |
+  []
+  [{id:1,s:"foo"},{id:2,s:null}]
+
+output: |
+  <fusion([fusion(none|{id:int64,s:fusion(string|null)})])>
+
+---
+
+spq: fuse(this)
+
+input: |
+  [{id:1,s:"foo"},{id:2,s:null}]
+  []
+
+output: |
+  <fusion([fusion(none|{id:int64,s:fusion(string|null)})])>
+
+---
+
+spq: fuse | defuse(this)
+
+input: &input |
+  [{id:1,s:"foo"},{id:2,s:null}]
+  []
+
+output: *input
+
+---
+
+spq: fuse | defuse(this)
+
+input: &input |
+  []
+  [{id:1,s:"foo"},{id:2,s:null}]
+
+output: *input


### PR DESCRIPTION
This commit fixes two problems with the fuser.  First, we need to preserve the none type instead of collapsing it so that empty arrays of type none are preserved upon defusion.  Second, we need to maintain the invariant that union types always hold at most one category of complex types.  This is accomplished by internally fusing each incoming type before it is fusion-merged with the running fused type.