### PR TITLE
add Makefile rule for test-boomerangs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,9 @@ test-run: build bin/minio
 test-heavy: build
 	@PATH="$(CURDIR)/dist:$(PATH)" go test -tags=heavy ./mdtest
 
+test-boomerangs: build bin/minio
+	@ZTEST_PATH="$(CURDIR)/dist:$(CURDIR)/bin" go test -parallel 1 . -run TestSPQ/boomerang -v
+
 build: $(PEG_DEP)
 	@mkdir -p dist
 	@go build -ldflags='$(LDFLAGS)' -o dist ./cmd/...


### PR DESCRIPTION
This commit adds a make rule so that boomerangs can be debugged separately without go test concurrency and with verbosity so problems can be diagnosed more easily when boomerangs are failing.  This is especially useful when boomerangs are panicing and test-system doesn't give any clue as to where the problem lies.