### PR TITLE
Revert "fix fuser bug producing non-fusion record with fusion field (#6857)"

### DIFF
--- a/book/src/super-sql/aggregates/fuse.md
+++ b/book/src/super-sql/aggregates/fuse.md
@@ -25,5 +25,5 @@ fuse(this)
 {a:1,b:2}
 {a:2,b:"foo"}
 # expected output
-<fusion({a:int64,b:fusion(int64|string)})>
+<{a:int64,b:fusion(int64|string)}>
 ```

--- a/book/src/super-sql/operators/fuse.md
+++ b/book/src/super-sql/operators/fuse.md
@@ -50,8 +50,8 @@ fuse
 {a:1}
 {a:"foo"}
 # expected output
-fusion({a:fusion(1::(int64|string),<int64>)},<{a:int64}>)
-fusion({a:fusion("foo"::(int64|string),<string>)},<{a:string}>)
+{a:fusion(1::(int64|string),<int64>)}
+{a:fusion("foo"::(int64|string),<string>)}
 ```
 
 ---

--- a/runtime/sam/expr/agg/fuser.go
+++ b/runtime/sam/expr/agg/fuser.go
@@ -77,7 +77,7 @@ func (f *Fuser) fuse(a, b super.Type) super.Type {
 				}
 			}
 			fusedRec := f.sctx.MustLookupTypeRecord(fields)
-			if a != fusedRec || b != fusedRec {
+			if recChanged(a, fusedRec) || recChanged(b, fusedRec) {
 				return f.fusion(fusedRec)
 			}
 			return fusedRec
@@ -262,4 +262,22 @@ func indexOfField(fields []super.Field, name string) (int, bool) {
 		}
 	}
 	return -1, false
+}
+
+// recChanged returns true iff the two record types are different
+// enough after fusing that they need to be wrapped in a fusion type.
+// As long as all the fields names and optionality are the same, then
+// any type differences in the fused type of the child fields will be
+// captured by a fusion wrapper somewhere in the descendent type.
+func recChanged(a, b *super.TypeRecord) bool {
+	if len(a.Fields) != len(b.Fields) {
+		return true
+	}
+	for k, af := range a.Fields {
+		bf := b.Fields[k]
+		if af.Name != bf.Name || af.Opt != bf.Opt {
+			return true
+		}
+	}
+	return false
 }

--- a/runtime/ztests/op/aggregate/fuse.yaml
+++ b/runtime/ztests/op/aggregate/fuse.yaml
@@ -27,7 +27,7 @@ input: |
   {fixed:{x:5},var:{s:"foo",t:{x:1}}}
 
 output: |
-  <fusion({fixed:{x:int64},var:fusion({s:string,a?:[int64],t?:fusion(int64|{x:int64})})})>
+  <{fixed:{x:int64},var:fusion({s:string,a?:[int64],t?:fusion(int64|{x:int64})})}>
 
 ---
 
@@ -41,7 +41,7 @@ input: |
   {a:[null]}
 
 output: |
-  <fusion({a:fusion([fusion(int64|string|null)])})>
+  <{a:fusion([fusion(int64|string|null)])}>
 
 ---
 

--- a/runtime/ztests/op/fuse.yaml
+++ b/runtime/ztests/op/fuse.yaml
@@ -115,9 +115,9 @@ input: |
   {a:[null]}
 
 output: |
-  fusion({a:fusion([fusion(1::(int64|string|null),<int64>),fusion(2::(int64|string|null),<int64>)],<[int64]>)},<{a:[int64]}>)
-  fusion({a:fusion([fusion("foo"::(int64|string|null),<string>)],<[string]>)},<{a:[string]}>)
-  fusion({a:fusion([fusion(null::(int64|string|null),<null>)],<[null]>)},<{a:[null]}>)
+  {a:fusion([fusion(1::(int64|string|null),<int64>),fusion(2::(int64|string|null),<int64>)],<[int64]>)}
+  {a:fusion([fusion("foo"::(int64|string|null),<string>)],<[string]>)}
+  {a:fusion([fusion(null::(int64|string|null),<null>)],<[null]>)}
 
 ---
 


### PR DESCRIPTION
This reverts commit 6955f9ce572fa94383885d00ba5c379b0213b7eb.

Non-fusion types are allowed to contain fusion types.  The change reverted here was based on the incorrect notion that this is not allowed.