### PR TITLE
Use latest v1 action-linkspector

### DIFF
--- a/.github/workflows/markdown-lint.yaml
+++ b/.github/workflows/markdown-lint.yaml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Lint
       run: make markdown-lint
-    - uses: umbrelladocs/action-linkspector@v1.4.2
+    - uses: umbrelladocs/action-linkspector@v1
       with:
         fail_on_error: true
         filter_mode: nofilter


### PR DESCRIPTION
The link checker Action we use has had some reliability issues lately that we've had to work around (#6743, #6834). Alas, as of today the `v1.4.2` we'd been pointing at now has a [problem](https://github.com/brimdata/super/actions/runs/24986040984) but their latest release is healthy, so I propose going back to using latest `v1` until they break it again. 😛