### PR TITLE
Adjust curl download of minio

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ tidy:
 	git diff --exit-code -- go.mod go.sum
 
 bin/minio: Makefile
-	@curl -o $@ --compressed --create-dirs \
+	@curl -fLo $@ --compressed --create-dirs \
 		https://dl.min.io/server/minio/release/$$(go env GOOS)-$$(go env GOARCH)/archive/minio.RELEASE.2022-05-04T07-45-27Z
 	@chmod +x $@
 


### PR DESCRIPTION
The minio tests invoked by `make test-system` have been [failing](https://github.com/brimdata/super/actions/runs/25021052713/job/73281342516) because the binaries are now hosted at a different location but our `curl` wasn't set to follow HTTP 302 redirects via `-L`.

Repro:

```
$ curl -o /tmp/minio-no-L --compressed "https://dl.min.io/server/minio/release/$(go env GOOS)-$(go env GOARCH)/archive/minio.RELEASE.2022-05-04T07-45-27Z" 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   148  100   148    0     0   2081      0 --:--:-- --:--:-- --:--:--  2084

$ cat /tmp/minio-no-L 
<a href="https://github.com/minio/minio/releases/download/RELEASE.2022-05-04T07-45-27Z/minio.darwin-amd64.RELEASE.2022-05-04T07-45-27Z">Found</a>.
```

While I'm making improvements, I'm also proposing adding `-f` as it's appropriate for the use case. It would not have helped in this particular HTTP 302, but would help if things like HTTP 404 or 500 should come up in the future.