### PR TITLE
fjson: Parse error on EOF

### DIFF
--- a/sio/fjsonio/valreader.go
+++ b/sio/fjsonio/valreader.go
@@ -1,6 +1,7 @@
 package fjsonio
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"slices"
@@ -22,47 +23,51 @@ func newValReader(r io.Reader) *valReader {
 }
 
 func (r *valReader) Next() ([]byte, error) {
-	start, end := jsonskip.Skip(r.cursor)
-	if start < 0 {
-		// XXX There's an issue here if we encounter a value that is larger than
-		// the default buffer size. We should probably include functionality to
-		// increase the buffer size to an arbitrary amount and return a detailed
-		// error if a value is larger than MaxBufSize.
-	again:
-		if err := r.fill(); err != nil {
-			return nil, err
+	var hasFilled bool
+	for {
+		if r.EOF && len(r.cursor) == 0 {
+			return nil, io.EOF
 		}
-		start, end = jsonskip.Skip(r.cursor)
+		start, end := jsonskip.Skip(r.cursor)
 		if start < 0 {
-			// if cursor is full size increase to make buffer size and try
-			// again.
-			if len(r.cursor) == len(r.buf) {
-				if len(r.buf) >= maxSize {
-					return nil, errors.New("encountered value larger than max buffer size")
+			if !hasFilled && !r.EOF {
+				if err := r.fill(); err != nil {
+					return nil, err
 				}
-				r.buf = slices.Grow(r.buf, maxSize)[:maxSize]
-				goto again
+				hasFilled = true
+				continue
 			}
-			return nil, errors.New("invalid input")
+			if hasFilled && !r.EOF {
+				// Check if our buffer is at max size or not. It's unfortunate
+				// to do this on every mid-stream parser error but we need to be
+				// sure we're not failing because we've encountered a JSON value
+				// that is too large to fit in buffer.
+				if len(r.cursor) == len(r.buf) && len(r.buf) < maxSize {
+					r.buf = slices.Grow(r.buf, maxSize)[:maxSize]
+					continue
+				}
+			}
+			if r.EOF && len(r.cursor) > 0 {
+				// If we're at EOF but still have data in cursor make sure its
+				// not just whitespace at the end of the file.
+				if len(bytes.TrimSpace(r.cursor)) == 0 {
+					return nil, io.EOF
+				}
+			}
+			return nil, errors.New("parse error")
 		}
+		b := r.cursor[start:end]
+		r.cursor = r.cursor[end:]
+		return b, nil
 	}
-	b := r.cursor[start:end]
-	r.cursor = r.cursor[end:]
-	return b, nil
 }
 
 func (r *valReader) fill() error {
-	if r.EOF {
-		return io.EOF
-	}
 	// copy rest of cursor to buf
 	cc := copy(r.buf, r.cursor)
 	n, err := r.r.Read(r.buf[cc:])
 	if errors.Is(err, io.EOF) {
 		r.EOF = true
-		if n == 0 {
-			return err
-		}
 		err = nil
 	}
 	if err != nil {

--- a/sio/fjsonio/ztests/parser-error.yaml
+++ b/sio/fjsonio/ztests/parser-error.yaml
@@ -1,0 +1,25 @@
+# Test parse error on EOF.
+spq: pass
+
+input-flags: '-i fjson'
+
+input: |
+  {"x":1}
+  {"x":}
+  {"x":1}
+
+error: |
+  parse error
+
+---
+
+# Test that we don't get a parser error on file with whitespace at the end.
+spq: pass
+
+input-flags: '-i fjson'
+output-flags: '-f json'
+
+input: "{\"x\":1}\n       \n\n\n\t"
+       
+output: |
+  {"x":1}


### PR DESCRIPTION
This commit fixes a bug in the fjson reader where parse errors at the end of a file were not getting reported.