### PR TITLE
fix fuser for non-nested maps of a single type

### DIFF
--- a/runtime/sam/expr/agg/fuser.go
+++ b/runtime/sam/expr/agg/fuser.go
@@ -173,7 +173,7 @@ func (f *Fuser) fuseInternal(typ super.Type) super.Type {
 	case *super.TypeSet:
 		out = f.sctx.LookupTypeSet(f.fuseInternal(typ.Type))
 	case *super.TypeMap:
-		out = f.fusion(f.sctx.LookupTypeMap(f.fuseInternal(typ.KeyType), f.fuseInternal(typ.ValType)))
+		out = f.sctx.LookupTypeMap(f.fuseInternal(typ.KeyType), f.fuseInternal(typ.ValType))
 	case *super.TypeUnion:
 		types := f.fuseIntoUnionTypes(nil, typ)
 		if len(types) == 1 {

--- a/runtime/ztests/op/aggregate/fuse.yaml
+++ b/runtime/ztests/op/aggregate/fuse.yaml
@@ -45,6 +45,22 @@ output: |
 
 ---
 
+spq: unnest this into ( fuse(this) )
+
+vector: true
+
+input: |
+  [map{1:2}]
+  [map{1:2},map{3:4}]
+  [map{1:2},map{"3":"4"}]
+
+output: |
+  <map{int64:int64}>
+  <map{int64:int64}>
+  <fusion(map{fusion(int64|string):fusion(int64|string)})>
+
+---
+
 spq: fuse(this)
 
 vector: true


### PR DESCRIPTION
Type fusion on

    map{1:2}
    map{3:4}

produces an unnecessary fusion type:

    <fusion(map{int64:int64})>

Fix it to produce a non-fusion type:

    <map{int64:int64}>