### PR TITLE
fix(regexp_replace): validate IsString on unwrapped union values

### DIFF
--- a/runtime/sam/expr/function/regexp.go
+++ b/runtime/sam/expr/function/regexp.go
@@ -63,8 +63,8 @@ func (r *RegexpReplace) Call(args []super.Value) super.Value {
 	if sVal.IsNull() || reVal.IsNull() || newVal.IsNull() {
 		return super.Null
 	}
-	for i := range args {
-		if !args[i].IsString() {
+	for i, v := range []super.Value{sVal, reVal, newVal} {
+		if !v.IsString() {
 			return r.sctx.WrapError("regexp_replace: string arg required", args[i])
 		}
 	}


### PR DESCRIPTION
Closes #6892.

`regexp_replace()` already unwraps each arg with `.Under()` to handle
union types, but the `IsString()` check was performed on the original
wrapper rather than the unwrapped value. For inputs typed as
`union(string|null)`, the wrapper carries the union type
(`IsString()==false`) even when the underlying value is a string, so
the call was rejected with `regexp_replace: string arg required`.

This patch validates `IsString()` on `sVal`/`reVal`/`newVal` directly,
so the function accepts string values whether they arrive as plain
strings or as the string member of a union. The vector runtime
unwraps before evaluation, which is why the same query worked under
`-vam`.

### Repro (from #6892)

Before:
```
$ echo '"hello world"::(string|null)' | super -sam -c "values regexp_replace(this, 'hello', 'goodbye')" -
error({message:"regexp_replace: string arg required",on:"hello world"::(string|null)})
```

After:
```
$ echo '"hello world"::(string|null)' | super -sam -c "values regexp_replace(this, 'hello', 'goodbye')" -
"goodbye world"
```