### PR TITLE
fix(agg/and+or): unwrap union values before bool aggregation

### DIFF
--- a/runtime/sam/expr/agg/logical.go
+++ b/runtime/sam/expr/agg/logical.go
@@ -11,7 +11,8 @@ type And struct {
 var _ Function = (*And)(nil)
 
 func (a *And) Consume(val super.Value) {
-	if super.TypeUnder(val.Type()) != super.TypeBool {
+	val = val.Under()
+	if val.IsNull() || val.Type() != super.TypeBool {
 		return
 	}
 	if a.val == nil {
@@ -49,7 +50,8 @@ type Or struct {
 var _ Function = (*Or)(nil)
 
 func (o *Or) Consume(val super.Value) {
-	if super.TypeUnder(val.Type()) != super.TypeBool {
+	val = val.Under()
+	if val.IsNull() || val.Type() != super.TypeBool {
 		return
 	}
 	if o.val == nil {


### PR DESCRIPTION
Closes #6896. Closes #6895.

`And.Consume` and `Or.Consume` checked `super.TypeUnder(val.Type())` to allow `union(bool|…)` inputs but still read `val.Bool()` on the union-wrapped value. That decoded the union tag bytes rather than the underlying bool, so the sequential runtime collapsed mixed-union rows to `null` even when the vector runtime correctly returned the boolean OR/AND.

### Repro from #6896

Before:
```
$ echo '
  false::(bool|null)
  true::(bool|int64)
' | super -sam -c "or(this)" -
null
```

After:
```
$ echo '
  false::(bool|null)
  true::(bool|int64)
' | super -sam -c "or(this)" -
true
```

The vector runtime already unwraps before evaluation (`-vam` returned `true`).

### Patch

Unwrap with `.Under()` first, then guard on `IsNull()` / `val.Type() != TypeBool` against the unwrapped value, then read `.Bool()`. Same change applies to both `And` and `Or`. `ConsumeAsPartial` already routes through `Consume`, so partial aggregation paths are covered.

Tests:
```
go vet ./runtime/sam/expr/agg/
go test ./runtime/sam/expr/agg/... -count=1
```