### PR TITLE
fix bug fusing option-type fields

### DIFF
--- a/runtime/sam/expr/agg/fuser.go
+++ b/runtime/sam/expr/agg/fuser.go
@@ -60,7 +60,7 @@ func (f *Fuser) fuse(a, b super.Type) super.Type {
 			// First change all fields to optional that are in "a" but not in "b".
 			for k, field := range fields {
 				if _, ok := indexOfField(b.Fields, field.Name); !ok {
-					fields[k].Type = f.sctx.Option(fields[k].Type)
+					fields[k].Type = f.makeOption(fields[k].Type)
 				}
 			}
 			// Now fuse all the fields in "b" that are also in "a" and add the fields
@@ -70,7 +70,7 @@ func (f *Fuser) fuse(a, b super.Type) super.Type {
 				if ok {
 					fields[i].Type = f.fuse(fields[i].Type, field.Type)
 				} else {
-					typ := f.sctx.Option(field.Type)
+					typ := f.makeOption(field.Type)
 					fields = append(fields, super.NewField(field.Name, typ))
 				}
 			}
@@ -142,6 +142,13 @@ func (f *Fuser) fuse(a, b super.Type) super.Type {
 		panic("a or b can't be anonymous unions at this point")
 	}
 	return f.fusion(union)
+}
+
+func (f *Fuser) makeOption(t super.Type) super.Type {
+	if fusion, ok := t.(*super.TypeFusion); ok {
+		return f.sctx.LookupTypeFusion(f.makeOption(fusion.Type))
+	}
+	return f.sctx.Option(t)
 }
 
 func isAll(t super.Type) bool {

--- a/runtime/ztests/expr/fuser.yaml
+++ b/runtime/ztests/expr/fuser.yaml
@@ -59,3 +59,14 @@ input: &input |
   [{id:1,s:"foo"},{id:2,s:null}]
 
 output: *input
+
+---
+
+spq: fuse | defuse(this)
+
+input: &input |
+  {x:1,y:{z:"foo"}}
+  {x:2,y:{z:"bar",w:true}}
+  {x:3}
+
+output: *input


### PR DESCRIPTION
With the new design for option types, the fuser needs to fuse optional fields such that the option type of the field is pushed into the field's fusion type so we have fusion(...|none) instead of none|fusion(...).  This problem was causing upcast to fail on such patterns.  We've added test coverage to catch this.