### PR TITLE
vam.defuse: Fix panic on array of union records

### DIFF
--- a/runtime/vam/expr/function/downcast.go
+++ b/runtime/vam/expr/function/downcast.go
@@ -332,7 +332,7 @@ func (d *downcast) separateValidAndErrVecs(dynamic *vector.Dynamic) ([]uint32, v
 				errTagMap[i] = uint32(len(errVecs))
 				errVecs = append(errVecs, vec)
 			}
-		} else {
+		} else if vec != nil {
 			validTagMap[i] = uint32(len(validVecs))
 			validVecs = append(validVecs, vec)
 		}
@@ -362,7 +362,7 @@ func (d *downcast) separateValidAndErrVecs(dynamic *vector.Dynamic) ([]uint32, v
 	case 1:
 		valid = validVecs[0]
 	default:
-		panic("system error: shouldn't have more than one valid vector in list")
+		valid = vector.Merge(d.sctx, validTags, validVecs)
 	}
 	return newTags, valid, errs
 }

--- a/runtime/ztests/expr/function/defuse.yaml
+++ b/runtime/ztests/expr/function/defuse.yaml
@@ -142,3 +142,14 @@ input: &input |
   {a:2}::(null|{a:int64})
 
 output: *input
+
+---
+
+spq: fuse | defuse(this)
+
+vector: true
+
+input: &input |
+  {a:[{x:1},{x:null}]}
+
+output: *input

--- a/vector/merge.go
+++ b/vector/merge.go
@@ -9,6 +9,11 @@ import (
 func MergeSameTypesInDynamic(sctx *super.Context, d *Dynamic) Any {
 	m := make(map[super.Type][]uint32)
 	for i, vec := range d.Values {
+		if vec == nil {
+			// Filter out nil values in dynamic.
+			m[nil] = nil
+			continue
+		}
 		typ := vec.Type()
 		m[typ] = append(m[typ], uint32(i))
 	}
@@ -20,7 +25,10 @@ func MergeSameTypesInDynamic(sctx *super.Context, d *Dynamic) Any {
 	}
 	remapTags := make([]uint32, len(d.Values))
 	var newVecs []Any
-	for _, valIdx := range m {
+	for typ, valIdx := range m {
+		if typ == nil {
+			continue
+		}
 		if len(valIdx) > 1 {
 			vecs := make([]Any, len(valIdx))
 			tagMap := slices.Repeat([]int{-1}, len(d.Values))


### PR DESCRIPTION
This commit fixes a panic that occurs when defusing an array whose inner type is a union of records.