### PR TITLE
sam: Deunion inputs for missing() and has()

### DIFF
--- a/runtime/sam/expr/function/has.go
+++ b/runtime/sam/expr/function/has.go
@@ -1,10 +1,13 @@
 package function
 
-import "github.com/brimdata/super"
+import (
+	"github.com/brimdata/super"
+)
 
 type Has struct{}
 
 func (h *Has) Call(args []super.Value) super.Value {
+	args = underAll(args)
 	for _, val := range args {
 		if val.IsNull() {
 			return super.Null

--- a/runtime/ztests/expr/function/has.yaml
+++ b/runtime/ztests/expr/function/has.yaml
@@ -8,6 +8,7 @@ input: |
   {a:1,b:2}
   {a:1,b:null}
   {a:null,b:2}
+  {a:null::(null|int64),b:null::(null|int64)}
   {a:error("other"),b:2}
   {a:1,b?:_::int64}
 
@@ -15,6 +16,7 @@ output: |
   false
   false
   true
+  null
   null
   null
   error("other")

--- a/runtime/ztests/expr/function/missing.yaml
+++ b/runtime/ztests/expr/function/missing.yaml
@@ -8,12 +8,14 @@ input: |
   {a:"foo",b:null}
   {b:null}
   {a:null}
+  {a:null::(null|int64),b:null::(null|int64)}
   {a:"foo",b:error("other")}
   {b:error("other")}
   {a:"foo",b?:_::string}
 
 output: |
   false
+  null
   null
   null
   null

--- a/value.go
+++ b/value.go
@@ -468,7 +468,7 @@ func (v Value) IsNone() bool {
 	if IsOptionType(v.Type()) {
 		return v.Deunion().Type() == TypeNone
 	}
-	return false
+	return v.Type() == TypeNone
 }
 
 // Under resolves named types and untags unions repeatedly, returning a value


### PR DESCRIPTION
Also change val.IsNone() to return true if the value is a non-union none type.

Fixes #6876