### PR TITLE
vam conditionals: Do not deunion values

### DIFF
--- a/runtime/vam/expr/aggregator.go
+++ b/runtime/vam/expr/aggregator.go
@@ -43,7 +43,7 @@ func (a *Aggregator) Eval(this vector.Any) vector.Any {
 
 func (*Aggregator) apply(args ...vector.Any) vector.Any {
 	vec, where := args[0], args[1]
-	bools, _ := BoolMask(where)
+	bools, _, _ := BoolMask(where)
 	if bools.IsEmpty() {
 		// everything is filtered.
 		return vector.NewNull(vec.Len())

--- a/runtime/vam/expr/conditional.go
+++ b/runtime/vam/expr/conditional.go
@@ -23,73 +23,75 @@ func NewConditional(sctx *super.Context, predicate, thenExpr, elseExpr Evaluator
 }
 
 func (c *conditional) Eval(this vector.Any) vector.Any {
-	return vector.Apply(true, c.eval, c.predicate.Eval(this), this)
+	n := uint64(this.Len())
+	pred := c.predicate.Eval(this)
+	trues, _, other := BoolMask(pred)
+	if trues.GetCardinality() == n {
+		return c.thenExpr.Eval(this)
+	}
+	if other.GetCardinality() == n {
+		return c.errPredicateType(pred)
+	}
+	if trues.IsEmpty() && other.IsEmpty() {
+		return c.elseExpr.Eval(this)
+	}
+	falses := roaring.Flip(roaring.Or(trues, other), 0, n)
+	var vecs []vector.Any
+	tags := make([]uint32, n)
+	if !trues.IsEmpty() {
+		index := trues.ToArray()
+		for _, idx := range index {
+			tags[idx] = uint32(len(vecs))
+		}
+		vecs = append(vecs, c.thenExpr.Eval(vector.Pick(this, index)))
+	}
+	if !falses.IsEmpty() {
+		index := falses.ToArray()
+		for _, idx := range index {
+			tags[idx] = uint32(len(vecs))
+		}
+		vecs = append(vecs, c.elseExpr.Eval(vector.Pick(this, index)))
+	}
+	if !other.IsEmpty() {
+		index := other.ToArray()
+		for _, idx := range index {
+			tags[idx] = uint32(len(vecs))
+		}
+		vecs = append(vecs, c.errPredicateType(vector.Pick(pred, index)))
+	}
+	return vector.NewDynamic(tags, vecs)
 }
 
-func (c *conditional) eval(vecs ...vector.Any) vector.Any {
-	predVec, thisVec := vecs[0], vecs[1]
-	switch predVec.Kind() {
-	case vector.KindBool:
-	case vector.KindNull:
-		return c.elseExpr.Eval(thisVec)
-	case vector.KindError:
-		return predVec
-	default:
-		return vector.NewWrappedError(c.sctx, "?-operator: bool predicate required", predVec)
-	}
-	var elseIndex []uint32
-	switch predVec := vector.Under(predVec).(type) {
-	case *vector.Const:
-		if vector.BoolValue(predVec, 0) {
-			return c.thenExpr.Eval(thisVec)
+func (c *conditional) errPredicateType(pred vector.Any) vector.Any {
+	return vector.Apply(true, func(vecs ...vector.Any) vector.Any {
+		vec := vecs[0]
+		if vec.Kind() == vector.KindError {
+			return vec
 		}
-		return c.elseExpr.Eval(thisVec)
-	case *vector.Bool:
-		if predVec.IsZero() {
-			return c.elseExpr.Eval(thisVec)
-		}
-		for i := range predVec.Len() {
-			if !predVec.IsSet(i) {
-				elseIndex = append(elseIndex, i)
-			}
-		}
-	default:
-		for i := range predVec.Len() {
-			if !vector.BoolValue(predVec, i) {
-				elseIndex = append(elseIndex, i)
-			}
-		}
-	}
-	if len(elseIndex) == 0 {
-		return c.thenExpr.Eval(thisVec)
-	}
-	elseVec := c.elseExpr.Eval(thisVec)
-	if len(elseIndex) == int(elseVec.Len()) {
-		return elseVec
-	}
-	thenVec := c.thenExpr.Eval(thisVec)
-	return combine(thenVec, elseVec, elseIndex)
+		return vector.NewWrappedError(c.sctx, "?-operator: bool predicate required", vec)
+	}, pred)
 }
 
-func BoolMask(mask vector.Any) (*roaring.Bitmap, *roaring.Bitmap) {
+func BoolMask(mask vector.Any) (*roaring.Bitmap, *roaring.Bitmap, *roaring.Bitmap) {
 	mask = vector.Apply(true, func(vecs ...vector.Any) vector.Any {
 		return vecs[0]
 	}, mask)
 	bools := roaring.New()
+	nulls := roaring.New()
 	other := roaring.New()
 	if dynamic, ok := mask.(*vector.Dynamic); ok {
 		reverse := dynamic.ReverseTagMap()
 		for i, val := range dynamic.Values {
-			boolMaskRidx(reverse[i], bools, other, val)
+			boolMaskRidx(reverse[i], bools, nulls, other, val)
 		}
 	} else {
-		boolMaskRidx(nil, bools, other, mask)
+		boolMaskRidx(nil, bools, nulls, other, mask)
 	}
-	return bools, other
+	return bools, nulls, other
 }
 
-func boolMaskRidx(ridx []uint32, bools, other *roaring.Bitmap, vec vector.Any) {
-	switch vec := vec.(type) {
+func boolMaskRidx(ridx []uint32, bools, nulls, other *roaring.Bitmap, vec vector.Any) {
+	switch vec := vector.Under(vec).(type) {
 	case *vector.Const:
 		if vec.Type().ID() != super.IDBool {
 			if ridx != nil {
@@ -117,6 +119,12 @@ func boolMaskRidx(ridx []uint32, bools, other *roaring.Bitmap, vec vector.Any) {
 			}
 		} else {
 			bools.Or(roaring.FromDense(trues.GetBits(), true))
+		}
+	case *vector.Null:
+		if ridx != nil {
+			nulls.AddMany(ridx)
+		} else {
+			nulls.AddRange(0, uint64(vec.Len()))
 		}
 	default:
 		if ridx != nil {

--- a/runtime/vam/expr/quiet.go
+++ b/runtime/vam/expr/quiet.go
@@ -81,7 +81,7 @@ func (d *Dequiet) dequiet(vec vector.Any) vector.Any {
 	if !ok {
 		return vec
 	}
-	b, _ := BoolMask(new(Not).eval(mask))
+	b, _, _ := BoolMask(new(Not).eval(mask))
 	if b.IsEmpty() {
 		return vec
 	}

--- a/runtime/vam/op/filter.go
+++ b/runtime/vam/op/filter.go
@@ -33,7 +33,7 @@ func (f *Filter) Pull(done bool) (vector.Any, error) {
 // Boolean are considered false.
 func applyMask(vec, mask vector.Any) (vector.Any, bool) {
 	// errors are ignored for filters
-	b, _ := expr.BoolMask(mask)
+	b, _, _ := expr.BoolMask(mask)
 	if b.IsEmpty() {
 		return nil, false
 	}

--- a/runtime/vam/op/nestedloopjoin.go
+++ b/runtime/vam/op/nestedloopjoin.go
@@ -108,7 +108,7 @@ func (n *nestedLoopJoin) join(yield func(vector.Any, error) bool) {
 				joinedVec := vector.Apply(false, n.makeResult, leftVec, rightVec)
 				if n.style != "cross" {
 					// Ignore condition errors.
-					hits, _ := expr.BoolMask(n.cond.Eval(joinedVec))
+					hits, _, _ := expr.BoolMask(n.cond.Eval(joinedVec))
 					if len(innerHits) > 0 {
 						innerHits[j].Or(hits)
 					} else if outerHits != nil {

--- a/runtime/vam/op/swtich.go
+++ b/runtime/vam/op/swtich.go
@@ -30,7 +30,7 @@ func (s *Switch) forward(vec vector.Any) bool {
 	doneMap := roaring.New()
 	for i, c := range s.cases {
 		maskVec := c.Eval(vec)
-		boolMap, errMap := expr.BoolMask(maskVec)
+		boolMap, _, errMap := expr.BoolMask(maskVec)
 		boolMap.AndNot(doneMap)
 		errMap.AndNot(doneMap)
 		doneMap.Or(boolMap)

--- a/runtime/ztests/expr/conditional.yaml
+++ b/runtime/ztests/expr/conditional.yaml
@@ -66,3 +66,19 @@ output: |
   [error(1)::namedErr,error(1)::namedErr]
   type namedUnion5=int64|error(int64)
   [error(1),error(1)::namedUnion5]
+
+---
+
+# Test conditionals do not de-union root values.
+spq: |
+  values this == 1 ? this : this
+
+vector: true
+
+input: |
+  1::(int64|null)
+  2::(int64|null)
+
+output: |
+  1::(int64|null)
+  2::(int64|null)


### PR DESCRIPTION
This commit fixes an issue in vam conditionals where the values in the then or else expressions where getting deunioned. This changes the approach by using expr.BoolMask to determine the routing of returned values.

Fixes #6907