### PR TITLE
Add union-typed values to ztests

### DIFF
--- a/runtime/ztests/expr/arith-nulls.yaml
+++ b/runtime/ztests/expr/arith-nulls.yaml
@@ -6,8 +6,14 @@ input: |
   {a:1,b:null}
   {a:null,b:1}
   {a:null,b:null}
+  {a:null::(int64|null),b:2::(int64|null)}
 
 output: |
+  null
+  null
+  null
+  null
+  null
   null
   null
   null

--- a/runtime/ztests/expr/complex-record-math.yaml
+++ b/runtime/ztests/expr/complex-record-math.yaml
@@ -7,9 +7,11 @@ input: |
   {a:4,b:3}
   {a:"hello"}
   {a:6,b:5}
+  {a:2::(int64|null),b:1::(int64|null)}
 
 output: |
   {r:{x:3,y:1},a1:[2],a2:[3,1]}
   {r:{x:7,y:1},a1:[4],a2:[7,1]}
   {r:{x:error("missing"),y:error("missing")},a1:["hello"],a2:[error("missing"),error("missing")]}
   {r:{x:11,y:1},a1:[6],a2:[11,1]}
+  {r:{x:3,y:1},a1:[2]::[int64|null],a2:[3,1]}

--- a/runtime/ztests/expr/f-string.yaml
+++ b/runtime/ztests/expr/f-string.yaml
@@ -9,6 +9,8 @@ input: |
   {a:1,b:null,c:3}
   {a:1,b:error("missing"),c:error("quiet")}
   {a:1,b:error("quiet"),c:error("missing")}
+  {a:1::(int64|null),b:" "::(string|null),c:3.3.3.3::(ip|null)}
+  {a:null::(int64|null),b:" "::(string|null),c:3.3.3.3::(ip|null)}
 
 output: |
   "1 3.3.3.3"
@@ -16,3 +18,5 @@ output: |
   "2"
   "13"
   error("missing")
+  "1 3.3.3.3"
+  " 3.3.3.3"

--- a/runtime/ztests/expr/function/abs.yaml
+++ b/runtime/ztests/expr/function/abs.yaml
@@ -12,6 +12,8 @@ input: |
   1::uint8
   null
   "foo"
+  2::(int64|null)
+  null::(int64|null)
 
 output: |
   1
@@ -23,3 +25,5 @@ output: |
   1::uint8
   null
   error({message:"abs: not a number",on:"foo"})
+  2
+  null

--- a/runtime/ztests/expr/function/base64.yaml
+++ b/runtime/ztests/expr/function/base64.yaml
@@ -7,9 +7,13 @@ input: |
   0x68656c6c6f20776f726c64
   "foo"
   null
+  "aGVsbG8="::(string|null)
+  null::(string|null)
 
 output: |
   0x68656c6c6f20776f726c64
   "aGVsbG8gd29ybGQ="
   error({message:"base64: string argument is not base64",on:"foo"})
+  null
+  0x68656c6c6f
   null

--- a/runtime/ztests/expr/function/bucket.yaml
+++ b/runtime/ztests/expr/function/bucket.yaml
@@ -10,6 +10,9 @@ input: |
   {t:2020-05-26T15:27:47Z,bin:null}
   {t:"foo",bin:2s}
   {t:1h,bin:"bar"}
+  {t:2020-05-26T15:27:47Z::(time|null),bin:1h::(duration|null)}
+  {t:2020-05-26T15:27:47Z::(time|null),bin:null::(duration|null)}
+  {t:null::(time|null),bin:1h::(duration|null)}
 
 output: |
   2020-05-26T15:00:00Z
@@ -19,3 +22,6 @@ output: |
   null
   error({message:"bucket: first argument is not a time or duration",on:"foo"})
   error({message:"bucket: second argument is not a duration",on:"bar"})
+  2020-05-26T15:00:00Z
+  null
+  null

--- a/runtime/ztests/expr/function/compare.yaml
+++ b/runtime/ztests/expr/function/compare.yaml
@@ -9,6 +9,8 @@ input: |
   {a:0,b:0.}
   {a:0}
   {b:0}
+  {a:2::(int64|null),b:1::(int64|null)}
+  {a:null::(int64|null),b:1::(int64|null)}
 
 output: |
   1
@@ -17,6 +19,8 @@ output: |
   0
   error("missing")
   error("missing")
+  1
+  1
 
 ---
 
@@ -29,8 +33,16 @@ vector: true
 
 input: |
   {a:null,b:2}
+  {a:null::(int64|null),b:2}
+  {a:null::(int64|null),b:2::(int64|null)}
 
 output: |
+  1
+  -1
+  error({message:"compare: nullsMax arg is not bool",on:"error"})
+  1
+  -1
+  error({message:"compare: nullsMax arg is not bool",on:"error"})
   1
   -1
   error({message:"compare: nullsMax arg is not bool",on:"error"})

--- a/runtime/ztests/expr/function/concat.yaml
+++ b/runtime/ztests/expr/function/concat.yaml
@@ -9,6 +9,8 @@ input: |
   {a:"a",b:null,c:"c"}
   {a:"a",b:2,c:error("quiet")}
   {a:"a",b:error("quiet"),c:3}
+  {a:"hello"::(string|null),b:" "::(string|null),c:"world"::(string|null)}
+  {a:null::(string|null),b:"b"::(string|null),c:null::(string|null)}
 
 output: |
   "hello world"
@@ -16,6 +18,8 @@ output: |
   "b"
   "ac"
   error({message:"concat: string arg required",on:2})
+  "hello world"
+  "b"
 
 ---
 
@@ -28,11 +32,15 @@ input: |
   null
   1
   error("quiet")
+  "hello"::(string|null)
+  null::(string|null)
 
 output: |
   "single"
   ""
   error({message:"concat: string arg required",on:1})
+  "hello"
+  ""
 
 ---
 

--- a/runtime/ztests/expr/function/flatten.yaml
+++ b/runtime/ztests/expr/function/flatten.yaml
@@ -10,6 +10,7 @@ input: |
   {foo:null}
   {foo:{bar:2::int32}}
   {foo:{bar:null}}
+  {a:1::(int64|null),b:null::(string|null)}
 
 output: |
   127.0.0.1
@@ -19,3 +20,4 @@ output: |
   [{key:["foo"],value:null}]
   [{key:["foo","bar"],value:2::int32}]
   [{key:["foo","bar"],value:null}]
+  [{key:["a"],value:1::(int64|null)},{key:["b"],value:null::(string|null)}]

--- a/runtime/ztests/expr/function/grep.yaml
+++ b/runtime/ztests/expr/function/grep.yaml
@@ -16,6 +16,8 @@ input: |
   {pattern:"z",input:{a:{b:"c"}}}
   {pattern:1,input:""}
   {pattern:null,input:"a"}
+  {pattern:"a",input:"hello"::(string|null)}
+  {pattern:"a",input:null::(string|null)}
 
 output: |
   [true,true]
@@ -26,3 +28,5 @@ output: |
   [true,false]
   [error({message:"grep: pattern argument must be a string",on:1}),error({message:"grep: pattern argument must be a string",on:1})]
   [error({message:"grep: pattern argument must be a string",on:null}),error({message:"grep: pattern argument must be a string",on:null})]
+  [true,false]
+  [true,false]

--- a/runtime/ztests/expr/function/has_error.yaml
+++ b/runtime/ztests/expr/function/has_error.yaml
@@ -14,6 +14,8 @@ input: |
   map{"k2":1,"k1":error(0)}
   <error(int64)>
   <{x:error(int64)}>
+  1::(int64|null)
+  null::(int64|null)
 
 output: |
   false
@@ -25,5 +27,7 @@ output: |
   true
   true
   true
+  false
+  false
   false
   false

--- a/runtime/ztests/expr/function/nameof.yaml
+++ b/runtime/ztests/expr/function/nameof.yaml
@@ -18,6 +18,8 @@ input: |
   {x:"foo",y:1,z:2}::bar2
   <{x:string,y:int64,z:int64}>
   null
+  1::(int64|null)
+  null::(int64|null)
 
 output: |
   error("missing")
@@ -28,5 +30,7 @@ output: |
   error("missing")
   error("missing")
   "bar2"
+  error("missing")
+  error("missing")
   error("missing")
   error("missing")

--- a/runtime/ztests/expr/function/nest_dotted.yaml
+++ b/runtime/ztests/expr/function/nest_dotted.yaml
@@ -9,6 +9,8 @@ input: |
   {a:1,b:null}
   null
   "foo"
+  {"a.b":1::(int64|null)}
+  {"a.b":null::(int64|null)}
 
 output: |
   {a:1,b:{a:2,b:3,c:{a:4}},c:5}
@@ -17,3 +19,5 @@ output: |
   {a:1,b:null}
   null
   error({message:"nest_dotted: non-record value",on:"foo"})
+  {a:{b:1::(int64|null)}}
+  {a:{b:null::(int64|null)}}

--- a/runtime/ztests/expr/function/pow.yaml
+++ b/runtime/ztests/expr/function/pow.yaml
@@ -10,6 +10,12 @@ input: |
   // error cases
   {a:"foo",b:2}
   {b:2,a:"bar"}
+  {a:2::(int64|null),b:3}
+  {a:null::(int64|null),b:3}
+  {a:2,b:3::(int64|null)}
+  {a:2,b:null::(int64|null)}
+  {a:2::(int64|null),b:3::(int64|null)}
+  {a:null::(int64|null),b:null::(int64|null)}
 
 output: |
   4.
@@ -18,3 +24,9 @@ output: |
   null
   error({message:"pow: not a number",on:"foo"})
   error({message:"pow: not a number",on:"bar"})
+  8.
+  null
+  8.
+  null
+  8.
+  null

--- a/runtime/ztests/expr/function/sqrt.yaml
+++ b/runtime/ztests/expr/function/sqrt.yaml
@@ -9,6 +9,8 @@ input: |
   -1
   null
   "9"
+  4.::(float64|null)
+  null::(float64|null)
 
 output: |
   2.
@@ -17,3 +19,5 @@ output: |
   NaN
   null
   error({message:"sqrt: number argument required",on:"9"})
+  2.
+  null

--- a/runtime/ztests/expr/function/unflatten.yaml
+++ b/runtime/ztests/expr/function/unflatten.yaml
@@ -11,6 +11,7 @@ input: |
   [{key:["a","b"],value:1},{key:["a","b","c"],value:2}]
   [{key:1,value:1}]
   [{key:"a",value:1},{key:"b",value:2},{key:"a",value:2}]
+  [{key:["a"],value:1::(int64|null)},{key:["b"],value:null::(int64|null)}]
 
 output: |
   {a:{a:1,b:2,x:{z:"foo"}},b:2,c:3}
@@ -21,3 +22,4 @@ output: |
   {a:{b:{c:2}}}
   error({message:"invalid key type int64: expected either string or [string]",on:{key:1,value:1}})
   error({message:"duplicate field: \"a\"",on:[{key:"a",value:1},{key:"b",value:2},{key:"a",value:2}]})
+  {a:1::(int64|null),b:null::(int64|null)}

--- a/runtime/ztests/op/aggregate/math-coercion.yaml
+++ b/runtime/ztests/op/aggregate/math-coercion.yaml
@@ -2,7 +2,12 @@ spq: sum(this), max(this), min(this), avg(this)
 
 vector: true
 
-input: -2 2.5 2::uint32
+input: |
+  -2
+  2.5
+  2::uint32
+  1::(int64|null)
+  null::(int64|null)
 
 output: |
-  {sum:2.5,max:2.5,min:-2.,avg:0.8333333333333334}
+  {sum:3.5,max:2.5,min:-2.,avg:0.875}

--- a/runtime/ztests/op/assert.yaml
+++ b/runtime/ztests/op/assert.yaml
@@ -6,8 +6,12 @@ input: |
   {a:1}
   {a:2}
   1
+  {a:1::(int64|null)}
+  {a:2::(int64|null)}
 
 output: |
   {a:1}
   error({message:"assertion failed",expr:"a==1",on:{a:2}})
   error("missing")
+  {a:1::(int64|null)}
+  error({message:"assertion failed",expr:"a==1",on:{a:2::(int64|null)}})

--- a/runtime/ztests/op/cut.yaml
+++ b/runtime/ztests/op/cut.yaml
@@ -7,9 +7,13 @@ input: |
   {foo:2,bar:"two"}
   {bar:"three"}
   null
+  {foo:1::(int64|null),bar:"x"}
+  {foo:null::(int64|null),bar:"x"}
 
 output: |
   {foo:1}
   {foo:2}
   {foo:error("missing")}
   {foo:error("missing")}
+  {foo:1::(int64|null)}
+  {foo:null::(int64|null)}

--- a/runtime/ztests/op/drop-foo.yaml
+++ b/runtime/ztests/op/drop-foo.yaml
@@ -6,8 +6,12 @@ input: |
   {foo:"foo1",bar:"bar1"}
   {foo:"foo2",bar:"bar2"}
   {foo:"foo3",bar:"bar3"}
+  {foo:"a"::(string|null),bar:"b"}
+  {foo:null::(string|null),bar:"c"}
 
 output: |
   {bar:"bar1"}
   {bar:"bar2"}
   {bar:"bar3"}
+  {bar:"b"}
+  {bar:"c"}

--- a/runtime/ztests/op/fork.yaml
+++ b/runtime/ztests/op/fork.yaml
@@ -4,7 +4,13 @@ vector: true
 
 input: |
   1
+  1::(int64|null)
+  null::(int64|null)
 
 output: |
   1
+  1::(int64|null)
+  null::(int64|null)
   1
+  1::(int64|null)
+  null::(int64|null)

--- a/runtime/ztests/op/put-1.yaml
+++ b/runtime/ztests/op/put-1.yaml
@@ -6,7 +6,11 @@ vector: true
 input: |
   {x:1::int32}
   {x:2::int32}
+  {x:1::(int64|null)}
+  {x:null::(int64|null)}
 
 output: |
   {x:1::int32,y:2}
   {x:2::int32,y:3}
+  {x:1::(int64|null),y:2}
+  {x:null::(int64|null),y:null}

--- a/runtime/ztests/op/rename-foo-bar.yaml
+++ b/runtime/ztests/op/rename-foo-bar.yaml
@@ -9,6 +9,8 @@ input: |
   {goo:"goo3",bar:"bar3"}
   {bar:"bar4",goo:"goo4",foo:"foo4"}
   {goo:"goo5"}
+  {foo:"hello"::(string|null)}
+  {foo:null::(string|null)}
 
 output: |
   {f:"foo0"}
@@ -17,3 +19,5 @@ output: |
   {goo:"goo3",b:"bar3"}
   {b:"bar4",goo:"goo4",f:"foo4"}
   {goo:"goo5"}
+  {f:"hello"::(string|null)}
+  {f:null::(string|null)}

--- a/runtime/ztests/op/tail-just-right.yaml
+++ b/runtime/ztests/op/tail-just-right.yaml
@@ -1,4 +1,4 @@
-spq: tail 3
+spq: tail 5
 
 vector: true
 
@@ -6,5 +6,7 @@ input: &input |
   1
   2
   3
+  1::(int64|null)
+  null::(int64|null)
 
 output: *input

--- a/runtime/ztests/op/uniq.yaml
+++ b/runtime/ztests/op/uniq.yaml
@@ -6,7 +6,12 @@ input: |
   1
   1
   {x:1}
+  1::(int64|null)
+  1::(int64|null)
+  2::(int64|null)
 
 output: |
   {value:1,count:2}
   {value:{x:1},count:1}
+  {value:1::(int64|null),count:2}
+  {value:2::(int64|null),count:1}


### PR DESCRIPTION
## What's Changing

This adds union-typed values to ztests that didn't have them before.

## Why

This is a complement to the many bugs I've opened lately about functions/operators/etc. that had problems with union-typed values. For the many I tested that _weren't_ buggy, it seems worthwhile to have the union test coverage so we can avoid regressions.

## Details

At a couple spots while I was making these changes I did need to do some close reading of the docs, e.g., confirming where dropping the union type info on output or returned values is _expected_ behavior, as I was nervous I might be putting in tests that actually lock down bad behavior. I _think_ I got 'em all right, but thorough review is appreciated!