### PR TITLE
fix downcast from record with optional field to union

### DIFF
--- a/runtime/sam/expr/function/downcast.go
+++ b/runtime/sam/expr/function/downcast.go
@@ -231,7 +231,40 @@ func (d *downcast) toEnum(typ super.Type, bytes scode.Bytes, to *super.TypeEnum)
 func (d *downcast) subTypeOf(typ super.Type, bytes scode.Bytes, types []super.Type) (int, super.Type, []byte) {
 	val := d.defuser.eval(super.NewValue(typ, bytes))
 	typ, bytes = val.Type(), val.Bytes()
-	return slices.Index(types, typ), typ, bytes
+	return DowncastSubtypeIndex(types, typ), typ, bytes
+}
+
+// DowncastSubtypeIndex returns the index of typ in types.  If typ does not
+// appear in types and typ is a record, DowncastSubtypeIndex returns the index
+// in types of the first record type having all of typ's required fields.  If
+// types contains no such record type, DowncastSubtypeIndex returns -1.
+func DowncastSubtypeIndex(types []super.Type, typ super.Type) int {
+	if i := slices.Index(types, typ); i >= 0 {
+		return i
+	}
+	if fromRec, ok := typ.(*super.TypeRecord); ok {
+		// Look for a record that has all fromRec's required fields.
+		return slices.IndexFunc(types, func(t super.Type) bool {
+			toRec, ok := t.(*super.TypeRecord)
+			return ok && hasRequiredFields(fromRec, toRec)
+		})
+	}
+	return -1
+}
+
+// hasRequiredFields returns true if every required field in from appears in to
+// with the same type.
+func hasRequiredFields(from, to *super.TypeRecord) bool {
+	for _, f := range from.Fields {
+		if !super.IsOptionType(f.Type) {
+			typ, ok := to.TypeOfField(f.Name)
+			if !ok || typ != f.Type {
+				// Required field is absent or has wrong type.
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func (d *downcast) toError(typ super.Type, bytes scode.Bytes, to *super.TypeError) (super.Value, *super.Value) {

--- a/runtime/vam/expr/function/downcast.go
+++ b/runtime/vam/expr/function/downcast.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 
 	"github.com/brimdata/super"
+	samfunc "github.com/brimdata/super/runtime/sam/expr/function"
 	"github.com/brimdata/super/runtime/vam/expr"
 	"github.com/brimdata/super/sup"
 	"github.com/brimdata/super/vector"
@@ -395,6 +396,7 @@ func (d *downcast) toUnion(vec vector.Any, to *super.TypeUnion) vector.Any {
 			}
 			return d.errSubtype(vec, to)
 		}
+		vec = d.downcast(vec, to.Types[tag])
 		return vector.NewUnion(to, make([]uint32, vec.Len()), []vector.Any{vec})
 	})
 }
@@ -468,12 +470,12 @@ func (d *downcast) subTypeOf(vec vector.Any, types []super.Type, f func(int, vec
 		vals := make([]vector.Any, len(d.Values))
 		for i, val := range d.Values {
 			if val != nil {
-				vals[i] = f(slices.Index(types, val.Type()), val)
+				vals[i] = f(samfunc.DowncastSubtypeIndex(types, val.Type()), val)
 			}
 		}
 		return vector.NewDynamic(d.Tags, vals)
 	}
-	return f(slices.Index(types, vec.Type()), vec)
+	return f(samfunc.DowncastSubtypeIndex(types, vec.Type()), vec)
 }
 
 // pick is the same as vector.Pick but it strips errDowncast then reapplies it.

--- a/runtime/vam/expr/function/upcast.go
+++ b/runtime/vam/expr/function/upcast.go
@@ -131,6 +131,9 @@ func (u *Upcast) upcast(vec vector.Any, to super.Type) vector.Any {
 func (u *Upcast) toRecord(vec vector.Any, to *super.TypeRecord) vector.Any {
 	recVec, ok := vec.(*vector.Record)
 	if !ok {
+		if vec.Kind() == vector.KindUnion {
+			return u.deunionAndUpcast(vec, to)
+		}
 		return nil
 	}
 	fieldVecs := make([]vector.Any, len(to.Fields))

--- a/runtime/ztests/expr/function/defuse.yaml
+++ b/runtime/ztests/expr/function/defuse.yaml
@@ -153,3 +153,27 @@ input: &input |
   {a:[{x:1},{x:null}]}
 
 output: *input
+
+---
+
+spq: fuse | defuse(this)
+
+vector: true
+
+input: &input |
+  {x:1}::(null|{x:int64})
+  {}
+
+output: *input
+
+---
+
+spq: fuse | defuse(this)
+
+vector: true
+
+input: &input |
+  {x:1}::({x:int64}|{x:int64,y:string})
+  {}
+
+output: *input

--- a/runtime/ztests/expr/function/downcast.yaml
+++ b/runtime/ztests/expr/function/downcast.yaml
@@ -6,6 +6,8 @@ vector: true
 input: |
   [{x:1},<{}>]
   [{x?:1},<{x:int64}>]
+  [{x?:1},<null|{x:int64}>]
+  [{x?:2,y?:_::int64},<null|{x:int64}>]
   [{x:1::(int64|string)},<{x:int64}>]
   [{x:1,y:"foo"},<{y:string}>]
   [{x:1::(int64|bool|string)},<{x:int64|string}>]
@@ -16,6 +18,8 @@ input: |
 output: |
   {}
   {x:1}
+  {x:1}::(null|{x:int64})
+  {x:2}::(null|{x:int64})
   {x:1}
   {y:"foo"}
   {x:1::(int64|string)}


### PR DESCRIPTION
Fix downcast from a record with an optional field to a union containing a record with an otherwise-identical required field.