### PR TITLE
Put error-producing inputs at bottom of input blocks

### DIFF
--- a/runtime/ztests/expr/f-string.yaml
+++ b/runtime/ztests/expr/f-string.yaml
@@ -7,16 +7,16 @@ input: |
   {a:null,b:null,c:null}
   {a:null,b:2,c:null}
   {a:1,b:null,c:3}
-  {a:1,b:error("missing"),c:error("quiet")}
-  {a:1,b:error("quiet"),c:error("missing")}
   {a:1::(int64|null),b:" "::(string|null),c:3.3.3.3::(ip|null)}
   {a:null::(int64|null),b:" "::(string|null),c:3.3.3.3::(ip|null)}
+  {a:1,b:error("missing"),c:error("quiet")}
+  {a:1,b:error("quiet"),c:error("missing")}
 
 output: |
   "1 3.3.3.3"
   ""
   "2"
   "13"
-  error("missing")
   "1 3.3.3.3"
   " 3.3.3.3"
+  error("missing")

--- a/runtime/ztests/expr/function/abs.yaml
+++ b/runtime/ztests/expr/function/abs.yaml
@@ -11,9 +11,9 @@ input: |
   -1::int8
   1::uint8
   null
-  "foo"
   2::(int64|null)
   null::(int64|null)
+  "foo"
 
 output: |
   1
@@ -24,6 +24,6 @@ output: |
   1::int8
   1::uint8
   null
-  error({message:"abs: not a number",on:"foo"})
   2
   null
+  error({message:"abs: not a number",on:"foo"})

--- a/runtime/ztests/expr/function/bucket.yaml
+++ b/runtime/ztests/expr/function/bucket.yaml
@@ -8,11 +8,11 @@ input: |
   {t:3s,bin:2s}
   {t:null,bin:2s}
   {t:2020-05-26T15:27:47Z,bin:null}
-  {t:"foo",bin:2s}
-  {t:1h,bin:"bar"}
   {t:2020-05-26T15:27:47Z::(time|null),bin:1h::(duration|null)}
   {t:2020-05-26T15:27:47Z::(time|null),bin:null::(duration|null)}
   {t:null::(time|null),bin:1h::(duration|null)}
+  {t:"foo",bin:2s}
+  {t:1h,bin:"bar"}
 
 output: |
   2020-05-26T15:00:00Z
@@ -20,8 +20,8 @@ output: |
   2s
   null
   null
-  error({message:"bucket: first argument is not a time or duration",on:"foo"})
-  error({message:"bucket: second argument is not a duration",on:"bar"})
   2020-05-26T15:00:00Z
   null
   null
+  error({message:"bucket: first argument is not a time or duration",on:"foo"})
+  error({message:"bucket: second argument is not a duration",on:"bar"})

--- a/runtime/ztests/expr/function/compare.yaml
+++ b/runtime/ztests/expr/function/compare.yaml
@@ -7,20 +7,20 @@ input: |
   {a:2,b:"1"}
   {a:null,b:2}
   {a:0,b:0.}
-  {a:0}
-  {b:0}
   {a:2::(int64|null),b:1::(int64|null)}
   {a:null::(int64|null),b:1::(int64|null)}
+  {a:0}
+  {b:0}
 
 output: |
   1
   -1
   1
   0
-  error("missing")
-  error("missing")
   1
   1
+  error("missing")
+  error("missing")
 
 ---
 

--- a/runtime/ztests/expr/function/concat.yaml
+++ b/runtime/ztests/expr/function/concat.yaml
@@ -7,19 +7,19 @@ input: |
   {a:null,b:null,c:null}
   {a:null,b:"b",c:null}
   {a:"a",b:null,c:"c"}
-  {a:"a",b:2,c:error("quiet")}
-  {a:"a",b:error("quiet"),c:3}
   {a:"hello"::(string|null),b:" "::(string|null),c:"world"::(string|null)}
   {a:null::(string|null),b:"b"::(string|null),c:null::(string|null)}
+  {a:"a",b:2,c:error("quiet")}
+  {a:"a",b:error("quiet"),c:3}
 
 output: |
   "hello world"
   ""
   "b"
   "ac"
-  error({message:"concat: string arg required",on:2})
   "hello world"
   "b"
+  error({message:"concat: string arg required",on:2})
 
 ---
 
@@ -30,17 +30,17 @@ vector: true
 input: |
   "single"
   null
-  1
-  error("quiet")
   "hello"::(string|null)
   null::(string|null)
+  1
+  error("quiet")
 
 output: |
   "single"
   ""
-  error({message:"concat: string arg required",on:1})
   "hello"
   ""
+  error({message:"concat: string arg required",on:1})
 
 ---
 

--- a/runtime/ztests/expr/function/grep.yaml
+++ b/runtime/ztests/expr/function/grep.yaml
@@ -14,10 +14,10 @@ input: |
   {pattern:"z",input:{a:{b:1}}}
   {pattern:"c",input:{a:{b:"c"}}}
   {pattern:"z",input:{a:{b:"c"}}}
-  {pattern:1,input:""}
-  {pattern:null,input:"a"}
   {pattern:"a",input:"hello"::(string|null)}
   {pattern:"a",input:null::(string|null)}
+  {pattern:1,input:""}
+  {pattern:null,input:"a"}
 
 output: |
   [true,true]
@@ -26,7 +26,7 @@ output: |
   [true,false]
   [true,true]
   [true,false]
+  [true,false]
+  [true,false]
   [error({message:"grep: pattern argument must be a string",on:1}),error({message:"grep: pattern argument must be a string",on:1})]
   [error({message:"grep: pattern argument must be a string",on:null}),error({message:"grep: pattern argument must be a string",on:null})]
-  [true,false]
-  [true,false]

--- a/runtime/ztests/expr/function/nest_dotted.yaml
+++ b/runtime/ztests/expr/function/nest_dotted.yaml
@@ -8,9 +8,9 @@ input: |
   {a:1,"b.a":2}
   {a:1,b:null}
   null
-  "foo"
   {"a.b":1::(int64|null)}
   {"a.b":null::(int64|null)}
+  "foo"
 
 output: |
   {a:1,b:{a:2,b:3,c:{a:4}},c:5}
@@ -18,6 +18,6 @@ output: |
   {a:1,b:{a:2}}
   {a:1,b:null}
   null
-  error({message:"nest_dotted: non-record value",on:"foo"})
   {a:{b:1::(int64|null)}}
   {a:{b:null::(int64|null)}}
+  error({message:"nest_dotted: non-record value",on:"foo"})

--- a/runtime/ztests/expr/function/pow.yaml
+++ b/runtime/ztests/expr/function/pow.yaml
@@ -7,26 +7,26 @@ input: |
   {a:3::uint64,b:2::int16}
   {a:null,b:2}
   {a:2,b:null}
-  // error cases
-  {a:"foo",b:2}
-  {b:2,a:"bar"}
   {a:2::(int64|null),b:3}
   {a:null::(int64|null),b:3}
   {a:2,b:3::(int64|null)}
   {a:2,b:null::(int64|null)}
   {a:2::(int64|null),b:3::(int64|null)}
   {a:null::(int64|null),b:null::(int64|null)}
+  // error cases
+  {a:"foo",b:2}
+  {b:2,a:"bar"}
 
 output: |
   4.
   9.
   null
   null
+  8.
+  null
+  8.
+  null
+  8.
+  null
   error({message:"pow: not a number",on:"foo"})
   error({message:"pow: not a number",on:"bar"})
-  8.
-  null
-  8.
-  null
-  8.
-  null

--- a/runtime/ztests/expr/function/sqrt.yaml
+++ b/runtime/ztests/expr/function/sqrt.yaml
@@ -8,9 +8,9 @@ input: |
   1e10
   -1
   null
-  "9"
   4.::(float64|null)
   null::(float64|null)
+  "9"
 
 output: |
   2.
@@ -18,6 +18,6 @@ output: |
   100000.
   NaN
   null
-  error({message:"sqrt: number argument required",on:"9"})
   2.
   null
+  error({message:"sqrt: number argument required",on:"9"})

--- a/runtime/ztests/expr/function/unflatten.yaml
+++ b/runtime/ztests/expr/function/unflatten.yaml
@@ -9,9 +9,9 @@ input: |
   [{key:["a","b"],value:1},{key:["a","c"],value:2},{key:"a",value:3}]
   [{key:"a",value:1},{key:"a",value:2}]
   [{key:["a","b"],value:1},{key:["a","b","c"],value:2}]
+  [{key:["a"],value:1::(int64|null)},{key:["b"],value:null::(int64|null)}]
   [{key:1,value:1}]
   [{key:"a",value:1},{key:"b",value:2},{key:"a",value:2}]
-  [{key:["a"],value:1::(int64|null)},{key:["b"],value:null::(int64|null)}]
 
 output: |
   {a:{a:1,b:2,x:{z:"foo"}},b:2,c:3}
@@ -20,6 +20,6 @@ output: |
   {a:3}
   {a:2}
   {a:{b:{c:2}}}
+  {a:1::(int64|null),b:null::(int64|null)}
   error({message:"invalid key type int64: expected either string or [string]",on:{key:1,value:1}})
   error({message:"duplicate field: \"a\"",on:[{key:"a",value:1},{key:"b",value:2},{key:"a",value:2}]})
-  {a:1::(int64|null),b:null::(int64|null)}

--- a/runtime/ztests/op/assert.yaml
+++ b/runtime/ztests/op/assert.yaml
@@ -4,14 +4,14 @@ vector: true
 
 input: |
   {a:1}
+  {a:1::(int64|null)}
   {a:2}
   1
-  {a:1::(int64|null)}
   {a:2::(int64|null)}
 
 output: |
   {a:1}
+  {a:1::(int64|null)}
   error({message:"assertion failed",expr:"a==1",on:{a:2}})
   error("missing")
-  {a:1::(int64|null)}
   error({message:"assertion failed",expr:"a==1",on:{a:2::(int64|null)}})

--- a/runtime/ztests/op/cut.yaml
+++ b/runtime/ztests/op/cut.yaml
@@ -5,15 +5,15 @@ vector: true
 input: |
   {foo:1,bar:"one"}
   {foo:2,bar:"two"}
-  {bar:"three"}
-  null
   {foo:1::(int64|null),bar:"x"}
   {foo:null::(int64|null),bar:"x"}
+  {bar:"three"}
+  null
 
 output: |
   {foo:1}
   {foo:2}
-  {foo:error("missing")}
-  {foo:error("missing")}
   {foo:1::(int64|null)}
   {foo:null::(int64|null)}
+  {foo:error("missing")}
+  {foo:error("missing")}


### PR DESCRIPTION
This is a follow-up to #6929. When looking over those changes, @mattnibs mentioned a preference to have the inputs that produce errors be at the bottom of the input blocks, so this brings the ztests touched in #6929 into compliance with that.