### PR TITLE
vam conditionals: Do not deunion values v2

### DIFF
--- a/runtime/vam/expr/conditional.go
+++ b/runtime/vam/expr/conditional.go
@@ -23,11 +23,11 @@ func NewConditional(sctx *super.Context, predicate, thenExpr, elseExpr Evaluator
 }
 
 func (c *conditional) Eval(this vector.Any) vector.Any {
-	return vector.Apply(true, c.eval, c.predicate.Eval(this), this)
+	return vector.Apply(true, c.eval, c.predicate.Eval(this), &vector.NoRip{Any: this})
 }
 
 func (c *conditional) eval(vecs ...vector.Any) vector.Any {
-	predVec, thisVec := vecs[0], vecs[1]
+	predVec, thisVec := vecs[0], vecs[1].(*vector.NoRip).Any
 	switch predVec.Kind() {
 	case vector.KindBool:
 	case vector.KindNull:

--- a/runtime/ztests/expr/conditional.yaml
+++ b/runtime/ztests/expr/conditional.yaml
@@ -66,3 +66,19 @@ output: |
   [error(1)::namedErr,error(1)::namedErr]
   type namedUnion5=int64|error(int64)
   [error(1),error(1)::namedUnion5]
+  
+---
+
+# Test conditionals do not de-union root values.
+spq: |
+  values this == 1 ? this : this
+
+vector: true
+
+input: |
+  1::(int64|null)
+  2::(int64|null)
+
+output: |
+  1::(int64|null)
+  2::(int64|null)

--- a/vector/pick.go
+++ b/vector/pick.go
@@ -25,6 +25,8 @@ func Pick(val Any, index []uint32) Any {
 		return NewError(val.Typ, Pick(val.Vals, index))
 	case *None:
 		return NewNone(uint32(len(index)))
+	case *NoRip:
+		return &NoRip{Pick(val.Any, index)}
 	case *Null:
 		return NewNull(uint32(len(index)))
 	case *Union:
@@ -44,6 +46,8 @@ func Pick(val Any, index []uint32) Any {
 	case *Named:
 		// Wrapped View under Named so vector.Under still works.
 		return &Named{val.Typ, Pick(val.Any, index)}
+	case nil:
+		return nil
 	}
 	return &View{val, index}
 }


### PR DESCRIPTION
This commit fixes an issue in vam conditionals where the values in the then or else expressions where getting deunioned.

Fixes #6907