### PR TITLE
fix fuser for deeply-nested unions

### DIFF
--- a/runtime/sam/expr/agg/fuser.go
+++ b/runtime/sam/expr/agg/fuser.go
@@ -180,7 +180,10 @@ func (f *Fuser) fuseInternal(typ super.Type) super.Type {
 	case *super.TypeMap:
 		out = f.sctx.LookupTypeMap(f.fuseInternal(typ.KeyType), f.fuseInternal(typ.ValType))
 	case *super.TypeUnion:
-		types := f.fuseIntoUnionTypes(nil, typ)
+		var types []super.Type
+		for _, t := range typ.Types {
+			types = f.fuseIntoUnionTypes(types, f.fuseInternal(t))
+		}
 		if len(types) == 1 {
 			out = types[0]
 		} else {

--- a/runtime/ztests/expr/function/defuse.yaml
+++ b/runtime/ztests/expr/function/defuse.yaml
@@ -185,6 +185,19 @@ spq: fuse | defuse(this)
 vector: true
 
 input: &input |
+  [1,[[2],[null]]]
+  set[1,set[set[2],set[null]]]
+  map{1:2,map{3:4}:map{5:map{6:7},null:map{null:null}}}
+
+output: *input
+
+---
+
+spq: fuse | defuse(this)
+
+vector: true
+
+input: &input |
   error(0)
   error(1)::(null|error(int64))
 

--- a/vector/builder.go
+++ b/vector/builder.go
@@ -427,6 +427,15 @@ type fusionBuilder struct {
 }
 
 func (f *fusionBuilder) Write(vec Any) {
+	if view, ok := vec.(*View); ok {
+		fusion := view.Any.(*Fusion)
+		f.typ = fusion.Typ
+		f.vals.Write(Pick(fusion.Values, view.Index))
+		for _, slot := range view.Index {
+			f.subtypes = append(f.subtypes, fusion.Subtypes.Value(slot))
+		}
+		return
+	}
 	fusion := vec.(*Fusion)
 	f.typ = fusion.Typ
 	f.vals.Write(fusion.Values)

--- a/vector/builder.go
+++ b/vector/builder.go
@@ -431,8 +431,9 @@ func (f *fusionBuilder) Write(vec Any) {
 		fusion := view.Any.(*Fusion)
 		f.typ = fusion.Typ
 		f.vals.Write(Pick(fusion.Values, view.Index))
+		types := fusion.Subtypes.Types()
 		for _, slot := range view.Index {
-			f.subtypes = append(f.subtypes, fusion.Subtypes.Value(slot))
+			f.subtypes = append(f.subtypes, types[slot])
 		}
 		return
 	}

--- a/vector/pick.go
+++ b/vector/pick.go
@@ -1,7 +1,6 @@
 package vector
 
 import (
-	"github.com/brimdata/super"
 	"github.com/brimdata/super/vector/bitvec"
 )
 
@@ -44,12 +43,6 @@ func Pick(val Any, index []uint32) Any {
 	case *Named:
 		// Wrapped View under Named so vector.Under still works.
 		return &Named{val.Typ, Pick(val.Any, index)}
-	case *Fusion:
-		subtypes := make([]super.Type, len(index))
-		for k, slot := range index {
-			subtypes[k] = val.Subtypes.Value(slot)
-		}
-		return NewFusion(val.Sctx, val.Typ, Pick(val.Values, index), subtypes)
 	case nil:
 		return nil
 	}

--- a/vector/pick.go
+++ b/vector/pick.go
@@ -1,6 +1,7 @@
 package vector
 
 import (
+	"github.com/brimdata/super"
 	"github.com/brimdata/super/vector/bitvec"
 )
 
@@ -43,6 +44,12 @@ func Pick(val Any, index []uint32) Any {
 	case *Named:
 		// Wrapped View under Named so vector.Under still works.
 		return &Named{val.Typ, Pick(val.Any, index)}
+	case *Fusion:
+		subtypes := make([]super.Type, len(index))
+		for k, slot := range index {
+			subtypes[k] = val.Subtypes.Value(slot)
+		}
+		return NewFusion(val.Sctx, val.Typ, Pick(val.Values, index), subtypes)
 	case nil:
 		return nil
 	}


### PR DESCRIPTION
The added test requires handling a vector.View wrapping a vector.Fusion
in vector.fusionBuilder.Write.