### PR TITLE
a few small changes toward the summit runtime

### DIFF
--- a/csup/metadata.go
+++ b/csup/metadata.go
@@ -255,6 +255,8 @@ func (d *Dynamic) Len(*Context) uint32 {
 func metadataValue(cctx *Context, sctx *super.Context, b *scode.Builder, id ID, projection field.Projection) super.Type {
 	m := cctx.Lookup(id)
 	switch m := under(cctx, m).(type) {
+	case *Fusion:
+		return metadataValue(cctx, sctx, b, m.Values, projection)
 	case *Dict:
 		return metadataValue(cctx, sctx, b, m.Values, projection)
 	case *Record:

--- a/runtime/vam/expr/compare.go
+++ b/runtime/vam/expr/compare.go
@@ -34,8 +34,8 @@ func (c *Compare) eval(vecs ...vector.Any) vector.Any {
 	if vec, ok := CheckForNullThenError(vecs); ok {
 		return vec
 	}
-	lhs := vector.Under(vecs[0])
-	rhs := vector.Under(vecs[1])
+	lhs := vector.Under(vector.Super(vecs[0]))
+	rhs := vector.Under(vector.Super(vecs[1]))
 	lhs, rhs, errVal := coerceVals(c.sctx, lhs, rhs)
 	if errVal != nil {
 		// Incompatible types so return true for != and false otherwise.

--- a/runtime/vam/expr/dot.go
+++ b/runtime/vam/expr/dot.go
@@ -39,7 +39,7 @@ func (d *DotExpr) Eval(vec vector.Any) vector.Any {
 }
 
 func (d *DotExpr) eval(vecs ...vector.Any) vector.Any {
-	switch val := vector.Under(vecs[0]).(type) {
+	switch val := vector.Under(vector.Super(vecs[0])).(type) {
 	case *vector.Record:
 		i, ok := val.Typ.IndexOfField(d.field)
 		if !ok {

--- a/vector/fusion.go
+++ b/vector/fusion.go
@@ -46,3 +46,10 @@ func (f *Fusion) Serialize(b *scode.Builder, slot uint32) {
 	f.Subtypes.Serialize(b, slot)
 	b.EndContainer()
 }
+
+func Super(vec Any) Any {
+	if vec, ok := vec.(*Fusion); ok {
+		return vec.Values
+	}
+	return vec
+}


### PR DESCRIPTION
This commit adds a vector.Super function to provide the fused value of a fusion type so that we can begin to thread fusion support throughout the vector runtime.  We added calls to dot expressions and comparisons so those two things work now and added support for fusion CSUP metadata so that the min/max stats in CSUP files works for vectors under a fusion (thereby allowing the pushdown filter to operate correctly for CSUP objects).

Fixes #6939