### PR TITLE
Update cast doc to reflect super#6666 change

### DIFF
--- a/book/src/super-sql/functions/types/cast.md
+++ b/book/src/super-sql/functions/types/cast.md
@@ -21,7 +21,9 @@ with the semantics of the [expression cast](../../expressions/cast.md).
 In the second form, the target type is a [named type](../../types/named.md)
 whose name is the `name` parameter and whose type is the type of `val`.
 
-When a cast is successful, the return value of `cast` always has the target type.
+When a cast is successful, the return value of `cast` has the target type,
+except when attempting to cast a `null` value to a non-null type, which returns
+a value with a nullable [union](../../types/union.md) type.
 
 If errors are encountered, then some or all of the resulting value
 will be embedded with structured errors and the result does not have
@@ -40,10 +42,12 @@ cast(this, <ip>)
 "10.0.0.1"
 1
 "foo"
+null
 # expected output
 10.0.0.1
 error({message:"cannot cast to ip",on:1})
 error({message:"cannot cast to ip",on:"foo"})
+null::(ip|null)
 ```
 
 ---
@@ -57,10 +61,12 @@ cast(this, <{b:string}>)
 {a:1,b:2}
 {b:4}
 {a:3}
+null
 # expected output
 {b:"2"}
 {b:"4"}
 {b:error("missing")}
+null::(null|{b:string})
 ```
 
 ---

--- a/book/src/super-sql/functions/types/cast.md
+++ b/book/src/super-sql/functions/types/cast.md
@@ -23,7 +23,7 @@ whose name is the `name` parameter and whose type is the type of `val`.
 
 When a cast is successful, the return value of `cast` has the target type,
 except when attempting to cast a `null` value to a non-null type, which returns
-a value with a nullable [union](../../types/union.md) type.
+a [union](../../types/union.md) of `null` and the target type.
 
 If errors are encountered, then some or all of the resulting value
 will be embedded with structured errors and the result does not have


### PR DESCRIPTION
## What's Changing

The user-facing docs for the `cast` function will now reflect that it's expected behavior for attempted cast of `null` to a non-null type to return a value of nullable union type.

## Why

The merge of #6666 made it behave this way, so the "always" that was previously in the doc has not been 100% accurate.

## Details

While updating the ztests I happened to notice how after casting `null` to the primitive type the `null` appears last in the nullable union whereas when casting `null` to the record type the `null` appears first in the union. This is just cosmetic, but I thought I'd point it out in case it's something we'd want to make consistent at some point. Happy to open an issue if so.