### PR TITLE
Fix link to Zeek TSV logs page

### DIFF
--- a/book/src/dev/integrations/zeek/logs.md
+++ b/book/src/dev/integrations/zeek/logs.md
@@ -4,7 +4,7 @@ SuperDB can read both of the common Zeek log formats. This section
 provides guidance for what to expect when reading logs of these formats using
 the [super](../../../command/super.md) command.
 
-[Zeek TSV](https://docs.zeek.org/en/current/log-formats.html#zeek-tsv-format-logs)
+[Zeek TSV](https://docs.zeek.org/en/current/log-formats.html#zeek-log-formats)
 is Zeek's default output format for logs. This format can be read automatically
 (i.e., no `-i` command line flag is necessary to indicate the input format)
 with [super](../../../command/super.md).

--- a/book/src/dev/integrations/zeek/types.md
+++ b/book/src/dev/integrations/zeek/types.md
@@ -1,7 +1,7 @@
 # Type System
 
 As the [super-structured data model](../../../formats/model.md) was in many ways inspired by the
-[Zeek TSV log format](https://docs.zeek.org/en/current/log-formats.html#zeek-tsv-format-logs),
+[Zeek TSV log format](https://docs.zeek.org/en/current/log-formats.html#zeek-log-formats),
 SuperDB's rich storage formats ([SUP](../../../formats/sup.md),
 [CSUP](../../../formats/csup.md), etc.) maintain comprehensive interoperability
 with Zeek.


### PR DESCRIPTION
The Zeek people changed this section name in their docs which has been flagged by the link checker on our deployed docs site.