### PR TITLE
simplify fusion for arrays, sets, and maps

### DIFF
--- a/book/src/super-sql/operators/fuse.md
+++ b/book/src/super-sql/operators/fuse.md
@@ -64,6 +64,6 @@ fuse
 {a:[1,2]}
 {a:["foo","bar"],b:10.0.0.1}
 # expected output
-fusion({a:fusion([fusion(1::(int64|string),<int64>),fusion(2::(int64|string),<int64>)],<[int64]>),b?:_::ip},<{a:[int64]}>)
-fusion({a:fusion([fusion("foo"::(int64|string),<string>),fusion("bar"::(int64|string),<string>)],<[string]>),b?:10.0.0.1},<{a:[string],b:ip}>)
+fusion({a:fusion([1,2]::[int64|string],<[int64]>),b?:_::ip},<{a:[int64]}>)
+fusion({a:fusion(["foo","bar"]::[int64|string],<[string]>),b?:10.0.0.1},<{a:[string],b:ip}>)
 ```

--- a/runtime/sam/expr/agg/fuser.go
+++ b/runtime/sam/expr/agg/fuser.go
@@ -82,16 +82,30 @@ func (f *Fuser) fuse(a, b super.Type) super.Type {
 		}
 	case *super.TypeArray:
 		if b, ok := b.(*super.TypeArray); ok {
-			return f.fusion(f.sctx.LookupTypeArray(f.fuse(a.Type, b.Type)))
+			inner := f.fuse(a.Type, b.Type)
+			if fusion, ok := inner.(*super.TypeFusion); ok {
+				inner = fusion.Type
+			}
+			return f.fusion(f.sctx.LookupTypeArray(inner))
 		}
 	case *super.TypeSet:
 		if b, ok := b.(*super.TypeSet); ok {
-			return f.fusion(f.sctx.LookupTypeSet(f.fuse(a.Type, b.Type)))
+			inner := f.fuse(a.Type, b.Type)
+			if fusion, ok := inner.(*super.TypeFusion); ok {
+				inner = fusion.Type
+			}
+			return f.fusion(f.sctx.LookupTypeSet(inner))
 		}
 	case *super.TypeMap:
 		if b, ok := b.(*super.TypeMap); ok {
 			keyType := f.fuse(a.KeyType, b.KeyType)
+			if fusion, ok := keyType.(*super.TypeFusion); ok {
+				keyType = fusion.Type
+			}
 			valType := f.fuse(a.ValType, b.ValType)
+			if fusion, ok := valType.(*super.TypeFusion); ok {
+				valType = fusion.Type
+			}
 			return f.fusion(f.sctx.LookupTypeMap(keyType, valType))
 		}
 	case *super.TypeUnion:

--- a/runtime/ztests/expr/fuser.yaml
+++ b/runtime/ztests/expr/fuser.yaml
@@ -27,7 +27,7 @@ input: |
   [{id:1,s:"foo"},{id:2,s:null}]
 
 output: |
-  <fusion([fusion(none|{id:int64,s:fusion(string|null)})])>
+  <fusion([none|{id:int64,s:fusion(string|null)}])>
 
 ---
 
@@ -38,7 +38,7 @@ input: |
   []
 
 output: |
-  <fusion([fusion(none|{id:int64,s:fusion(string|null)})])>
+  <fusion([none|{id:int64,s:fusion(string|null)}])>
 
 ---
 

--- a/runtime/ztests/op/aggregate/fuse.yaml
+++ b/runtime/ztests/op/aggregate/fuse.yaml
@@ -40,7 +40,7 @@ input: |
   {a:[null]}
 
 output: |
-  <{a:fusion([fusion(int64|string|null)])}>
+  <{a:fusion([int64|string|null])}>
 
 ---
 
@@ -56,7 +56,7 @@ input: |
 output: |
   <map{int64:int64}>
   <map{int64:int64}>
-  <fusion(map{fusion(int64|string):fusion(int64|string)})>
+  <fusion(map{int64|string:int64|string})>
 
 ---
 
@@ -106,4 +106,4 @@ input: |
 output: |
   type n1=[int64]
   type n2=int64
-  <fusion(n1|[fusion(n2|int64)])>
+  <fusion(n1|[n2|int64])>

--- a/runtime/ztests/op/fuse.yaml
+++ b/runtime/ztests/op/fuse.yaml
@@ -29,11 +29,11 @@ input: |
   [{a:null,b:null}]
 
 output: |
-  fusion([fusion({a:fusion(1::(int64|null|none),<int64>),b:fusion(_::(int64|null|none),<none>)},<{a:int64}>)],<[{a:int64}]>)
-  fusion([fusion({a:fusion(_::(int64|null|none),<none>),b:fusion(2::(int64|null|none),<int64>)},<{b:int64}>)],<[{b:int64}]>)
-  fusion([fusion({a:fusion(3::(int64|null|none),<int64>),b:fusion(_::(int64|null|none),<none>)},<{a:int64}>),fusion({a:fusion(_::(int64|null|none),<none>),b:fusion(3::(int64|null|none),<int64>)},<{b:int64}>)],<[{a:int64}|{b:int64}]>)
-  fusion([fusion({a:fusion(3::(int64|null|none),<int64>),b:fusion(3::(int64|null|none),<int64>)},<{a:int64,b:int64}>)],<[{a:int64,b:int64}]>)
-  fusion([fusion({a:fusion(null::(int64|null|none),<null>),b:fusion(null::(int64|null|none),<null>)},<{a:null,b:null}>)],<[{a:null,b:null}]>)
+  fusion([{a:fusion(1::(int64|null|none),<int64>),b:fusion(_::(int64|null|none),<none>)}],<[{a:int64}]>)
+  fusion([{a:fusion(_::(int64|null|none),<none>),b:fusion(2::(int64|null|none),<int64>)}],<[{b:int64}]>)
+  fusion([{a:fusion(3::(int64|null|none),<int64>),b:fusion(_::(int64|null|none),<none>)},{a:fusion(_::(int64|null|none),<none>),b:fusion(3::(int64|null|none),<int64>)}],<[{a:int64}|{b:int64}]>)
+  fusion([{a:fusion(3::(int64|null|none),<int64>),b:fusion(3::(int64|null|none),<int64>)}],<[{a:int64,b:int64}]>)
+  fusion([{a:fusion(null::(int64|null|none),<null>),b:fusion(null::(int64|null|none),<null>)}],<[{a:null,b:null}]>)
 
 ---
 
@@ -51,12 +51,12 @@ input: |
   ["s"]
 
 output: |
-  fusion({a:fusion(1::(int64|string),<int64>)}::(int64|string|{a:fusion(int64|string)}|[fusion(int64|string)]),<{a:int64}>)
-  fusion({a:fusion("s"::(int64|string),<string>)}::(int64|string|{a:fusion(int64|string)}|[fusion(int64|string)]),<{a:string}>)
-  fusion(1::(int64|string|{a:fusion(int64|string)}|[fusion(int64|string)]),<int64>)
-  fusion("s"::(int64|string|{a:fusion(int64|string)}|[fusion(int64|string)]),<string>)
-  fusion([fusion(1::(int64|string),<int64>)]::(int64|string|{a:fusion(int64|string)}|[fusion(int64|string)]),<[int64]>)
-  fusion([fusion("s"::(int64|string),<string>)]::(int64|string|{a:fusion(int64|string)}|[fusion(int64|string)]),<[string]>)
+  fusion({a:fusion(1::(int64|string),<int64>)}::(int64|string|{a:fusion(int64|string)}|[int64|string]),<{a:int64}>)
+  fusion({a:fusion("s"::(int64|string),<string>)}::(int64|string|{a:fusion(int64|string)}|[int64|string]),<{a:string}>)
+  fusion(1::(int64|string|{a:fusion(int64|string)}|[int64|string]),<int64>)
+  fusion("s"::(int64|string|{a:fusion(int64|string)}|[int64|string]),<string>)
+  fusion([1]::[int64|string]::(int64|string|{a:fusion(int64|string)}|[int64|string]),<[int64]>)
+  fusion(["s"]::[int64|string]::(int64|string|{a:fusion(int64|string)}|[int64|string]),<[string]>)
 
 ---
 
@@ -99,9 +99,9 @@ input: |
   [null]
 
 output: |
-  fusion([fusion(1::(int64|string|null),<int64>),fusion(2::(int64|string|null),<int64>)],<[int64]>)
-  fusion([fusion("foo"::(int64|string|null),<string>)],<[string]>)
-  fusion([fusion(null::(int64|string|null),<null>)],<[null]>)
+  fusion([1,2]::[int64|string|null],<[int64]>)
+  fusion(["foo"]::[int64|string|null],<[string]>)
+  fusion([null]::[int64|string|null],<[null]>)
 
 ---
 
@@ -115,9 +115,9 @@ input: |
   {a:[null]}
 
 output: |
-  {a:fusion([fusion(1::(int64|string|null),<int64>),fusion(2::(int64|string|null),<int64>)],<[int64]>)}
-  {a:fusion([fusion("foo"::(int64|string|null),<string>)],<[string]>)}
-  {a:fusion([fusion(null::(int64|string|null),<null>)],<[null]>)}
+  {a:fusion([1,2]::[int64|string|null],<[int64]>)}
+  {a:fusion(["foo"]::[int64|string|null],<[string]>)}
+  {a:fusion([null]::[int64|string|null],<[null]>)}
 
 ---
 


### PR DESCRIPTION
This commit simplifies type fusion for container types (i.e., arrays, sets, and maps) by moving the fusion-type wrapper from the inner types to the container type.  There is no loss of information about subtypes because a container type completely identifies the types of the consituent elements so there is no need for the elements to also carry their subtypes, i.e., they are passed down from the parent to the children elements during a donwcast.  Note that retaining the fusion types on the elements instead of the parent container would *not* work because empty containers would have nowhere to store the empty container type.

Docs updates are forthcoming on a subsequent PR.