### PR TITLE
vector.Builder: Support Dicts, Consts

### DIFF
--- a/vector/builder.go
+++ b/vector/builder.go
@@ -1,6 +1,7 @@
 package vector
 
 import (
+	"math"
 	"net/netip"
 	"slices"
 
@@ -79,9 +80,8 @@ func NewBuilder(typ super.Type) Builder {
 		*super.TypeOfUint32,
 		*super.TypeOfUint64:
 		return &genericBuilder[uint64]{
-			typ:      typ,
 			valuesOf: func(vec Any) []uint64 { return vec.(*Uint).Values },
-			build: func(_ *super.Context, typ super.Type, vals []uint64) Any {
+			build: func(_ *super.Context, vals []uint64) Any {
 				return NewUint(typ, vals)
 			},
 		}
@@ -92,9 +92,8 @@ func NewBuilder(typ super.Type) Builder {
 		*super.TypeOfDuration,
 		*super.TypeOfTime:
 		return &genericBuilder[int64]{
-			typ:      typ,
 			valuesOf: func(vec Any) []int64 { return vec.(*Int).Values },
-			build: func(_ *super.Context, typ super.Type, vals []int64) Any {
+			build: func(_ *super.Context, vals []int64) Any {
 				return NewInt(typ, vals)
 			},
 		}
@@ -102,9 +101,8 @@ func NewBuilder(typ super.Type) Builder {
 		*super.TypeOfFloat32,
 		*super.TypeOfFloat64:
 		return &genericBuilder[float64]{
-			typ:      typ,
 			valuesOf: func(vec Any) []float64 { return vec.(*Float).Values },
-			build: func(_ *super.Context, typ super.Type, vals []float64) Any {
+			build: func(_ *super.Context, vals []float64) Any {
 				return NewFloat(typ, vals)
 			},
 		}
@@ -115,24 +113,22 @@ func NewBuilder(typ super.Type) Builder {
 		return newStringBytesBuilder(typ)
 	case *super.TypeOfIP:
 		return &genericBuilder[netip.Addr]{
-			typ:      typ,
 			valuesOf: func(vec Any) []netip.Addr { return vec.(*IP).Values },
-			build: func(_ *super.Context, _ super.Type, vals []netip.Addr) Any {
+			build: func(_ *super.Context, vals []netip.Addr) Any {
 				return NewIP(vals)
 			},
 		}
 	case *super.TypeOfNet:
 		return &genericBuilder[netip.Prefix]{
-			typ:      typ,
 			valuesOf: func(vec Any) []netip.Prefix { return vec.(*Net).Values },
-			build: func(_ *super.Context, _ super.Type, vals []netip.Prefix) Any {
+			build: func(_ *super.Context, vals []netip.Prefix) Any {
 				return NewNet(vals)
 			},
 		}
 	case *super.TypeOfType:
 		return &genericBuilder[super.Type]{
 			valuesOf: func(vec Any) []super.Type { return vec.(*TypeValue).types },
-			build: func(sctx *super.Context, _ super.Type, vals []super.Type) Any {
+			build: func(sctx *super.Context, vals []super.Type) Any {
 				return NewTypeValue(sctx, vals)
 			},
 		}
@@ -161,38 +157,166 @@ func NewBuilder(typ super.Type) Builder {
 	}
 }
 
-type genericBuilder[E any] struct {
-	typ      super.Type
-	vals     []E
+type genericBuilder[E comparable] struct {
+	writer   genericWriter
 	valuesOf func(Any) []E
-	build    func(*super.Context, super.Type, []E) Any
+	build    func(*super.Context, []E) Any
 }
 
 func (b *genericBuilder[E]) Write(vec Any) {
-	switch vec := vec.(type) {
-	case *View:
-		vals := b.valuesOf(vec.Any)
-		for _, slot := range vec.Index {
-			b.vals = append(b.vals, vals[slot])
+	if b.writer == nil {
+		b.writer = &genericConstWriter[E]{
+			valuesOf: b.valuesOf,
+			build:    b.build,
 		}
-	case *Const:
-		vals := b.valuesOf(vec.Any)
-		for range vec.len {
-			b.vals = append(b.vals, vals[0])
-		}
-	case *Dict:
-		vals := b.valuesOf(vec.Any)
-		for _, slot := range vec.Index {
-			b.vals = append(b.vals, vals[slot])
-		}
-	case *Empty:
-	default:
-		b.vals = append(b.vals, b.valuesOf(vec)...)
 	}
+	b.writer = b.writer.Write(vec)
 }
 
 func (b *genericBuilder[E]) Build(sctx *super.Context) Any {
-	return b.build(sctx, b.typ, b.vals)
+	if b.writer == nil {
+		b.writer = &genericFlatWriter[E]{
+			valuesOf: b.valuesOf,
+			build:    b.build,
+		}
+	}
+	return b.writer.Build(sctx)
+}
+
+type genericWriter interface {
+	Write(Any) genericWriter
+	Build(*super.Context) Any
+}
+
+type genericConstWriter[E comparable] struct {
+	val      E
+	len      uint32
+	valuesOf func(Any) []E
+	build    func(*super.Context, []E) Any
+}
+
+func (c *genericConstWriter[E]) Write(vec Any) genericWriter {
+	if const_, ok := vec.(*Const); ok {
+		vals := c.valuesOf(const_.Any)
+		if c.len == 0 {
+			c.val = vals[0]
+		}
+		if c.val == vals[0] {
+			c.len += const_.len
+			return c
+		}
+	}
+	w := genericWriter(&genericDictWriter[E]{
+		dict:     make(map[E]byte),
+		valuesOf: c.valuesOf,
+		build:    c.build,
+	})
+	if c.len > 0 {
+		w = w.Write(c.Build(nil))
+	}
+	return w.Write(vec)
+}
+
+func (c *genericConstWriter[E]) Build(sctx *super.Context) Any {
+	return NewConst(c.build(sctx, []E{c.val}), c.len)
+}
+
+type genericDictWriter[E comparable] struct {
+	dict     map[E]byte
+	counts   []uint32
+	index    []byte
+	valuesOf func(Any) []E
+	build    func(*super.Context, []E) Any
+}
+
+func (d *genericDictWriter[E]) Write(vec Any) genericWriter {
+	switch vec := vec.(type) {
+	case *Const:
+		vals := d.valuesOf(vec.Any)
+		idx, ok := d.writeEntry(vals[0], vec.len)
+		if ok {
+			d.index = append(d.index, slices.Repeat([]byte{idx}, int(vec.len))...)
+			return d
+		}
+	case *Dict:
+		vals := d.valuesOf(vec.Any)
+		remap := make([]byte, len(vals))
+		var ok bool
+		for i, val := range vals {
+			if remap[i], ok = d.writeEntry(val, vec.Counts[i]); !ok {
+				break
+			}
+		}
+		if ok {
+			for _, idx := range vec.Index {
+				d.index = append(d.index, remap[idx])
+			}
+			return d
+		}
+	}
+	w := genericWriter(&genericFlatWriter[E]{
+		valuesOf: d.valuesOf,
+		build:    d.build,
+	})
+	if len(d.index) > 0 {
+		w = w.Write(d.Build(nil))
+	}
+	return w.Write(vec)
+}
+
+func (d *genericDictWriter[E]) writeEntry(val E, count uint32) (byte, bool) {
+	idx, ok := d.dict[val]
+	if !ok {
+		if len(d.counts) > math.MaxUint8 {
+			return 0, false
+		}
+		idx = byte(len(d.counts))
+		d.dict[val] = idx
+		d.counts = append(d.counts, 0)
+	}
+	d.counts[idx] += count
+	return idx, true
+}
+
+func (d *genericDictWriter[E]) Build(sctx *super.Context) Any {
+	vals := make([]E, len(d.counts))
+	for val, idx := range d.dict {
+		vals[idx] = val
+	}
+	return NewDict(d.build(sctx, vals), d.index, d.counts)
+}
+
+type genericFlatWriter[E comparable] struct {
+	vals     []E
+	valuesOf func(Any) []E
+	build    func(*super.Context, []E) Any
+}
+
+func (f *genericFlatWriter[E]) Write(vec Any) genericWriter {
+	switch vec := vec.(type) {
+	case *Const:
+		vals := f.valuesOf(vec.Any)
+		for range vec.len {
+			f.vals = append(f.vals, vals[0])
+		}
+	case *Dict:
+		vals := f.valuesOf(vec.Any)
+		for _, idx := range vec.Index {
+			f.vals = append(f.vals, vals[idx])
+		}
+	case *View:
+		vals := f.valuesOf(vec.Any)
+		for _, idx := range vec.Index {
+			f.vals = append(f.vals, vals[idx])
+		}
+	default:
+		f.vals = append(f.vals, f.valuesOf(vec)...)
+	}
+	return f
+}
+
+func (f *genericFlatWriter[E]) Build(sctx *super.Context) Any {
+	return f.build(sctx, f.vals)
 }
 
 type boolBuilder struct {


### PR DESCRIPTION
The commit adds functionality for primitives in vector.Builder so that if the inputs are all Consts and Dicts the builder will attempt to keep the inputs as Consts and Dicts if able.