### PR TITLE
simplify array fusion for fjson

### DIFF
--- a/sio/fjsonio/jsonvec/materialize.go
+++ b/sio/fjsonio/jsonvec/materialize.go
@@ -101,6 +101,9 @@ func (m *materializer) makeUnionSubtypes(tags []uint32, dynamic [][]uint32, fixe
 
 func (m *materializer) array(a *Array) (vector.Any, []uint32) {
 	inner, ids := m.value(a.Inner)
+	// Unwrap fusion since the inner subtype IDs are redundant with
+	// the subtypes of a parent array.
+	inner = vector.Super(inner)
 	arrayType := m.sctx.LookupTypeArray(inner.Type())
 	array := vector.NewArray(arrayType, a.Offsets, inner)
 	if ids == nil {


### PR DESCRIPTION
This commit moves the fusion of array elements to their parents for fjson as PR #6949 did for the fuse agg func.