### PR TITLE
removed named types from upcast/downcast logic

### DIFF
--- a/runtime/sam/expr/function/downcast.go
+++ b/runtime/sam/expr/function/downcast.go
@@ -71,8 +71,6 @@ func (d *downcast) downcast(typ super.Type, bytes scode.Bytes, to super.Type) (s
 		return d.toEnum(typ, bytes, to)
 	case *super.TypeError:
 		return d.toError(typ, bytes, to)
-	case *super.TypeNamed:
-		return d.toNamed(typ, bytes, to)
 	case *super.TypeFusion:
 		// Can't downcast to a super type
 		return super.Value{}, d.sctx.WrapError("downcast: cannot downcast to a fusion type", super.NewValue(typ, bytes)).Ptr()
@@ -276,38 +274,6 @@ func (d *downcast) toError(typ super.Type, bytes scode.Bytes, to *super.TypeErro
 		return super.NewValue(to, body.Bytes()), nil
 	}
 	return super.Value{}, d.errMismatch(typ, bytes, to)
-}
-
-func (d *downcast) toNamed(typ super.Type, bytes scode.Bytes, to *super.TypeNamed) (super.Value, *super.Value) {
-	if unionType, ok := typ.(*super.TypeUnion); ok {
-		typ, bytes = deunion(typ, bytes)
-		// If we are casting a union type to a named, we need to look through the
-		// union for the named type in question since type fusion fuses named
-		// types by name.  Then when we find the name, we need to form the subtype
-		// from the union options present.
-		for _, t := range unionType.Types {
-			if named, ok := t.(*super.TypeNamed); ok && named.Name == to.Name {
-				typ, bytes = deunion(typ, bytes)
-				return super.NewValue(to, bytes), nil
-			}
-		}
-		return super.Value{}, d.errMismatch(typ, bytes, to)
-	}
-	if fromType, ok := typ.(*super.TypeNamed); ok {
-		if fromType.Name != to.Name {
-			return super.Value{}, d.errMismatch(typ, bytes, to)
-		}
-		val, errVal := d.downcast(fromType.Type, bytes, to.Type)
-		if errVal != nil {
-			return super.Value{}, errVal
-		}
-		return super.NewValue(to, val.Bytes()), errVal
-	}
-	val, errVal := d.downcast(typ, bytes, to.Type)
-	if errVal != nil {
-		return super.Value{}, errVal
-	}
-	return super.NewValue(to, val.Bytes()), errVal
 }
 
 func (d *downcast) errNonOptionNone(to super.Type) *super.Value {

--- a/runtime/sam/expr/function/upcast.go
+++ b/runtime/sam/expr/function/upcast.go
@@ -59,8 +59,6 @@ func (u *Upcast) upcast(b *scode.Builder, typ super.Type, bytes scode.Bytes, to 
 		return u.toEnum(b, typ, bytes, to)
 	case *super.TypeError:
 		return u.toError(b, typ, bytes, to)
-	case *super.TypeNamed:
-		return u.toNamed(b, typ, bytes, to)
 	case *super.TypeFusion:
 		return u.toFusion(b, typ, bytes, to)
 	default:
@@ -226,13 +224,6 @@ func UpcastUnionTag(types []super.Type, out super.Type) int {
 func (u *Upcast) toError(b *scode.Builder, typ super.Type, bytes scode.Bytes, to *super.TypeError) bool {
 	if errorType, ok := typ.(*super.TypeError); ok {
 		return u.upcast(b, errorType.Type, bytes, to.Type)
-	}
-	return false
-}
-
-func (u *Upcast) toNamed(b *scode.Builder, typ super.Type, bytes scode.Bytes, to *super.TypeNamed) bool {
-	if named, ok := typ.(*super.TypeNamed); ok {
-		return u.upcast(b, named.Type, bytes, to.Type)
 	}
 	return false
 }

--- a/runtime/vam/expr/function/downcast.go
+++ b/runtime/vam/expr/function/downcast.go
@@ -117,8 +117,6 @@ func (d *downcast) downcast(vec vector.Any, to super.Type) vector.Any {
 		return d.toEnum(vec, to)
 	case *super.TypeError:
 		return d.toError(vec, to)
-	case *super.TypeNamed:
-		return d.toNamed(vec, to)
 	case *super.TypeFusion:
 		return d.err(vector.NewWrappedError(d.sctx, "downcast: cannot downcast to a fusion type", vec))
 	default:
@@ -443,20 +441,6 @@ func (d *downcast) toError(vec vector.Any, to *super.TypeError) vector.Any {
 		})
 	}
 	return d.errMismatch(vec, to)
-}
-
-func (d *downcast) toNamed(vec vector.Any, to *super.TypeNamed) vector.Any {
-	if fromVec, ok := vec.(*vector.Named); ok {
-		if fromVec.Typ != to {
-			return d.errMismatch(vec, to)
-		}
-		return vec
-	}
-	out := d.downcast(vec, to.Type)
-	if isErrDowncast(out) {
-		return out
-	}
-	return vector.NewNamed(to, out)
 }
 
 func (d *downcast) deunion(vec vector.Any, f func(vector.Any) vector.Any) vector.Any {

--- a/runtime/vam/expr/function/upcast.go
+++ b/runtime/vam/expr/function/upcast.go
@@ -120,8 +120,6 @@ func (u *Upcast) upcast(vec vector.Any, to super.Type) vector.Any {
 		return u.toEnum(vec, to)
 	case *super.TypeError:
 		return u.toError(vec, to)
-	case *super.TypeNamed:
-		return u.toNamed(vec, to)
 	case *super.TypeFusion:
 		return u.toFusion(vec, to)
 	default:
@@ -271,18 +269,6 @@ func (u *Upcast) toError(vec vector.Any, to *super.TypeError) vector.Any {
 		return nil
 	}
 	return vector.NewError(to, values)
-}
-
-func (u *Upcast) toNamed(vec vector.Any, to *super.TypeNamed) vector.Any {
-	namedVec, ok := vec.(*vector.Named)
-	if !ok {
-		return nil
-	}
-	vec = u.upcast(namedVec.Any, to.Type)
-	if vec == nil {
-		return nil
-	}
-	return vector.NewNamed(to, vec)
 }
 
 func (u *Upcast) toFusion(vec vector.Any, to *super.TypeFusion) vector.Any {

--- a/runtime/ztests/expr/function/downcast.yaml
+++ b/runtime/ztests/expr/function/downcast.yaml
@@ -175,8 +175,8 @@ input: |
   ["foo"::(int64|string),<foo>]
 
 output: |
+  error({message:"downcast: type mismatch to foo",on:1})
+  error({message:"downcast: type mismatch to foo",on:1})
   type foo=int64
-  1::foo
-  1::foo
   error({message:"downcast: type mismatch to bar",on:1::foo})
-  error({message:"downcast: type mismatch to int64",on:"foo"})
+  error({message:"downcast: type mismatch to foo",on:"foo"})

--- a/runtime/ztests/expr/function/upcast.yaml
+++ b/runtime/ztests/expr/function/upcast.yaml
@@ -25,43 +25,41 @@ input: |
   ["x"::enum(x,y),<fusion(enum(y,z))>]
   [fusion(1::(int64|string),<int64>),<fusion(int64|string)>]
   type n31=int64
-  type n32=int64
-  [1::n31,<n32>]
+  [1::n31,<n31>]
   type n41=int64
   type n42={b:n41}
   type n43={a:n42}
   type n46=int64
   type n45={b:n46}
   type n44={a:n45}
-  [{a:{b:1}}::n43,<n44>]
+  [{a:{b:1}}::n44,<n44>]
   type n51=int64
   type n52=[n51]
   type n53=[n52]
   type n56=int64
   type n55=[n56]
   type n54=[n55]
-  [[[1]]::n53,<n54>]
+  [[[1]]::n54,<n54>]
   type n61=int64
   type n62=set[n61]
   type n63=set[n62]
   type n66=int64
   type n65=set[n66]
   type n64=set[n65]
-  [set[set[1]]::n63,<n64>]
+  [set[set[1]]::n64,<n64>]
   type n71=int64
   type n72=int64
   type n73=map{n71:n72}
   type n75=int64
   type n76=int64
   type n74=map{n75:n76}
-  [map{1:2}::n73,<n74>]
+  [map{1:2}::n74,<n74>]
   type n82=int64
   type n81=n82
   type n83=string
   [1::n81,<n81|n83>]
   type n91=enum(a,b)
-  type n92=enum(a,b)
-  ["a"::n91,<n92>]
+  ["a"::n91,<n91>]
   type n101=int64
   [1::n101,<fusion(n101|string)>]
 
@@ -73,8 +71,8 @@ output: |
   fusion("x"::enum(x,y,z),<enum(x,y)>)
   error({message:"upcast: value not a subtype of fusion(enum(y,z))",on:"x"::enum(x,y)})
   fusion(1::(int64|string),<int64|string>)
-  type n32=int64
-  1::n32
+  type n31=int64
+  1::n31
   type n46=int64
   type n45={b:n46}
   type n44={a:n45}
@@ -95,8 +93,8 @@ output: |
   type n81=n82
   type n83=string
   1::n81::(n81|n83)
-  type n92=enum(a,b)
-  "a"::n92
+  type n91=enum(a,b)
+  "a"::n91
   type n101=int64
   fusion(1::n101::(n101|string),<n101>)
 


### PR DESCRIPTION
Named types are a barrier to type fusion so this commit removes the unnecessary logic for upcasting and downcasting the bodies of named types.