### PR TITLE
vector: Enforce union invariant

### DIFF
--- a/runtime/vam/expr/arrayexpr.go
+++ b/runtime/vam/expr/arrayexpr.go
@@ -133,7 +133,7 @@ func unwrapSpread(vec vector.Any) (vector.Any, []uint32) {
 	if k := vec.Kind(); k != vector.KindArray && k != vector.KindSet {
 		return nil, nil
 	}
-	switch vec := PushContainerViewDown(vec).(type) {
+	switch vec := vector.PushView(vec).(type) {
 	case *vector.Array:
 		return vec.Values, vec.Offsets
 	case *vector.Set:

--- a/runtime/vam/expr/cast/cast.go
+++ b/runtime/vam/expr/cast/cast.go
@@ -13,15 +13,7 @@ func To(sctx *super.Context, vec vector.Any, typ super.Type) vector.Any {
 	vec = vector.Under(vec)
 	switch vec.Kind() {
 	case vector.KindNull:
-		union := sctx.Nullable(typ)
-		tag := union.TagOf(super.TypeNull)
-		tags := make([]uint32, vec.Len())
-		for i := range vec.Len() {
-			tags[i] = uint32(tag)
-		}
-		vecs := make([]vector.Any, len(union.Types))
-		vecs[tag] = vector.NewNull(vec.Len())
-		return vector.NewUnion(union, tags, vecs)
+		return vector.NewUnionOfOne(sctx.Nullable(typ), vector.NewNull(vec.Len()))
 	case vector.KindError:
 		return vec
 	}

--- a/runtime/vam/expr/function/defuse.go
+++ b/runtime/vam/expr/function/defuse.go
@@ -51,7 +51,7 @@ func (d *defuse) eval(in vector.Any) vector.Any {
 		}
 		return vector.NewDynamic(dynamic.Tags, vecs)
 	case vector.KindFusion:
-		fusion := expr.PushContainerViewDown(in).(*vector.Fusion)
+		fusion := vector.PushView(in).(*vector.Fusion)
 		return d.downcast.call(fusion.Values, fusion.Subtypes.Types())
 	default:
 		// primitives, named types, enums
@@ -61,7 +61,7 @@ func (d *defuse) eval(in vector.Any) vector.Any {
 }
 
 func (d *defuse) defuseRecord(vec vector.Any) vector.Any {
-	rec := expr.PushContainerViewDown(vec).(*vector.Record)
+	rec := vector.PushView(vec).(*vector.Record)
 	var vecs []vector.Any
 	for _, vec := range rec.Fields {
 		vecs = append(vecs, d.eval(vec))
@@ -85,7 +85,7 @@ func (d *defuse) defuseRecord(vec vector.Any) vector.Any {
 }
 
 func (d *defuse) defuseArray(in vector.Any) vector.Any {
-	array := expr.PushContainerViewDown(in).(*vector.Array)
+	array := vector.PushView(in).(*vector.Array)
 	inner := d.eval(array.Values)
 	if !vector.IsDynamic(inner) {
 		return vector.NewArray(d.sctx.LookupTypeArray(inner.Type()), array.Offsets, inner)
@@ -103,7 +103,7 @@ func (d *defuse) defuseArray(in vector.Any) vector.Any {
 }
 
 func (d *defuse) defuseSet(in vector.Any) vector.Any {
-	set := expr.PushContainerViewDown(in).(*vector.Set)
+	set := vector.PushView(in).(*vector.Set)
 	inner := d.eval(set.Values)
 	if !vector.IsDynamic(inner) {
 		return vector.NewSet(d.sctx.LookupTypeSet(inner.Type()), set.Offsets, inner)
@@ -121,7 +121,7 @@ func (d *defuse) defuseSet(in vector.Any) vector.Any {
 }
 
 func (d *defuse) defuseMap(in vector.Any) vector.Any {
-	vmap := expr.PushContainerViewDown(in).(*vector.Map)
+	vmap := vector.PushView(in).(*vector.Map)
 	keys := d.eval(vmap.Values)
 	vals := d.eval(vmap.Values)
 	if !vector.IsDynamic(keys) && !vector.IsDynamic(vals) {

--- a/runtime/vam/expr/function/downcast.go
+++ b/runtime/vam/expr/function/downcast.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/brimdata/super"
 	samfunc "github.com/brimdata/super/runtime/sam/expr/function"
-	"github.com/brimdata/super/runtime/vam/expr"
 	"github.com/brimdata/super/sup"
 	"github.com/brimdata/super/vector"
 	"github.com/brimdata/super/vector/vbuild"
@@ -85,25 +84,24 @@ func (d *downcast) call(from vector.Any, types []super.Type) vector.Any {
 // of type "to" intermixed with one or more other error types.  The caller
 // can check for success by comparing the return vector's type with "to".
 func (d *downcast) downcast(vec vector.Any, to super.Type) vector.Any {
+	vec = vector.PushView(vec)
+	// XXX this shouldn't happen but for some reason fusion vectors
+	// show up with dynamics in the fusion.Values fields so this dynamic
+	// ends up here.
+	if dynamic, ok := vec.(*vector.Dynamic); ok {
+		return d.downcastDynamic(dynamic, to)
+	}
+	if vec.Type() == to {
+		return vec
+	}
 	// XXX Handle vec type All.
 	if _, ok := to.(*super.TypeUnion); !ok {
-		if vec.Kind() == vector.KindFusion {
-			return d.downcastFusion(vec, to)
+		if fusion, ok := vec.(*vector.Fusion); ok {
+			return d.downcastFusion(fusion, to)
 		}
 	}
-	vec = vector.Deunion(vec)
-	if dynamic, ok := vec.(*vector.Dynamic); ok {
-		var vecs []vector.Any
-		for _, vec := range dynamic.Values {
-			vecs = append(vecs, d.downcast(vec, to))
-		}
-		if _, ok := to.(*super.TypeUnion); ok {
-			return vbuild.MergeSameTypesInDynamic(d.sctx, vector.NewDynamic(dynamic.Tags, vecs))
-		}
-		if len(vecs) == 1 {
-			return vecs[0]
-		}
-		return vector.NewDynamic(dynamic.Tags, vecs)
+	if union, ok := vec.(*vector.Union); ok {
+		return d.downcastDynamic(union.Dynamic(), to)
 	}
 	switch to := to.(type) {
 	case *super.TypeRecord:
@@ -123,18 +121,14 @@ func (d *downcast) downcast(vec vector.Any, to super.Type) vector.Any {
 	case *super.TypeFusion:
 		return vector.NewWrappedError(d.sctx, "downcast: cannot downcast to a fusion type", vec)
 	default:
-		if vec.Type() != to {
-			if vec.Type() == super.TypeNone {
-				return d.errNonOptionNone(vec, to)
-			}
-			return d.errMismatch(vec, to)
+		if vec.Type() == super.TypeNone {
+			return d.errNonOptionNone(vec, to)
 		}
-		return vec
+		return d.errMismatch(vec, to)
 	}
 }
 
-func (d *downcast) downcastFusion(in vector.Any, to super.Type) vector.Any {
-	fusion := expr.PushContainerViewDown(in).(*vector.Fusion)
+func (d *downcast) downcastFusion(fusion *vector.Fusion, to super.Type) vector.Any {
 	vec := d.Call(fusion.Values, fusion.Subtypes)
 	return vector.Apply(false, func(vecs ...vector.Any) vector.Any {
 		vec := vecs[0]
@@ -145,11 +139,22 @@ func (d *downcast) downcastFusion(in vector.Any, to super.Type) vector.Any {
 	}, vec)
 }
 
+func (d *downcast) downcastDynamic(dynamic *vector.Dynamic, to super.Type) vector.Any {
+	vecs := make([]vector.Any, len(dynamic.Values))
+	for tag, vec := range dynamic.Values {
+		vecs[tag] = d.downcast(vec, to)
+	}
+	// Flatten nested dynamics.
+	return vector.Apply(false, func(vecs ...vector.Any) vector.Any {
+		return vecs[0]
+	}, vector.NewDynamic(dynamic.Tags, vecs))
+}
+
 func (d *downcast) toRecord(vec vector.Any, to *super.TypeRecord) vector.Any {
-	if vec.Kind() != vector.KindRecord {
+	rec, ok := vec.(*vector.Record)
+	if !ok {
 		return d.errMismatch(vec, to)
 	}
-	rec := expr.PushContainerViewDown(vec).(*vector.Record)
 	if len(to.Fields) == 0 {
 		return vector.NewRecord(to, nil, vec.Len())
 	}
@@ -181,18 +186,18 @@ func (d *downcast) toRecord(vec vector.Any, to *super.TypeRecord) vector.Any {
 }
 
 func (d *downcast) toArray(vec vector.Any, to *super.TypeArray) vector.Any {
-	if vec.Kind() != vector.KindArray {
+	array, ok := vec.(*vector.Array)
+	if !ok {
 		return d.errMismatch(vec, to)
 	}
-	array := expr.PushContainerViewDown(vec).(*vector.Array)
 	return d.toContainer(array.Offsets, array.Values, to, to.Type)
 }
 
 func (d *downcast) toSet(vec vector.Any, to *super.TypeSet) vector.Any {
-	if vec.Kind() != vector.KindSet {
+	set, ok := vec.(*vector.Set)
+	if !ok {
 		return d.errMismatch(vec, to)
 	}
-	set := expr.PushContainerViewDown(vec).(*vector.Set)
 	return d.toContainer(set.Offsets, set.Values, to, to.Type)
 }
 
@@ -217,10 +222,10 @@ func (d *downcast) toContainer(offsets []uint32, inner vector.Any, to, toElem su
 }
 
 func (d *downcast) toMap(vec vector.Any, to *super.TypeMap) vector.Any {
-	if vec.Kind() != vector.KindMap {
+	m, ok := vec.(*vector.Map)
+	if !ok {
 		return d.errMismatch(vec, to)
 	}
-	m := expr.PushContainerViewDown(vec).(*vector.Map)
 	keyTags, keys, keyErr := d.toList(m.Offsets, m.Keys, to.KeyType)
 	valTags, vals, valErr := d.toList(m.Offsets, m.Values, to.ValType)
 	if keyErr == nil && valErr == nil {
@@ -393,18 +398,29 @@ func newContainer(typ super.Type, offsets []uint32, inner vector.Any) vector.Any
 }
 
 func (d *downcast) toUnion(vec vector.Any, to *super.TypeUnion) vector.Any {
-	if vec.Type() == to {
-		return vec
-	}
 	return d.subTypeOf(vec, to.Types, func(tag int, vec vector.Any) vector.Any {
 		if tag < 0 {
 			if _, ok := vec.(*vector.Union); ok {
-				return d.downcast(vector.Deunion(vec), to)
+				// Try downcasting the pieces of the union...
+				return d.downcast(vec, to)
 			}
 			return d.errSubtype(vec, to)
 		}
 		vec = d.downcast(vec, to.Types[tag])
-		return vector.NewUnion(to, make([]uint32, vec.Len()), []vector.Any{vec})
+		if dynamic, ok := vec.(*vector.Dynamic); ok {
+			for k, vec := range dynamic.Values {
+				if vec != nil {
+					if vec.Type() == to.Types[tag] {
+						dynamic.Values[k] = vector.NewUnionOfOne(to, vec)
+					}
+				}
+			}
+			return dynamic
+		}
+		if vec.Type() != to.Types[tag] {
+			return d.errSubtype(vec, to)
+		}
+		return vector.NewUnionOfOne(to, vec)
 	})
 }
 

--- a/runtime/vam/expr/function/upcast.go
+++ b/runtime/vam/expr/function/upcast.go
@@ -227,8 +227,7 @@ func (u *Upcast) toUnion(vec vector.Any, to *super.TypeUnion) vector.Any {
 	if values == nil {
 		return nil
 	}
-	tags := make([]uint32, vec.Len())
-	return vector.NewUnion(to, tags, []vector.Any{values})
+	return vector.NewUnionOfOne(to, values)
 }
 
 func (u *Upcast) toUnionValue(vec vector.Any, to *super.TypeUnion) vector.Any {

--- a/runtime/vam/expr/unblend.go
+++ b/runtime/vam/expr/unblend.go
@@ -12,7 +12,7 @@ func Unblend(sctx *super.Context, vec vector.Any) vector.Any {
 	case vector.KindRecord:
 		return unblendRecord(sctx, vec)
 	case vector.KindArray:
-		array := PushContainerViewDown(vec).(*vector.Array)
+		array := vector.PushView(vec).(*vector.Array)
 		tags, inners, offsets := SplitListByTypes(sctx, array.Offsets, Unblend(sctx, array.Values))
 		var vals []vector.Any
 		for i, inner := range inners {
@@ -24,7 +24,7 @@ func Unblend(sctx *super.Context, vec vector.Any) vector.Any {
 		}
 		return vals[0]
 	case vector.KindSet:
-		set := PushContainerViewDown(vec).(*vector.Set)
+		set := vector.PushView(vec).(*vector.Set)
 		tags, inners, offsets := SplitListByTypes(sctx, set.Offsets, Unblend(sctx, set.Values))
 		var vals []vector.Any
 		for i, inner := range inners {
@@ -36,7 +36,7 @@ func Unblend(sctx *super.Context, vec vector.Any) vector.Any {
 		}
 		return vals[0]
 	case vector.KindMap:
-		return unblendMap(sctx, PushContainerViewDown(vec).(*vector.Map))
+		return unblendMap(sctx, vector.PushView(vec).(*vector.Map))
 	case vector.KindUnion:
 		out := vector.Apply(true, func(vecs ...vector.Any) vector.Any {
 			return Unblend(sctx, vecs[0])
@@ -270,51 +270,4 @@ func typeOfRange(sctx *super.Context, dynamic *vector.Dynamic, alltypes []super.
 		panic(types)
 	}
 	return out
-}
-
-func PushContainerViewDown(val vector.Any) vector.Any {
-	view, ok := val.(*vector.View)
-	if !ok {
-		return val
-	}
-	switch val := view.Any.(type) {
-	case *vector.Record:
-		var fields []vector.Any
-		for _, field := range val.Fields {
-			fields = append(fields, vector.Pick(field, view.Index))
-		}
-		return vector.NewRecord(val.Typ, fields, view.Len())
-	case *vector.Array:
-		inner, offsets := pickList(val.Values, view.Index, val.Offsets)
-		return vector.NewArray(val.Typ, offsets, inner)
-	case *vector.Set:
-		inner, offsets := pickList(val.Values, view.Index, val.Offsets)
-		return vector.NewSet(val.Typ, offsets, inner)
-	case *vector.Map:
-		keys, offsets := pickList(val.Keys, view.Index, val.Offsets)
-		values, _ := pickList(val.Values, view.Index, val.Offsets)
-		return vector.NewMap(val.Typ, offsets, keys, values)
-	case *vector.Fusion:
-		types := val.Subtypes.Types()
-		outTypes := make([]super.Type, len(view.Index))
-		for i, slot := range view.Index {
-			outTypes[i] = types[slot]
-		}
-		return vector.NewFusion(val.Sctx, val.Typ, vector.Pick(val.Values, view.Index), outTypes)
-	default:
-		panic(val)
-	}
-}
-
-func pickList(inner vector.Any, index, offsets []uint32) (vector.Any, []uint32) {
-	newOffsets := []uint32{0}
-	var innerIndex []uint32
-	for _, idx := range index {
-		start, end := offsets[idx], offsets[idx+1]
-		for ; start < end; start++ {
-			innerIndex = append(innerIndex, start)
-		}
-		newOffsets = append(newOffsets, uint32(len(innerIndex)))
-	}
-	return vector.Pick(inner, innerIndex), newOffsets
 }

--- a/sio/fjsonio/ztests/array-bug.yaml
+++ b/sio/fjsonio/ztests/array-bug.yaml
@@ -1,5 +1,7 @@
 spq: defuse(this)
 
+vector: true
+
 input-flags: '-i fjson'
 output-flags: '-f json -pretty=0'
 
@@ -13,6 +15,8 @@ output: *input
 
 spq: defuse(this)
 
+vector: true
+
 input-flags: '-i fjson'
 output-flags: '-f json -pretty=0'
 
@@ -25,6 +29,8 @@ output: *input
 ---
 
 spq: defuse(this)
+
+vector: true
 
 input-flags: '-i fjson'
 output-flags: '-f json -pretty=0'

--- a/vector/empty.go
+++ b/vector/empty.go
@@ -3,6 +3,7 @@ package vector
 import (
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/scode"
+	"github.com/brimdata/super/sup"
 )
 
 // An Empty vector represents a vector with a type of zero length.
@@ -20,7 +21,48 @@ func NewEmpty(typ super.Type) *Empty {
 }
 
 func (e *Empty) Kind() Kind {
-	panic(e)
+	switch e.typ.(type) {
+	case *super.TypeOfUint8, *super.TypeOfUint16, *super.TypeOfUint32, *super.TypeOfUint64:
+		return KindUint
+	case *super.TypeOfInt8, *super.TypeOfInt16, *super.TypeOfInt32, *super.TypeOfInt64, *super.TypeOfDuration, *super.TypeOfTime:
+		return KindInt
+	case *super.TypeOfFloat16, *super.TypeOfFloat32, *super.TypeOfFloat64:
+		return KindFloat
+	case *super.TypeOfBool:
+		return KindBool
+	case *super.TypeOfBytes:
+		return KindBytes
+	case *super.TypeOfString:
+		return KindString
+	case *super.TypeOfIP:
+		return KindIP
+	case *super.TypeOfNet:
+		return KindNet
+	case *super.TypeOfType:
+		return KindType
+	case *super.TypeOfNull:
+		return KindNull
+	case *super.TypeOfNone:
+		return KindNone
+	case *super.TypeRecord:
+		return KindRecord
+	case *super.TypeArray:
+		return KindArray
+	case *super.TypeSet:
+		return KindSet
+	case *super.TypeMap:
+		return KindMap
+	case *super.TypeUnion:
+		return KindUnion
+	case *super.TypeEnum:
+		return KindEnum
+	case *super.TypeError:
+		return KindError
+	case *super.TypeFusion:
+		return KindFusion
+	default:
+		panic(sup.String(e.typ))
+	}
 }
 
 func (e *Empty) Type() super.Type {

--- a/vector/union.go
+++ b/vector/union.go
@@ -1,11 +1,13 @@
 package vector
 
 import (
+	"fmt"
 	"slices"
 	"sync"
 
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/scode"
+	"github.com/brimdata/super/sup"
 )
 
 type Union struct {
@@ -18,7 +20,28 @@ type Union struct {
 var _ Any = (*Union)(nil)
 
 func NewUnion(typ *super.TypeUnion, tags []uint32, vals []Any) *Union {
+	verifyUnion(typ, vals)
 	return &Union{dynamic: NewDynamic(tags, vals), Typ: typ}
+}
+
+func NewUnionOfOne(typ *super.TypeUnion, vec Any) *Union {
+	tag := typ.TagOf(vec.Type())
+	if tag < 0 {
+		panic(fmt.Sprintf("trying to put %s inside %s", sup.String(vec.Type()), sup.String(typ)))
+	}
+	tags := make([]uint32, vec.Len())
+	for k := range tags {
+		tags[k] = uint32(tag)
+	}
+	vecs := make([]Any, len(typ.Types))
+	for k, typ := range typ.Types {
+		if k == tag {
+			vecs[k] = vec
+		} else {
+			vecs[k] = NewEmpty(typ)
+		}
+	}
+	return NewUnion(typ, tags, vecs)
 }
 
 func NewUnionFromDynamic(sctx *super.Context, d *Dynamic) *Union {
@@ -34,6 +57,7 @@ func NewUnionFromDynamic(sctx *super.Context, d *Dynamic) *Union {
 }
 
 func NewUnionFromRLE(typ *super.TypeUnion, rle []uint32, vecs []Any) *Union {
+	verifyUnion(typ, vecs)
 	return &Union{dynamic: NewDynamic(nil, vecs), rle: rle, Typ: typ}
 }
 
@@ -68,6 +92,27 @@ func NewUnionOptionRLE(sctx *super.Context, vec Any, length uint32, runlens []ui
 	//XXX we should use the RLEs only when substantially smaller than tags
 	vecs := []Any{vec, NewNone(noneLength(runlens))}
 	return NewUnionFromRLE(optionType, runlens, vecs)
+}
+
+// verifyUnion verifies that a created union:
+// 1. Has a vector for every type in the union.
+// 2. There are not multiple vectors with the same type.
+func verifyUnion(utyp *super.TypeUnion, vecs []Any) {
+	if len(utyp.Types) != len(vecs) {
+		panic("NewUnion: must have one vector for each type")
+	}
+	seen := make(map[super.Type]struct{})
+	for _, vec := range vecs {
+		typ := vec.Type()
+		if utyp.TagOf(typ) == -1 {
+			panic(fmt.Sprintf("NewUnion: type %s not a member of union %s", sup.FormatType(vec.Type()), sup.FormatType(utyp)))
+		}
+		if _, ok := seen[typ]; ok {
+			panic(fmt.Sprintf("NewUnion: multiple vectors with the same type %s", sup.FormatType(typ)))
+		}
+		seen[typ] = struct{}{}
+	}
+
 }
 
 func (*Union) Kind() Kind {

--- a/vector/union_test.go
+++ b/vector/union_test.go
@@ -1,0 +1,40 @@
+package vector
+
+import (
+	"testing"
+
+	"github.com/brimdata/super"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewUnionVerifyPanics(t *testing.T) {
+	sctx := super.NewContext()
+	intVec := NewInt(super.TypeInt64, nil)
+	utyp, _ := sctx.LookupTypeUnion([]super.Type{super.TypeInt64, super.TypeString})
+	require.PanicsWithValue(t, "NewUnion: must have one vector for each type", func() {
+		NewUnion(utyp, nil, []Any{intVec})
+	})
+	require.PanicsWithValue(t, "NewUnion: multiple vectors with the same type int64", func() {
+		NewUnion(utyp, nil, []Any{intVec, intVec})
+	})
+	ipVec := NewIP(nil)
+	require.PanicsWithValue(t, "NewUnion: type ip not a member of union int64|string", func() {
+		NewUnion(utyp, nil, []Any{intVec, ipVec})
+	})
+}
+
+func TestNewUnionFromRLEVerifyPanics(t *testing.T) {
+	sctx := super.NewContext()
+	intVec := NewInt(super.TypeInt64, nil)
+	utyp, _ := sctx.LookupTypeUnion([]super.Type{super.TypeInt64, super.TypeString})
+	require.PanicsWithValue(t, "NewUnion: must have one vector for each type", func() {
+		NewUnionFromRLE(utyp, nil, []Any{intVec})
+	})
+	require.PanicsWithValue(t, "NewUnion: multiple vectors with the same type int64", func() {
+		NewUnionFromRLE(utyp, nil, []Any{intVec, intVec})
+	})
+	ipVec := NewIP(nil)
+	require.PanicsWithValue(t, "NewUnion: type ip not a member of union int64|string", func() {
+		NewUnionFromRLE(utyp, nil, []Any{intVec, ipVec})
+	})
+}

--- a/vector/view.go
+++ b/vector/view.go
@@ -1,6 +1,7 @@
 package vector
 
 import (
+	"github.com/brimdata/super"
 	"github.com/brimdata/super/scode"
 )
 
@@ -21,4 +22,54 @@ func (v *View) Len() uint32 {
 
 func (v *View) Serialize(b *scode.Builder, slot uint32) {
 	v.Any.Serialize(b, v.Index[slot])
+}
+
+func PushView(val Any) Any {
+	view, ok := val.(*View)
+	if !ok {
+		return val
+	}
+	if view.Len() == 0 {
+		return NewEmpty(view.Type())
+	}
+	switch val := view.Any.(type) {
+	case *Record:
+		var fields []Any
+		for _, field := range val.Fields {
+			fields = append(fields, Pick(field, view.Index))
+		}
+		return NewRecord(val.Typ, fields, view.Len())
+	case *Array:
+		inner, offsets := pickList(val.Values, view.Index, val.Offsets)
+		return NewArray(val.Typ, offsets, inner)
+	case *Set:
+		inner, offsets := pickList(val.Values, view.Index, val.Offsets)
+		return NewSet(val.Typ, offsets, inner)
+	case *Map:
+		keys, offsets := pickList(val.Keys, view.Index, val.Offsets)
+		values, _ := pickList(val.Values, view.Index, val.Offsets)
+		return NewMap(val.Typ, offsets, keys, values)
+	case *Fusion:
+		types := val.Subtypes.Types()
+		outTypes := make([]super.Type, len(view.Index))
+		for i, slot := range view.Index {
+			outTypes[i] = types[slot]
+		}
+		return NewFusion(val.Sctx, val.Typ, Pick(val.Values, view.Index), outTypes)
+	default:
+		return view
+	}
+}
+
+func pickList(inner Any, index, offsets []uint32) (Any, []uint32) {
+	newOffsets := []uint32{0}
+	var innerIndex []uint32
+	for _, idx := range index {
+		start, end := offsets[idx], offsets[idx+1]
+		for ; start < end; start++ {
+			innerIndex = append(innerIndex, start)
+		}
+		newOffsets = append(newOffsets, uint32(len(innerIndex)))
+	}
+	return Pick(inner, innerIndex), newOffsets
 }


### PR DESCRIPTION
This commit adds a check on creation of union vectors that ensures that union vectors have one and only one vector for every type in the union and panics if the invariant is not met.