### PR TITLE
vbuild: Support recursive named types

### DIFF
--- a/vector/vbuild/builder.go
+++ b/vector/vbuild/builder.go
@@ -88,7 +88,7 @@ func New(typ super.Type) Builder {
 	case *super.TypeError:
 		return &errorBuilder{vals: New(typ.Type)}
 	case *super.TypeNamed:
-		return &namedBuilder{name: typ.Name, vals: New(typ.Type)}
+		return newNamedBuilder(typ)
 	case *super.TypeFusion:
 		return newFusionBuilder(typ)
 	default:

--- a/vector/vbuild/named.go
+++ b/vector/vbuild/named.go
@@ -6,19 +6,30 @@ import (
 )
 
 type namedBuilder struct {
-	name string
+	typ  *super.TypeNamed
 	vals Builder
 }
 
+func newNamedBuilder(typ *super.TypeNamed) Builder {
+	return &namedBuilder{typ: typ}
+}
+
 func (n *namedBuilder) Write(vec vector.Any) {
+	if vec.Len() == 0 {
+		return
+	}
+	if n.vals == nil {
+		n.vals = New(n.typ.Type)
+	}
 	n.vals.Write(vec.(*vector.Named).Any)
 }
 
 func (n *namedBuilder) Build(sctx *super.Context) vector.Any {
-	vals := n.vals.Build(sctx)
-	typ, err := sctx.LookupTypeNamed(n.name, vals.Type())
-	if err != nil {
-		panic(err)
+	var vec vector.Any
+	if n.vals != nil {
+		vec = n.vals.Build(sctx)
+	} else {
+		vec = vector.NewEmpty(n.typ.Type)
 	}
-	return vector.NewNamed(typ, vals)
+	return vector.NewNamed(n.typ, vec)
 }


### PR DESCRIPTION
This commit adds support for recursive named types in package vbuild by only creating a Builder in a named type when values arrive and returning Empty(typ) if no value is recieved.