### PR TITLE
fix HasFusion for union types

### DIFF
--- a/runtime/sam/expr/function/defuse.go
+++ b/runtime/sam/expr/function/defuse.go
@@ -174,6 +174,8 @@ func (d *Defuse) HasFusion(typ super.Type) bool {
 		has = d.HasFusion(typ.Type)
 	case *super.TypeSet:
 		has = d.HasFusion(typ.Type)
+	case *super.TypeUnion:
+		has = slices.ContainsFunc(typ.Types, func(t super.Type) bool { return d.HasFusion(t) })
 	case *super.TypeMap:
 		has = d.HasFusion(typ.KeyType) || d.HasFusion(typ.ValType)
 	case *super.TypeError:

--- a/runtime/sam/expr/function/defuse.go
+++ b/runtime/sam/expr/function/defuse.go
@@ -175,7 +175,7 @@ func (d *Defuse) HasFusion(typ super.Type) bool {
 	case *super.TypeSet:
 		has = d.HasFusion(typ.Type)
 	case *super.TypeUnion:
-		has = slices.ContainsFunc(typ.Types, func(t super.Type) bool { return d.HasFusion(t) })
+		has = slices.ContainsFunc(typ.Types, d.HasFusion)
 	case *super.TypeMap:
 		has = d.HasFusion(typ.KeyType) || d.HasFusion(typ.ValType)
 	case *super.TypeError:


### PR DESCRIPTION
This commit fixes HasFusion for union types.

HasFusion previously returned false for unions that had descendents with fusion types.  Since type fusion wraps such unions in fusion types, this behavior doesn't create any current problems but it is odd not to include this case here and is confusing during debugging when such conditions arise.