### PR TITLE
vector.TypeValue: remove unneeded sctx to NewTypeValue

### DIFF
--- a/runtime/vam/expr/agg/fuse.go
+++ b/runtime/vam/expr/agg/fuse.go
@@ -63,7 +63,7 @@ func (f *fuse) Result(sctx *super.Context) vector.Any {
 	for _, typ := range f.types {
 		fuser.Fuse(typ)
 	}
-	return vector.NewTypeValue(sctx, []super.Type{fuser.Type()})
+	return vector.NewTypeValue([]super.Type{fuser.Type()})
 }
 
 func (f *fuse) ConsumeAsPartial(partial vector.Any) {

--- a/runtime/vam/expr/cast/type.go
+++ b/runtime/vam/expr/cast/type.go
@@ -12,7 +12,7 @@ func castToType(sctx *super.Context, vec vector.Any, index []uint32) (vector.Any
 		return vec, nil, "", true
 	case *vector.String:
 		n := lengthOf(vec, index)
-		out := vector.NewTypeValueEmpty(sctx)
+		out := vector.NewTypeValueEmpty()
 		var errs []uint32
 		for i := range n {
 			idx := i

--- a/runtime/vam/expr/dot.go
+++ b/runtime/vam/expr/dot.go
@@ -48,7 +48,7 @@ func (d *DotExpr) eval(vecs ...vector.Any) vector.Any {
 		return val.Fields[i]
 	case *vector.TypeValue:
 		var errs []uint32
-		typvals := vector.NewTypeValueEmpty(d.sctx)
+		typvals := vector.NewTypeValueEmpty()
 		for i := range val.Len() {
 			typ := val.Value(i)
 			if typ, ok := super.TypeUnder(typ).(*super.TypeRecord); ok {

--- a/runtime/vam/expr/function/types.go
+++ b/runtime/vam/expr/function/types.go
@@ -170,7 +170,7 @@ func (t *TypeName) Call(args ...vector.Any) vector.Any {
 		return vector.NewWrappedError(t.sctx, "typename: argument must be a string", args[0])
 	}
 	var errs []uint32
-	out := vector.NewTypeValueEmpty(t.sctx)
+	out := vector.NewTypeValueEmpty()
 	for i := range vec.Len() {
 		s := vector.StringValue(vec, i)
 		if typ := t.sctx.LookupByName(s); typ == nil {

--- a/runtime/vam/expr/function/under.go
+++ b/runtime/vam/expr/function/under.go
@@ -34,7 +34,7 @@ func (u *Under) Call(args ...vector.Any) vector.Any {
 	case *vector.Union:
 		return vec.Dynamic()
 	case *vector.TypeValue:
-		typs := vector.NewTypeValueEmpty(u.sctx)
+		typs := vector.NewTypeValueEmpty()
 		for i := range vec.Len() {
 			typs.Append(super.TypeUnder(vec.Value(i)))
 		}

--- a/runtime/vam/expr/function/upcast.go
+++ b/runtime/vam/expr/function/upcast.go
@@ -280,5 +280,5 @@ func (u *Upcast) toFusion(vec vector.Any, to *super.TypeFusion) vector.Any {
 	for i := range subtypes {
 		subtypes[i] = typ
 	}
-	return vector.NewFusion(u.sctx, to, values, subtypes)
+	return vector.NewFusion(to, values, subtypes)
 }

--- a/vector/const.go
+++ b/vector/const.go
@@ -67,7 +67,7 @@ func NewConstNet(v netip.Prefix, length uint32) *Const {
 	return &Const{vec, length}
 }
 func NewConstType(sctx *super.Context, typ super.Type, length uint32) *Const {
-	vec := NewTypeValue(sctx, []super.Type{typ})
+	vec := NewTypeValue([]super.Type{typ})
 	return &Const{vec, length}
 }
 

--- a/vector/fusion.go
+++ b/vector/fusion.go
@@ -6,7 +6,6 @@ import (
 )
 
 type Fusion struct {
-	Sctx   *super.Context
 	Typ    *super.TypeFusion
 	Values Any
 	// The TypeValue vectors are always created as typedefs, whether
@@ -20,12 +19,12 @@ type Fusion struct {
 
 var _ Any = (*Fusion)(nil)
 
-func NewFusion(sctx *super.Context, typ *super.TypeFusion, vals Any, subtypes []super.Type) *Fusion {
-	return &Fusion{Sctx: sctx, Typ: typ, Values: vals, Subtypes: NewTypeValue(sctx, subtypes)}
+func NewFusion(typ *super.TypeFusion, vals Any, subtypes []super.Type) *Fusion {
+	return &Fusion{Typ: typ, Values: vals, Subtypes: NewTypeValue(subtypes)}
 }
 
 func NewFusionWithLoader(sctx *super.Context, typ *super.TypeFusion, loader TypesLoader, vals Any) *Fusion {
-	return &Fusion{Sctx: sctx, Typ: typ, Values: vals, Subtypes: NewTypeValueWithLoader(sctx, loader)}
+	return &Fusion{Typ: typ, Values: vals, Subtypes: NewTypeValueWithLoader(sctx, loader)}
 }
 
 func (*Fusion) Kind() Kind {

--- a/vector/type.go
+++ b/vector/type.go
@@ -8,8 +8,9 @@ import (
 )
 
 type TypeValue struct {
-	Sctx   *super.Context
-	mu     sync.Mutex
+	mu sync.Mutex
+	// sctx is only populated/needed if values are retrieved via the loader.
+	sctx   *super.Context
 	loader TypesLoader
 	types  []super.Type
 }
@@ -26,16 +27,16 @@ type TypesLoader interface {
 
 var _ Any = (*TypeValue)(nil)
 
-func NewTypeValue(sctx *super.Context, types []super.Type) *TypeValue {
-	return &TypeValue{Sctx: sctx, types: types}
+func NewTypeValue(types []super.Type) *TypeValue {
+	return &TypeValue{types: types}
 }
 
 func NewTypeValueWithLoader(sctx *super.Context, loader TypesLoader) *TypeValue {
-	return &TypeValue{Sctx: sctx, loader: loader}
+	return &TypeValue{sctx: sctx, loader: loader}
 }
 
-func NewTypeValueEmpty(sctx *super.Context) *TypeValue {
-	return &TypeValue{Sctx: sctx}
+func NewTypeValueEmpty() *TypeValue {
+	return &TypeValue{}
 }
 
 func (t *TypeValue) Append(typ super.Type) {
@@ -99,7 +100,7 @@ func (t *TypeValue) Types() []super.Type {
 	if t.types == nil {
 		defs, ids := t.typeIDs()
 		t.types = make([]super.Type, len(ids))
-		mapper := super.NewTypeDefsMapper(t.Sctx, defs)
+		mapper := super.NewTypeDefsMapper(t.sctx, defs)
 		for i, id := range ids {
 			t.types[i] = mapper.LookupType(id)
 			if t.types[i] == nil {

--- a/vector/valuebuilder.go
+++ b/vector/valuebuilder.go
@@ -280,7 +280,7 @@ func (f *fusionValueBuilder) Build(sctx *super.Context) Any {
 		}
 		types = append(types, t)
 	}
-	return NewFusion(sctx, f.typ, f.values.Build(sctx), types)
+	return NewFusion(f.typ, f.values.Build(sctx), types)
 }
 
 type enumValueBuilder struct {
@@ -378,7 +378,7 @@ func (t *typeValueValueBuilder) Build(sctx *super.Context) Any {
 			panic("bad type value")
 		}
 	}
-	return NewTypeValue(sctx, types)
+	return NewTypeValue(types)
 }
 
 type bytesStringValueBuilder struct {

--- a/vector/vbuild/builder.go
+++ b/vector/vbuild/builder.go
@@ -68,7 +68,7 @@ func New(typ super.Type) Builder {
 		return &genericBuilder[super.Type]{
 			valuesOf: func(vec vector.Any) []super.Type { return vec.(*vector.TypeValue).Types() },
 			build: func(sctx *super.Context, vals []super.Type) vector.Any {
-				return vector.NewTypeValue(sctx, vals)
+				return vector.NewTypeValue(vals)
 			},
 		}
 	case *super.TypeOfNull:

--- a/vector/vbuild/fusion.go
+++ b/vector/vbuild/fusion.go
@@ -35,5 +35,5 @@ func (f *fusionBuilder) Write(vec vector.Any) {
 
 func (f *fusionBuilder) Build(sctx *super.Context) vector.Any {
 	vals := f.vals.Build(sctx)
-	return vector.NewFusion(sctx, f.typ, vals, f.subtypes)
+	return vector.NewFusion(f.typ, vals, f.subtypes)
 }

--- a/vector/view.go
+++ b/vector/view.go
@@ -55,7 +55,7 @@ func PushView(val Any) Any {
 		for i, slot := range view.Index {
 			outTypes[i] = types[slot]
 		}
-		return NewFusion(val.Sctx, val.Typ, Pick(val.Values, view.Index), outTypes)
+		return NewFusion(val.Typ, Pick(val.Values, view.Index), outTypes)
 	default:
 		return view
 	}


### PR DESCRIPTION
This commits removes the unnecessary Sctx passed into both NewTypeValue and NewTypeValueEmpty. The super Context is only required when creating a TypeValue vector with the Loader pattern.

Also remove unncessary Sctx argument from Fusion vectors.