### PR TITLE
semantic: resolve table-qualified column refs over dynamic joins

### DIFF
--- a/compiler/semantic/scope.go
+++ b/compiler/semantic/scope.go
@@ -187,6 +187,23 @@ func (s *Scope) resolve(t *translator, n ast.Node, path field.Path, inType super
 	}
 	out, dyn, err := scope.resolveUnqualified(path[0])
 	if err != nil {
+		// A multi-element path that fails unqualified resolution may still
+		// be a valid qualified (table.column) reference; the leading name
+		// only looked like an unqualified column. This happens for joins
+		// over dynamic inputs, where any name resolves as a dynamic column,
+		// so a real table-qualified reference like "a.id" would otherwise
+		// be rejected with a misleading error.
+		if len(path) >= 2 {
+			q, qerr := scope.resolveQualified(path[0], path[1])
+			if qerr != nil {
+				t.error(n, qerr)
+				return badExpr, t.checker.unknown
+			}
+			if q != nil {
+				this := sem.NewThis(n, append(q, path[2:]...))
+				return this, t.checker.this(n, this, inType)
+			}
+		}
 		t.error(n, err)
 		return badExpr, t.checker.unknown
 	}

--- a/compiler/ztests/sql/join-dynamic-qualified.yaml
+++ b/compiler/ztests/sql/join-dynamic-qualified.yaml
@@ -1,0 +1,18 @@
+script: |
+  super -s -dynamic -c "SELECT a.x FROM 'a.sup' AS a JOIN 'b.sup' AS b ON a.id = b.id"
+
+inputs:
+  - name: a.sup
+    data: |
+      {x:1,id:1}
+      {x:2,id:2}
+  - name: b.sup
+    data: |
+      {y:10,id:1}
+      {y:20,id:2}
+
+outputs:
+  - name: stdout
+    data: |
+      {x:1}
+      {x:2}


### PR DESCRIPTION
Closes #6974.

`resolveExpr` resolves a column reference unqualified-first: `path[0]` is looked up as a column before being treated as a table qualifier. For a join over dynamic inputs, every name resolves as a dynamic column, so `joinScope.resolveUnqualified` raises `join on dynamic column %q requires table-qualified reference` for the leading name of `a.id`. That error is returned immediately, before the qualified (`table.column`) resolution further down ever runs.

So a query whose references are already table-qualified fails under `-dynamic` with an error claiming they aren't:

```
$ super -s -dynamic -c "SELECT a.x FROM 'a.json' AS a JOIN 'b.json' AS b ON a.id = b.id"
join on dynamic column "a" requires table-qualified reference at line 1, column 53:
...
```

The same query works without `-dynamic`.

The fix: when unqualified resolution fails on a multi-element path, try resolving it as a qualified reference before surfacing the error. A genuinely unqualified dynamic column in a join is a single-element path (`ON id = id`), so that case still reports the original error, and `compiler/ztests/sql/join-dynamic-err.yaml` still passes. Added `join-dynamic-qualified.yaml` covering the fixed case.