### PR TITLE
sam: fix bool comparison with <= and >=

### DIFF
--- a/runtime/sam/expr/eval.go
+++ b/runtime/sam/expr/eval.go
@@ -323,12 +323,8 @@ func (c *Compare) Eval(this super.Value) super.Value {
 	case lid != rid:
 		return super.False
 	case lid == super.IDBool:
-		if lhs.Bool() {
-			if rhs.Bool() {
-				return c.result(0)
-			}
-
-		}
+		v := lhs.Bool() == rhs.Bool() && (c.operator == "<=" || c.operator == ">=")
+		return super.NewBool(v)
 	case lid == super.IDBytes:
 		return c.result(bytes.Compare(super.DecodeBytes(lhs.Bytes()), super.DecodeBytes(rhs.Bytes())))
 	case lid == super.IDString:

--- a/runtime/sam/expr/expr_test.go
+++ b/runtime/sam/expr/expr_test.go
@@ -242,12 +242,6 @@ type port=uint16
 }
 `
 
-	// bool
-	testSuccessful(t, "b == true", record, "true")
-	testSuccessful(t, "b == false", record, "false")
-	testSuccessful(t, "b != true", record, "false")
-	testSuccessful(t, "b != false", record, "true")
-
 	// string
 	testSuccessful(t, `s == "hello"`, record, "true")
 	testSuccessful(t, `s != "hello"`, record, "false")

--- a/runtime/ztests/expr/compare.yaml
+++ b/runtime/ztests/expr/compare.yaml
@@ -1,5 +1,21 @@
 spq: values [a==b, a!=b, a<b, a<=b, a>=b, a>b]
 
+input: |
+  {a:false,b:false}
+  {a:false,b:true}
+  {a:true,b:false}
+  {a:true,b:true}
+
+output: |
+  [true,false,false,true,true,false]
+  [false,true,false,false,false,false]
+  [false,true,false,false,false,false]
+  [true,false,false,true,true,false]
+
+---
+
+spq: values [a==b, a!=b, a<b, a<=b, a>=b, a>b]
+
 vector: true
 
 input: |


### PR DESCRIPTION
Comparison of bool values with <= or >= always evaluates to false. Fix so the result is true when the values are equal.