### PR TITLE
vam: fix panic on upcast from union to union

### DIFF
--- a/runtime/vam/expr/function/upcast.go
+++ b/runtime/vam/expr/function/upcast.go
@@ -212,11 +212,18 @@ func (u *Upcast) toMap(vec vector.Any, to *super.TypeMap) vector.Any {
 
 func (u *Upcast) toUnion(vec vector.Any, to *super.TypeUnion) vector.Any {
 	if unionVec, ok := vec.(*vector.Union); ok {
-		values := make([]vector.Any, len(unionVec.Values()))
-		for i, vec := range unionVec.Values() {
-			values[i] = u.toUnionValue(vec, to)
-			if values[i] == nil {
+		values := make([]vector.Any, len(to.Types))
+		for _, vec := range unionVec.Values() {
+			vec = u.toUnionValue(vec, to)
+			if vec == nil {
 				return nil
+			}
+			tag := to.TagOf(vec.Type())
+			values[tag] = vec
+		}
+		for i := range values {
+			if values[i] == nil {
+				values[i] = vector.NewEmpty(to.Types[i])
 			}
 		}
 		//XXX We should copy RLE instead of making tags when we can.

--- a/runtime/vam/expr/function/upcast.go
+++ b/runtime/vam/expr/function/upcast.go
@@ -212,18 +212,19 @@ func (u *Upcast) toMap(vec vector.Any, to *super.TypeMap) vector.Any {
 
 func (u *Upcast) toUnion(vec vector.Any, to *super.TypeUnion) vector.Any {
 	if unionVec, ok := vec.(*vector.Union); ok {
-		values := make([]vector.Any, len(to.Types))
+		types := map[super.Type]struct{}{}
+		values := make([]vector.Any, 0, len(to.Types))
 		for _, vec := range unionVec.Values() {
 			vec = u.toUnionValue(vec, to)
 			if vec == nil {
 				return nil
 			}
-			tag := to.TagOf(vec.Type())
-			values[tag] = vec
+			types[vec.Type()] = struct{}{}
+			values = append(values, vec)
 		}
-		for i := range values {
-			if values[i] == nil {
-				values[i] = vector.NewEmpty(to.Types[i])
+		for _, typ := range to.Types {
+			if _, ok := types[typ]; !ok {
+				values = append(values, vector.NewEmpty(typ))
 			}
 		}
 		//XXX We should copy RLE instead of making tags when we can.

--- a/runtime/ztests/expr/fuser.yaml
+++ b/runtime/ztests/expr/fuser.yaml
@@ -9,6 +9,8 @@ output: *input
 
 spq: fuse | defuse(this)
 
+vector: true
+
 input: &input |
   "foo"::(int64|string)
   type named1=string


### PR DESCRIPTION
Fix a panic in vam/expr/funciton.Upcast.toUnion when upcasting from one union type to another by ensuring that the call to vector.NewUnion receives one vector per type in the target union.