### PR TITLE
ztest: always run YAML SPQ-style tests with sam and vam

### DIFF
--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -176,6 +176,9 @@ func Load(dirname string) ([]Bundle, error) {
 			continue
 		}
 		for _, zt := range zts {
+			if zt.SPQ != "" {
+				zt.Vector = true
+			}
 			bundles = append(bundles, Bundle{filename, zt, nil})
 		}
 	}


### PR DESCRIPTION
Always run SPQ-style tests loaded from YAML with both sam and vam regardless of the value of the vector key.

This does not affect ztests not loaded from YAML (namely those in runtime/sam/expr/expr_test.go, runtime/sam/expr/functions_test.go, and runtime/sam/op/sort/sort_test.go).