### PR TITLE
ztest: replace vector YAML key with runtime

### DIFF
--- a/compiler/ztests/lift-filters.yaml
+++ b/compiler/ztests/lift-filters.yaml
@@ -1,3 +1,5 @@
+runtime: sam
+
 script: |
   super compile -C -O -dynamic 'from f | values {a:b,c:d} | where a==1 and c==2'
   echo ===

--- a/compiler/ztests/merge-filters.yaml
+++ b/compiler/ztests/merge-filters.yaml
@@ -1,3 +1,5 @@
+runtime: sam
+
 script: |
   super compile -C -O 'from /dev/null | where a | where b'
   echo ===

--- a/compiler/ztests/pushdown.yaml
+++ b/compiler/ztests/pushdown.yaml
@@ -1,3 +1,5 @@
+runtime: sam
+
 script: |
   echo === debug
   super compile -C -O 'from /dev/null | debug a | values b'

--- a/compiler/ztests/remove-passops.yaml
+++ b/compiler/ztests/remove-passops.yaml
@@ -1,3 +1,5 @@
+runtime: sam
+
 script: super compile -O -C 'from /dev/null | x>1 | pass | pass | x>2 | pass'
 
 outputs:

--- a/compiler/ztests/repeated-from-subquery.yaml
+++ b/compiler/ztests/repeated-from-subquery.yaml
@@ -1,7 +1,5 @@
 script: super -s -c "values 1,2,3 | {x:[cross join (from in.sup)]}"
 
-vector: true
-
 inputs:
   - name: in.sup
     data: |

--- a/compiler/ztests/runtime-select.yaml
+++ b/compiler/ztests/runtime-select.yaml
@@ -1,3 +1,5 @@
+runtime: sam
+
 script: |
   # Check the environment variable works.
   SUPER_RUNTIME=vam super compile -dag -C -runtime 'values "foo"'

--- a/compiler/ztests/sql/cte.yaml
+++ b/compiler/ztests/sql/cte.yaml
@@ -4,8 +4,6 @@ script: |
   super -s -c 'with x as ( select 1 as y ) select z.y from x as z'
   ! super -c 'with x as ( select 1 as y ), x as ( select 2 as y ) select * from x'
 
-vector: true
-
 inputs:
   - name: sales.spq
     data: |

--- a/compiler/ztests/sql/subqueries.yaml
+++ b/compiler/ztests/sql/subqueries.yaml
@@ -16,8 +16,6 @@ script: |
   # pass errors through unmodified, i.e., do not turn into missing
   super -s -c "select (values error('foo')) as e"
 
-vector: true
-
 outputs:
   - name: stdout
     data: |

--- a/csup/ztests/empty-file.yaml
+++ b/csup/ztests/empty-file.yaml
@@ -1,3 +1,5 @@
+runtime: sam
+
 script: |
   ! super -i csup /dev/null
 

--- a/db/ztests/consecutive-ts.yaml
+++ b/db/ztests/consecutive-ts.yaml
@@ -1,3 +1,5 @@
+runtime: sam
+
 script: |
   export SUPER_DB=test
   super db init -q

--- a/db/ztests/dirs.yaml
+++ b/db/ztests/dirs.yaml
@@ -1,3 +1,5 @@
+runtime: sam
+
 script: |
   export SUPER_DB=test
   super db init -q

--- a/runtime/sam/expr/expr_test.go
+++ b/runtime/sam/expr/expr_test.go
@@ -15,9 +15,10 @@ func testSuccessful(t *testing.T, e, input, expected string) {
 		input = "{}"
 	}
 	zt := ztest.ZTest{
-		SPQ:    fmt.Sprintf("values %s", e),
-		Input:  &input,
-		Output: expected + "\n",
+		Runtime: new("sam"),
+		SPQ:     fmt.Sprintf("values %s", e),
+		Input:   &input,
+		Output:  expected + "\n",
 	}
 	if err := zt.RunInternal(t.Context()); err != nil {
 		t.Fatal(err)

--- a/runtime/sam/op/meta/ztests/pruner.yaml
+++ b/runtime/sam/op/meta/ztests/pruner.yaml
@@ -1,4 +1,6 @@
-# This test makes sure the type context from metadata processing doesn't 
+runtime: sam
+
+# This test makes sure the type context from metadata processing doesn't
 # leak into the flowgraph, except for metaqueries, where it should.
 script: |
   export SUPER_DB=test

--- a/runtime/sam/op/ztests/rename-dynamic-field.yaml
+++ b/runtime/sam/op/ztests/rename-dynamic-field.yaml
@@ -1,3 +1,5 @@
+runtime: sam
+
 script: |
   echo '{target:"foo",src:"bar"} {target:"fool",src:"baz"}' | super -s -c 'rename this[target] := src' -
   echo '// ==='

--- a/runtime/ztests/expr/cut-dup-fields.yaml
+++ b/runtime/ztests/expr/cut-dup-fields.yaml
@@ -4,8 +4,6 @@ script: |
   ! super -s -c "cut rec.sub,rec.sub.sub" in.sup
   ! super -s -c "cut rec.sub.sub,rec.sub" in.sup
 
-vector: true
-
 inputs:
   - name: in.sup
     data: |

--- a/runtime/ztests/expr/cut-not-adjacent.yaml
+++ b/runtime/ztests/expr/cut-not-adjacent.yaml
@@ -4,8 +4,6 @@ script: |
   ! super -s -c "cut rec1.rec2.sub1,other,rec1.rec2.sub2" in.sup
   ! super -s -c "cut t.rec.sub1,t.other,t.rec.sub2" in.sup
 
-vector: true
-
 inputs:
   - name: in.sup
     data: |

--- a/runtime/ztests/expr/math-coerce.yaml
+++ b/runtime/ztests/expr/math-coerce.yaml
@@ -6,8 +6,6 @@ script: |
     done
   done
 
-vector: true
-
 inputs:
   - name: types.txt
     data: |

--- a/runtime/ztests/expr/port-math.yaml
+++ b/runtime/ztests/expr/port-math.yaml
@@ -5,8 +5,6 @@ script: |
   echo ===
   super -s -c "put x:=a+p1+p2" in.sup
 
-vector: true
-
 inputs:
   - name: in.sup
     data: |

--- a/runtime/ztests/expr/queryexpr-from-eval.yaml
+++ b/runtime/ztests/expr/queryexpr-from-eval.yaml
@@ -1,7 +1,5 @@
 script: super -s -I query.spq
 
-vector: true
-
 inputs:
   - name: query.spq
     data: |

--- a/runtime/ztests/op/aggregate/aggregate.yaml
+++ b/runtime/ztests/op/aggregate/aggregate.yaml
@@ -20,8 +20,6 @@ script: |
   echo === reverse-sorted-null ===
   super -s -c "count() by ts:=bucket(ts, 1s) | sort this" in-rev.sup
 
-vector: true
-
 inputs:
   - name: in.sup
     data: |

--- a/runtime/ztests/op/aggregate/args.yaml
+++ b/runtime/ztests/op/aggregate/args.yaml
@@ -4,8 +4,6 @@ script: |
     ! super -s -c "$agg()" in.sup
   done
 
-vector: true
-
 inputs:
   - name: in.sup
     data: "{}"

--- a/runtime/ztests/op/aggregate/collect-partial-view.yaml
+++ b/runtime/ztests/op/aggregate/collect-partial-view.yaml
@@ -3,8 +3,6 @@
 script: |
   super -s -c 'from "test.sup" | collect(a) by b | sort b'
 
-vector: true
-
 inputs:
   - name: test.sup
     data: |

--- a/runtime/ztests/op/aggregate/container-partials.yaml
+++ b/runtime/ztests/op/aggregate/container-partials.yaml
@@ -6,8 +6,6 @@ script: |
   super -s -c "union(x) by key with -limit 1 | sort key" in.sup > union.sup
   super -s -c "collect(x) by key with -limit 1 | sort key" in.sup > collect.sup
 
-vector: true
-
 inputs:
   - name: in.sup
     data: |

--- a/runtime/ztests/op/aggregate/container.yaml
+++ b/runtime/ztests/op/aggregate/container.yaml
@@ -2,8 +2,6 @@ script: |
   super -s -c "union(x)" in.sup > union.sup
   super -s -c "collect(x)" in.sup > collect.sup
 
-vector: true
-
 inputs:
   - name: in.sup
     data: |

--- a/runtime/ztests/op/aggregate/distinct-partials.yaml
+++ b/runtime/ztests/op/aggregate/distinct-partials.yaml
@@ -8,8 +8,6 @@ script: |
       sum(distinct n) by key
     | sort key'
 
-vector: true
-
 inputs:
   - name: test.sup
     data: |

--- a/runtime/ztests/op/aggregate/math-partials.yaml
+++ b/runtime/ztests/op/aggregate/math-partials.yaml
@@ -7,8 +7,6 @@ script: |
   super -s -c "min(n) by key with -limit 1 | sort key" in.sup > min.sup
   super -s -c "max(n) by key with -limit 1 | sort key" in.sup > max.sup
 
-vector: true
-
 inputs:
   - name: in.sup
     data: |

--- a/runtime/ztests/op/aggregate/math.yaml
+++ b/runtime/ztests/op/aggregate/math.yaml
@@ -8,8 +8,6 @@ script: |
   super -s -c "min(n)" in.sup > min.sup
   super -s -c "max(n)" in.sup > max.sup
 
-vector: true
-
 inputs:
   - name: in.sup
     data: |

--- a/runtime/ztests/op/count.yaml
+++ b/runtime/ztests/op/count.yaml
@@ -16,8 +16,6 @@ script: |
   >&2 echo // ===
   ! super -s -c 'count {foo:"foo",1}'
 
-vector: true
-
 outputs:
   - name: stdout
     data: |

--- a/runtime/ztests/op/cut-nested.yaml
+++ b/runtime/ztests/op/cut-nested.yaml
@@ -5,8 +5,6 @@ script: |
   echo ===
   super -s -c "cut rec1.sub1.foo,rec1['sub2']['bar'],rec2.foo,foo" nested2.sup
 
-vector: true
-
 inputs:
   - name: nested1.sup
     data: |

--- a/runtime/ztests/op/debug-filter.yaml
+++ b/runtime/ztests/op/debug-filter.yaml
@@ -2,8 +2,6 @@ script: |
   super -s -c 'values {x:1,y:2},{x:3,y:4} | debug {debug:y} filter (x=1)'
   super -s -c 'values {x:1,y:2},{x:3,y:4} | debug filter (x=1)'
 
-vector: true
-
 outputs:
   - name: stdout
     data: |

--- a/runtime/ztests/op/debug-into.yaml
+++ b/runtime/ztests/op/debug-into.yaml
@@ -3,8 +3,6 @@ script: |
   echo ===
   super -s -I q2.spq 2>&1 | super -s -c "sort this" -
 
-vector: true
-
 inputs:
   # from issue #6681
   - name: q1.spq

--- a/runtime/ztests/op/debug.yaml
+++ b/runtime/ztests/op/debug.yaml
@@ -1,8 +1,6 @@
 script: |
   super -s -c 'values "foo", "bar" | debug f"debug: {this}" | values f"{this}2" | head 1'
 
-vector: true
-
 outputs:
   - name: stdout
     data: |

--- a/runtime/ztests/op/distinct.yaml
+++ b/runtime/ztests/op/distinct.yaml
@@ -5,8 +5,6 @@ script: |
   echo ===
   super -s -c 'from "3.sup" | unnest this into (distinct this | count())'
 
-vector: true
-
 inputs:
   - name: 1.sup
     data: |

--- a/runtime/ztests/op/fuse-spill.yaml
+++ b/runtime/ztests/op/fuse-spill.yaml
@@ -2,8 +2,6 @@
 script: |
   super -s -fusemem 13B -c blend in.sup
 
-vector: true
-
 inputs:
   - name: in.sup
     data: |

--- a/runtime/ztests/op/join-empty-inner.yaml
+++ b/runtime/ztests/op/join-empty-inner.yaml
@@ -4,8 +4,6 @@ script: |
   echo === nested loop join
   super -dynamic -s -c 'left join (from C.sup) on left.a<right.a | values {...left,hit:right.sc} | sort' A.sup
 
-vector: true
-
 inputs:
   - name: A.sup
     data: |

--- a/runtime/ztests/op/join-from-pass.yaml
+++ b/runtime/ztests/op/join-from-pass.yaml
@@ -1,7 +1,5 @@
 script: super -s -I join.spq left.sup
 
-vector: true
-
 inputs:
   - name: join.spq
     data: |

--- a/runtime/ztests/op/join-kinds.yaml
+++ b/runtime/ztests/op/join-kinds.yaml
@@ -18,8 +18,6 @@ script: |
   echo === cross
   super -s -c 'cross join (from C.sup) | values {...left,...right} | sort b, sb, c' B.sup
 
-vector: true
-
 inputs:
   - name: A.sup
     data: |

--- a/runtime/ztests/op/join-stdin.yaml
+++ b/runtime/ztests/op/join-stdin.yaml
@@ -1,8 +1,6 @@
 script: |
   super -s -c 'join (from B.sup) on left.a=right.b | values {...left,b:right.b}' -
 
-vector: true
-
 inputs:
   - name: stdin
     data: |

--- a/runtime/ztests/op/join-subquery.yaml
+++ b/runtime/ztests/op/join-subquery.yaml
@@ -1,8 +1,6 @@
 script: |
   super -s -c 'from a.sup | inner join (from b.sup) on left.a=right.b | values left | sort'
 
-vector: true
-
 inputs:
   - name: a.sup
     data: |

--- a/runtime/ztests/op/join-union.yaml
+++ b/runtime/ztests/op/join-union.yaml
@@ -4,8 +4,6 @@ script: |
   echo // nested loop join
   super -s -c 'from a.sup | inner join (from b.sup) on left.a<right.b | values left | sort'
 
-vector: true
-
 inputs:
   - name: a.sup
     data: |

--- a/runtime/ztests/op/robot-array.yaml
+++ b/runtime/ztests/op/robot-array.yaml
@@ -1,8 +1,6 @@
 script: |
   super -s -c 'from which.sup | values "a"||val::string||".sup","a"||(val+1)::string||".sup" | select s from f"{this}"'
 
-vector: true
-
 inputs:
   - name: which.sup
     data: |

--- a/runtime/ztests/op/robot-basic.yaml
+++ b/runtime/ztests/op/robot-basic.yaml
@@ -1,8 +1,6 @@
 script: |
   super -s -c 'from files.sup | from f"{f}"'
 
-vector: true
-
 inputs:
   - name: files.sup
     data: |
@@ -25,8 +23,6 @@ outputs:
 
 script: |
   super -s -c 'values "a", "b" | ( from f"{this}.sup" | head 1 )'
-
-vector: true
 
 inputs:
   - name: a.sup

--- a/runtime/ztests/op/robot-example.yaml
+++ b/runtime/ztests/op/robot-example.yaml
@@ -5,8 +5,6 @@ script: |
   echo ===
   super -s -c 'from files.sup | select value this from [f]'
 
-vector: true
-
 inputs:
   - name: files.sup
     data: |

--- a/runtime/ztests/op/skip.yaml
+++ b/runtime/ztests/op/skip.yaml
@@ -3,8 +3,6 @@ script: |
   seq 1000 | super -s -c 'skip 900 | head 1' -
   ! super -c 'skip "hello"'
 
-vector: true
-
 outputs:
   - name: stdout
     data: |

--- a/runtime/ztests/op/user-errors.yaml
+++ b/runtime/ztests/op/user-errors.yaml
@@ -2,8 +2,6 @@ script: |
   ! super compile -dag -I error-duplicate-parameters.spq
   ! super compile -dag -I error-const-lhs.spq
 
-vector: true
-
 inputs:
   - name: error-duplicate-parameters.spq
     data: |

--- a/runtime/ztests/op/user-from.yaml
+++ b/runtime/ztests/op/user-from.yaml
@@ -1,8 +1,6 @@
 script: |
  super - | super -s -I test.spq
 
-vector: true
-
 inputs:
   - name: test.spq
     data: |

--- a/runtime/ztests/op/user-join.yaml
+++ b/runtime/ztests/op/user-join.yaml
@@ -12,8 +12,6 @@ script: |
   super db load -q -use people people.sup
   super db -s -I test.spq
 
-vector: true
-
 inputs:
   - name: test.spq
     data: |

--- a/sio/bsupio/ztests/pushdown-filter.yaml
+++ b/sio/bsupio/ztests/pushdown-filter.yaml
@@ -3,8 +3,6 @@ script: |
   super in.sup > test.bsup 
   super -s -c 'from test.bsup | where this'
 
-vector: true
-
 inputs:
   - name: in.sup
     data: |

--- a/sio/bsupio/ztests/zctx-named-reset-2.yaml
+++ b/sio/bsupio/ztests/zctx-named-reset-2.yaml
@@ -1,5 +1,6 @@
-# Test that type names are properly reset and reusable after stream boundaries.
+runtime: sam
 
+# Test that type names are properly reset and reusable after stream boundaries.
 script: |
   super -c "head 1" in.sup > t1.bsup
   super -c "tail 2" in.sup > t2.bsup

--- a/sio/csupio/ztests/issue-5736.yaml
+++ b/sio/csupio/ztests/issue-5736.yaml
@@ -12,8 +12,6 @@ script: |
         by event
     | sort -r count"
 
-vector: true
-
 inputs:
   - name: stdin
     data: |

--- a/sio/csupio/ztests/stdin-error.yaml
+++ b/sio/csupio/ztests/stdin-error.yaml
@@ -2,8 +2,6 @@ script: |
   super -f csup -o t.csup in.sup
   ! cat t.csup | super -i csup -
 
-vector: true
-
 inputs:
   - name: in.sup
     data: |

--- a/sio/parquetio/ztests/aggregate.yaml
+++ b/sio/parquetio/ztests/aggregate.yaml
@@ -1,8 +1,6 @@
 script: |
   super -s -c 'from conn.parquet | aggregate count()'
 
-vector: true
-
 inputs:
   - name: conn.parquet
 

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -176,9 +176,6 @@ func Load(dirname string) ([]Bundle, error) {
 			continue
 		}
 		for _, zt := range zts {
-			if zt.SPQ != "" {
-				zt.Vector = true
-			}
 			bundles = append(bundles, Bundle{filename, zt, nil})
 		}
 	}
@@ -266,9 +263,10 @@ func (f *File) load(dir string) ([]byte, *regexp.Regexp, error) {
 
 // ZTest defines a ztest.
 type ZTest struct {
-	Line int    `yaml:"-"`
-	Skip string `yaml:"skip,omitempty"`
-	Tag  string `yaml:"tag,omitempty"`
+	Line    int     `yaml:"-"`
+	Runtime *string `yaml:"runtime,omitempty"`
+	Skip    string  `yaml:"skip,omitempty"`
+	Tag     string  `yaml:"tag,omitempty"`
 
 	// For SPQ-style tests.
 	SPQ         string  `yaml:"spq,omitempty"`
@@ -287,6 +285,9 @@ type ZTest struct {
 }
 
 func (z *ZTest) check() error {
+	if r := z.Runtime; r != nil && *r != "sam" && *r != "vam" {
+		return fmt.Errorf(`unknown runtime %q: must be "sam" or "vam"`, *r)
+	}
 	if z.Script != "" {
 		if z.Outputs == nil {
 			return errors.New("outputs field missing in a sh test")
@@ -363,18 +364,19 @@ func (z *ZTest) run(fn func(exec.Runtime) error) error {
 	if err := z.check(); err != nil {
 		return fmt.Errorf("bad yaml format: %w", err)
 	}
-	serr := fn(exec.RuntimeSAM)
-	if !z.Vector {
-		return serr
+	r := z.Runtime
+	var samErr, vamErr error
+	if r == nil || *r == "sam" {
+		if err := fn(exec.RuntimeSAM); err != nil {
+			samErr = fmt.Errorf("=== sam ===\n%w", err)
+		}
 	}
-	if serr != nil {
-		serr = fmt.Errorf("=== sequence ===\n%w", serr)
+	if r == nil || *r == "vam" {
+		if err := fn(exec.RuntimeVAM); err != nil {
+			vamErr = fmt.Errorf("=== vam ===\n%w", err)
+		}
 	}
-	verr := fn(exec.RuntimeVAM)
-	if verr != nil {
-		verr = fmt.Errorf("=== vector ===\n%w", verr)
-	}
-	return errors.Join(serr, verr)
+	return errors.Join(samErr, vamErr)
 }
 
 func (z *ZTest) diffInternal(out string, err error) error {

--- a/ztest/ztest_test.go
+++ b/ztest/ztest_test.go
@@ -9,6 +9,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestRuntime(t *testing.T) {
+	ctx := t.Context()
+	assert.EqualError(t, (&ZTest{SPQ: ")"}).RunInternal(ctx), "=== sam ===\nexpected and actual error differ:\n--- expected\n+++ actual\n@@ -1 +1,4 @@\n+parse error at line 1, column 1:\n+)\n+^ ===\n \n\n=== vam ===\nexpected and actual error differ:\n--- expected\n+++ actual\n@@ -1 +1,4 @@\n+parse error at line 1, column 1:\n+)\n+^ ===\n \n")
+	assert.EqualError(t, (&ZTest{Runtime: new("sam"), SPQ: ")"}).RunInternal(ctx), "=== sam ===\nexpected and actual error differ:\n--- expected\n+++ actual\n@@ -1 +1,4 @@\n+parse error at line 1, column 1:\n+)\n+^ ===\n \n")
+	assert.EqualError(t, (&ZTest{Runtime: new("vam"), SPQ: ")"}).RunInternal(ctx), "=== vam ===\nexpected and actual error differ:\n--- expected\n+++ actual\n@@ -1 +1,4 @@\n+parse error at line 1, column 1:\n+)\n+^ ===\n \n")
+	assert.EqualError(t, (&ZTest{Runtime: new("bad"), SPQ: ")"}).RunInternal(ctx), `bad yaml format: unknown runtime "bad": must be "sam" or "vam"`)
+}
+
 func TestShouldSkip(t *testing.T) {
 	assert.Equal(t, "in-process test on script run", (&ZTest{SPQ: "x"}).ShouldSkip("y"))
 	assert.Equal(t, "script test on in-process run", (&ZTest{Script: "x"}).ShouldSkip(""))
@@ -48,6 +56,6 @@ func TestRunScript(t *testing.T) {
 			Script:  "echo 1; echo 2 >&2; exit 3",
 			Outputs: []File{},
 		}).RunScript(t.Context(), "", "", func() string { return "" })
-		assert.EqualError(t, err, "script failed: exit status 3\n=== stdout ===\n1\n=== stderr ===\n2\n")
+		assert.EqualError(t, err, "=== sam ===\nscript failed: exit status 3\n=== stdout ===\n1\n=== stderr ===\n2\n\n=== vam ===\nscript failed: exit status 3\n=== stdout ===\n1\n=== stderr ===\n2\n")
 	})
 }


### PR DESCRIPTION
Ztests now run under both sam and vam by default.  To limit a test to one runtime, add "runtime: sam" or "runtime: vam" to its YAML.

Note that "make test-system" takes nearly twice as long now because most script-style tests run twice (once under sam and once under vam).