### PR TITLE
fix(optimizer): avoid panic on join with bare this reference

### DIFF
--- a/compiler/optimizer/join.go
+++ b/compiler/optimizer/join.go
@@ -160,16 +160,20 @@ func equiJoinKeyExprs(e dag.Expr, leftAlias, rightAlias string) (left, right dag
 // firstThisPathComponent returns the first component common to every dag.This.Path
 // in e and a Boolean indicating whether such a common first component exists.
 func firstThisPathComponent(e dag.Expr) (prefix string, ok bool) {
+	first, valid := true, true
 	walkT(reflect.ValueOf(e), func(t dag.ThisExpr) dag.ThisExpr {
-		if prefix == "" {
+		// A bare this reference has no first component, so no common prefix can exist.
+		if len(t.Path) == 0 {
+			valid = false
+		} else if first {
 			prefix = t.Path[0]
-			ok = true
+			first = false
 		} else if prefix != t.Path[0] {
-			ok = false
+			valid = false
 		}
 		return t
 	})
-	return prefix, ok
+	return prefix, valid && !first
 }
 
 // stripFirstThisPathComponent removes the first component of every dag.This.Path in e.

--- a/compiler/optimizer/join_test.go
+++ b/compiler/optimizer/join_test.go
@@ -1,0 +1,38 @@
+package optimizer
+
+import (
+	"testing"
+
+	"github.com/brimdata/super/compiler/dag"
+)
+
+// TestFirstThisPathComponentEmptyPath verifies that a bare this reference (an
+// empty Path) does not panic and is reported as having no common first
+// component. See brimdata/super#6971.
+func TestFirstThisPathComponentEmptyPath(t *testing.T) {
+	e := &dag.BinaryExpr{
+		Kind: "BinaryExpr",
+		Op:   "==",
+		LHS:  &dag.ThisExpr{Kind: "This", Path: nil},
+		RHS:  &dag.ThisExpr{Kind: "This", Path: []string{"id"}},
+	}
+	_, ok := firstThisPathComponent(e)
+	if ok {
+		t.Fatalf("expected ok=false for expression containing a bare this reference")
+	}
+}
+
+// TestFirstThisPathComponentCommonPrefix verifies the normal case where every
+// this reference shares a first path component.
+func TestFirstThisPathComponentCommonPrefix(t *testing.T) {
+	e := &dag.BinaryExpr{
+		Kind: "BinaryExpr",
+		Op:   "==",
+		LHS:  &dag.ThisExpr{Kind: "This", Path: []string{"ducks", "id"}},
+		RHS:  &dag.ThisExpr{Kind: "This", Path: []string{"ducks", "name"}},
+	}
+	prefix, ok := firstThisPathComponent(e)
+	if !ok || prefix != "ducks" {
+		t.Fatalf("got prefix=%q ok=%v, want prefix=\"ducks\" ok=true", prefix, ok)
+	}
+}


### PR DESCRIPTION
Fixes #6971.

`firstThisPathComponent` indexed `t.Path[0]` unconditionally, so a bare `this` reference (empty Path) in a join key triggered `index out of range [0] with length 0` during optimization.

The empty Path now invalidates the common-prefix result instead of panicking, which matches the function's documented contract (returns false when no common first component exists). `equiJoinKeyExprs` then falls back gracefully and the join compiles. Added unit tests for the bare-`this` case and the normal shared-prefix case.