### PR TITLE
csup.Bool: Switch MemLength and Length

### DIFF
--- a/csup/bool.go
+++ b/csup/bool.go
@@ -39,8 +39,8 @@ func (b *BoolEncoder) Encode(group *errgroup.Group) {
 func (b *BoolEncoder) Metadata(cctx *Context, off uint64) (uint64, ID) {
 	loc := Segment{
 		Offset:            off,
-		MemLength:         uint64(len(b.out)),
-		Length:            b.bytesLen,
+		Length:            uint64(len(b.out)),
+		MemLength:         b.bytesLen,
 		CompressionFormat: b.fmt,
 	}
 	off += loc.Length


### PR DESCRIPTION
This commit fixes a bug with boolean vectors in the csup writer where the values Segment.MemLength and Segment.Length were switched.

Closes #6991