### PR TITLE
vam: don't rip unions in defuse()

### DIFF
--- a/runtime/vam/expr/function/defuse.go
+++ b/runtime/vam/expr/function/defuse.go
@@ -24,6 +24,8 @@ func newDefuse(sctx *super.Context) *defuse {
 	return d
 }
 
+func (*defuse) RipUnions() bool { return false }
+
 func (d *defuse) Call(args ...vector.Any) vector.Any {
 	return d.eval(args[0])
 }

--- a/runtime/ztests/expr/function/defuse.yaml
+++ b/runtime/ztests/expr/function/defuse.yaml
@@ -176,3 +176,12 @@ input: &input |
   error(1)::(null|error(int64))
 
 output: *input
+
+---
+
+spq: fuse | defuse(this)
+
+input: &input |
+  1::(int64|null)
+
+output: *input


### PR DESCRIPTION
Ripping discards union types that defuse() should preserve.