### PR TITLE
Revert "simplify fusion for arrays, sets, and maps (#6949)"

### DIFF
--- a/book/src/super-sql/operators/fuse.md
+++ b/book/src/super-sql/operators/fuse.md
@@ -64,6 +64,6 @@ fuse
 {a:[1,2]}
 {a:["foo","bar"],b:10.0.0.1}
 # expected output
-fusion({a:fusion([1,2]::[int64|string],<[int64]>),b?:_::ip},<{a:[int64]}>)
-fusion({a:fusion(["foo","bar"]::[int64|string],<[string]>),b?:10.0.0.1},<{a:[string],b:ip}>)
+fusion({a:fusion([fusion(1::(int64|string),<int64>),fusion(2::(int64|string),<int64>)],<[int64]>),b?:_::ip},<{a:[int64]}>)
+fusion({a:fusion([fusion("foo"::(int64|string),<string>),fusion("bar"::(int64|string),<string>)],<[string]>),b?:10.0.0.1},<{a:[string],b:ip}>)
 ```

--- a/runtime/sam/expr/agg/fuser.go
+++ b/runtime/sam/expr/agg/fuser.go
@@ -82,30 +82,16 @@ func (f *Fuser) fuse(a, b super.Type) super.Type {
 		}
 	case *super.TypeArray:
 		if b, ok := b.(*super.TypeArray); ok {
-			inner := f.fuse(a.Type, b.Type)
-			if fusion, ok := inner.(*super.TypeFusion); ok {
-				inner = fusion.Type
-			}
-			return f.fusion(f.sctx.LookupTypeArray(inner))
+			return f.fusion(f.sctx.LookupTypeArray(f.fuse(a.Type, b.Type)))
 		}
 	case *super.TypeSet:
 		if b, ok := b.(*super.TypeSet); ok {
-			inner := f.fuse(a.Type, b.Type)
-			if fusion, ok := inner.(*super.TypeFusion); ok {
-				inner = fusion.Type
-			}
-			return f.fusion(f.sctx.LookupTypeSet(inner))
+			return f.fusion(f.sctx.LookupTypeSet(f.fuse(a.Type, b.Type)))
 		}
 	case *super.TypeMap:
 		if b, ok := b.(*super.TypeMap); ok {
 			keyType := f.fuse(a.KeyType, b.KeyType)
-			if fusion, ok := keyType.(*super.TypeFusion); ok {
-				keyType = fusion.Type
-			}
 			valType := f.fuse(a.ValType, b.ValType)
-			if fusion, ok := valType.(*super.TypeFusion); ok {
-				valType = fusion.Type
-			}
 			return f.fusion(f.sctx.LookupTypeMap(keyType, valType))
 		}
 	case *super.TypeUnion:

--- a/runtime/ztests/expr/function/defuse.yaml
+++ b/runtime/ztests/expr/function/defuse.yaml
@@ -206,3 +206,46 @@ input: &input |
   1::(int64|null)
 
 output: *input
+
+---
+
+spq: fuse | defuse(this)
+
+input: &input |
+  [{a:1}]
+  [{a:3},{b:3}]
+
+output: *input
+
+---
+
+spq: fuse | defuse(this)
+
+input: &input |
+  [1]
+  [[2],["a"]]
+
+output: *input
+
+---
+
+spq: fuse | defuse(this)
+
+input: &input |
+  [1]
+  [map{2:3},map{4:"a"}]
+
+output: *input
+
+---
+
+# Panics in vam.
+runtime: sam
+
+spq: fuse | defuse(this)
+
+input: &input |
+  [1]
+  [map{2:3},map{4:"a"}::map{int64|string:int64|string}]
+
+output: *input

--- a/runtime/ztests/expr/fuser.yaml
+++ b/runtime/ztests/expr/fuser.yaml
@@ -27,7 +27,7 @@ input: |
   [{id:1,s:"foo"},{id:2,s:null}]
 
 output: |
-  <fusion([none|{id:int64,s:fusion(string|null)}])>
+  <fusion([fusion(none|{id:int64,s:fusion(string|null)})])>
 
 ---
 
@@ -38,7 +38,7 @@ input: |
   []
 
 output: |
-  <fusion([none|{id:int64,s:fusion(string|null)}])>
+  <fusion([fusion(none|{id:int64,s:fusion(string|null)})])>
 
 ---
 

--- a/runtime/ztests/op/aggregate/fuse.yaml
+++ b/runtime/ztests/op/aggregate/fuse.yaml
@@ -36,7 +36,7 @@ input: |
   {a:[null]}
 
 output: |
-  <{a:fusion([int64|string|null])}>
+  <{a:fusion([fusion(int64|string|null)])}>
 
 ---
 
@@ -50,7 +50,7 @@ input: |
 output: |
   <map{int64:int64}>
   <map{int64:int64}>
-  <fusion(map{int64|string:int64|string})>
+  <fusion(map{fusion(int64|string):fusion(int64|string)})>
 
 ---
 
@@ -94,4 +94,4 @@ input: |
 output: |
   type n1=[int64]
   type n2=int64
-  <fusion(n1|[n2|int64])>
+  <fusion(n1|[fusion(n2|int64)])>

--- a/runtime/ztests/op/fuse.yaml
+++ b/runtime/ztests/op/fuse.yaml
@@ -25,11 +25,11 @@ input: |
   [{a:null,b:null}]
 
 output: |
-  fusion([{a:fusion(1::(int64|null|none),<int64>),b:fusion(_::(int64|null|none),<none>)}],<[{a:int64}]>)
-  fusion([{a:fusion(_::(int64|null|none),<none>),b:fusion(2::(int64|null|none),<int64>)}],<[{b:int64}]>)
-  fusion([{a:fusion(3::(int64|null|none),<int64>),b:fusion(_::(int64|null|none),<none>)},{a:fusion(_::(int64|null|none),<none>),b:fusion(3::(int64|null|none),<int64>)}],<[{a:int64}|{b:int64}]>)
-  fusion([{a:fusion(3::(int64|null|none),<int64>),b:fusion(3::(int64|null|none),<int64>)}],<[{a:int64,b:int64}]>)
-  fusion([{a:fusion(null::(int64|null|none),<null>),b:fusion(null::(int64|null|none),<null>)}],<[{a:null,b:null}]>)
+  fusion([fusion({a:fusion(1::(int64|null|none),<int64>),b:fusion(_::(int64|null|none),<none>)},<{a:int64}>)],<[{a:int64}]>)
+  fusion([fusion({a:fusion(_::(int64|null|none),<none>),b:fusion(2::(int64|null|none),<int64>)},<{b:int64}>)],<[{b:int64}]>)
+  fusion([fusion({a:fusion(3::(int64|null|none),<int64>),b:fusion(_::(int64|null|none),<none>)},<{a:int64}>),fusion({a:fusion(_::(int64|null|none),<none>),b:fusion(3::(int64|null|none),<int64>)},<{b:int64}>)],<[{a:int64}|{b:int64}]>)
+  fusion([fusion({a:fusion(3::(int64|null|none),<int64>),b:fusion(3::(int64|null|none),<int64>)},<{a:int64,b:int64}>)],<[{a:int64,b:int64}]>)
+  fusion([fusion({a:fusion(null::(int64|null|none),<null>),b:fusion(null::(int64|null|none),<null>)},<{a:null,b:null}>)],<[{a:null,b:null}]>)
 
 ---
 
@@ -45,12 +45,12 @@ input: |
   ["s"]
 
 output: |
-  fusion({a:fusion(1::(int64|string),<int64>)}::(int64|string|{a:fusion(int64|string)}|[int64|string]),<{a:int64}>)
-  fusion({a:fusion("s"::(int64|string),<string>)}::(int64|string|{a:fusion(int64|string)}|[int64|string]),<{a:string}>)
-  fusion(1::(int64|string|{a:fusion(int64|string)}|[int64|string]),<int64>)
-  fusion("s"::(int64|string|{a:fusion(int64|string)}|[int64|string]),<string>)
-  fusion([1]::[int64|string]::(int64|string|{a:fusion(int64|string)}|[int64|string]),<[int64]>)
-  fusion(["s"]::[int64|string]::(int64|string|{a:fusion(int64|string)}|[int64|string]),<[string]>)
+  fusion({a:fusion(1::(int64|string),<int64>)}::(int64|string|{a:fusion(int64|string)}|[fusion(int64|string)]),<{a:int64}>)
+  fusion({a:fusion("s"::(int64|string),<string>)}::(int64|string|{a:fusion(int64|string)}|[fusion(int64|string)]),<{a:string}>)
+  fusion(1::(int64|string|{a:fusion(int64|string)}|[fusion(int64|string)]),<int64>)
+  fusion("s"::(int64|string|{a:fusion(int64|string)}|[fusion(int64|string)]),<string>)
+  fusion([fusion(1::(int64|string),<int64>)]::(int64|string|{a:fusion(int64|string)}|[fusion(int64|string)]),<[int64]>)
+  fusion([fusion("s"::(int64|string),<string>)]::(int64|string|{a:fusion(int64|string)}|[fusion(int64|string)]),<[string]>)
 
 ---
 
@@ -89,9 +89,9 @@ input: |
   [null]
 
 output: |
-  fusion([1,2]::[int64|string|null],<[int64]>)
-  fusion(["foo"]::[int64|string|null],<[string]>)
-  fusion([null]::[int64|string|null],<[null]>)
+  fusion([fusion(1::(int64|string|null),<int64>),fusion(2::(int64|string|null),<int64>)],<[int64]>)
+  fusion([fusion("foo"::(int64|string|null),<string>)],<[string]>)
+  fusion([fusion(null::(int64|string|null),<null>)],<[null]>)
 
 ---
 
@@ -103,9 +103,9 @@ input: |
   {a:[null]}
 
 output: |
-  {a:fusion([1,2]::[int64|string|null],<[int64]>)}
-  {a:fusion(["foo"]::[int64|string|null],<[string]>)}
-  {a:fusion([null]::[int64|string|null],<[null]>)}
+  {a:fusion([fusion(1::(int64|string|null),<int64>),fusion(2::(int64|string|null),<int64>)],<[int64]>)}
+  {a:fusion([fusion("foo"::(int64|string|null),<string>)],<[string]>)}
+  {a:fusion([fusion(null::(int64|string|null),<null>)],<[null]>)}
 
 ---
 


### PR DESCRIPTION
This reverts commit 9d215b8b03734a4e284371d03cdec90679144172.

Reverting because the change in #6949 prevents `fuse | defuse(this)` from reproducing some inputs.  A few examples are added to runtime/ztests/expr/function/defuse.yaml.