### PR TITLE
ztest: remove ZTest.Vector field

### DIFF
--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -275,7 +275,6 @@ type ZTest struct {
 	Output      string  `yaml:"output,omitempty"`
 	OutputFlags string  `yaml:"output-flags,omitempty"`
 	Error       string  `yaml:"error,omitempty"`
-	Vector      bool    `yaml:"vector"`
 
 	// For script-style tests.
 	Script  string   `yaml:"script,omitempty"`


### PR DESCRIPTION
I missed this in #6989.