### PR TITLE
vam: fix panic in downcast() on zero-length vector

### DIFF
--- a/runtime/vam/expr/function/downcast.go
+++ b/runtime/vam/expr/function/downcast.go
@@ -94,17 +94,17 @@ func (d *downcast) downcast(vec vector.Any, to super.Type) vector.Any {
 	if vec.Type() == to {
 		return vec
 	}
+	if vec.Len() == 0 {
+		return vector.NewEmpty(to)
+	}
 	// XXX Handle vec type All.
 	if _, ok := to.(*super.TypeUnion); !ok {
 		if fusion, ok := vec.(*vector.Fusion); ok {
 			return d.downcastFusion(fusion, to)
 		}
 	}
-	switch vec := vec.(type) {
-	case *vector.Union:
-		return d.downcastDynamic(vec.Dynamic(), to)
-	case *vector.Empty:
-		return vector.NewEmpty(to)
+	if u, ok := vec.(*vector.Union); ok {
+		return d.downcastDynamic(u.Dynamic(), to)
 	}
 	switch to := to.(type) {
 	case *super.TypeRecord:

--- a/runtime/ztests/expr/function/defuse.yaml
+++ b/runtime/ztests/expr/function/defuse.yaml
@@ -249,3 +249,13 @@ input: &input |
   [map{2:3},map{4:"a"}::map{int64|string:int64|string}]
 
 output: *input
+
+---
+
+spq: fuse | defuse(this)
+
+input: &input |
+  null::(null|set[string])
+  set[null]::set[string|null]
+
+output: *input


### PR DESCRIPTION
The vector.Empty handling added in #6999 addressed a specific instance of the general need to handle zero-length vectors.