### PR TITLE
vam: fix panic in upcast()

### DIFF
--- a/runtime/vam/expr/function/upcast.go
+++ b/runtime/vam/expr/function/upcast.go
@@ -2,7 +2,6 @@ package function
 
 import (
 	"fmt"
-	"slices"
 
 	"github.com/brimdata/super"
 	samfunc "github.com/brimdata/super/runtime/sam/expr/function"
@@ -82,6 +81,9 @@ func (u *Upcast) Cast(vec vector.Any, to super.Type) (vector.Any, bool) {
 func (u *Upcast) upcast(vec vector.Any, to super.Type) vector.Any {
 	if vec.Type() == to && vec.Kind() != vector.KindFusion {
 		return vec
+	}
+	if vec.Len() == 0 {
+		return vector.NewEmpty(to)
 	}
 	switch vec := vec.(type) {
 	case *vector.Fusion:
@@ -181,16 +183,15 @@ func (u *Upcast) deunionAndUpcast(vec vector.Any, to super.Type) vector.Any {
 	if !ok {
 		return u.upcast(vec, to)
 	}
-	vecs := slices.Clone(d.Values)
-	for i, vec := range vecs {
-		if vec == nil || vec.Len() == 0 {
-			continue
-		}
-		vecs[i] = u.upcast(vecs[i], to)
+	vecs := make([]vector.Any, len(d.Values))
+	for i, vec := range d.Values {
+		vecs[i] = u.upcast(vec, to)
 		if vecs[i] == nil {
 			return nil
 		}
 	}
+	// All elements of vecs have type to so this should always return a
+	// vector with type to (and never a dynamic).
 	return vbuild.MergeSameTypesInDynamic(vector.NewDynamic(d.Tags, vecs))
 }
 

--- a/runtime/ztests/expr/function/defuse.yaml
+++ b/runtime/ztests/expr/function/defuse.yaml
@@ -239,9 +239,6 @@ output: *input
 
 ---
 
-# Panics in vam.
-runtime: sam
-
 spq: fuse | defuse(this)
 
 input: &input |

--- a/vector/vbuild/merge.go
+++ b/vector/vbuild/merge.go
@@ -73,6 +73,9 @@ func Merge(tags []uint32, vecs []vector.Any) vector.Any {
 	reverse := make([][]uint32, len(vecs))
 	var k uint32
 	for i, vec := range vecs {
+		if vec.Len() == 0 {
+			continue
+		}
 		b.Write(vec)
 		for range vec.Len() {
 			reverse[i] = append(reverse[i], k)

--- a/vector/vbuild/merge.go
+++ b/vector/vbuild/merge.go
@@ -73,9 +73,6 @@ func Merge(tags []uint32, vecs []vector.Any) vector.Any {
 	reverse := make([][]uint32, len(vecs))
 	var k uint32
 	for i, vec := range vecs {
-		if vec.Len() == 0 {
-			continue
-		}
 		b.Write(vec)
 		for range vec.Len() {
 			reverse[i] = append(reverse[i], k)


### PR DESCRIPTION
runtime/vam/expr/function.Upcast.deunionAndUpcast does not change the type of zero-length vectors.  This causes trouble because the vectors passed to vbuild.MergeSameTypesInDynamic then have multiple types, causing that function to return a vector.Dynamic instead of the expected vector with the target type.  Fix by changing the type of zero-length
vectors to the target type in deunionAndUpcast.