### PR TITLE
vector/vbuild: handle vector.Empty in Builder.Write

### DIFF
--- a/vector/vbuild/array.go
+++ b/vector/vbuild/array.go
@@ -22,6 +22,9 @@ func newArraySetBuilder(typ super.Type) *arraySetBuilder {
 
 func (a *arraySetBuilder) Write(vec vector.Any) {
 	n := vec.Len()
+	if n == 0 {
+		return
+	}
 	var index []uint32
 	if view, ok := vec.(*vector.View); ok {
 		vec = view.Any

--- a/vector/vbuild/bool.go
+++ b/vector/vbuild/bool.go
@@ -10,6 +10,9 @@ type boolBuilder struct {
 }
 
 func (b *boolBuilder) Write(vec vector.Any) {
+	if vec.Len() == 0 {
+		return
+	}
 	switch vec := vec.(type) {
 	case *vector.Const:
 		v := vec.Any.(*vector.Bool).IsSet(0)

--- a/vector/vbuild/bytes.go
+++ b/vector/vbuild/bytes.go
@@ -34,6 +34,9 @@ type bytesConstWriter struct {
 }
 
 func (b *bytesConstWriter) Write(vec vector.Any) genericWriter {
+	if vec.Len() == 0 {
+		return b
+	}
 	if c, ok := vec.(*vector.Const); ok {
 		v := bytesTableOf(c.Any).Bytes(0)
 		if b.val == nil {
@@ -68,6 +71,9 @@ type bytesDictWriter struct {
 }
 
 func (b *bytesDictWriter) Write(vec vector.Any) genericWriter {
+	if vec.Len() == 0 {
+		return b
+	}
 	switch vec := vec.(type) {
 	case *vector.Const:
 		t := bytesTableOf(vec.Any)
@@ -137,6 +143,9 @@ type bytesFlatWriter struct {
 }
 
 func (b *bytesFlatWriter) Write(vec vector.Any) genericWriter {
+	if vec.Len() == 0 {
+		return b
+	}
 	switch vec := vec.(type) {
 	case *vector.View:
 		table := bytesTableOf(vec.Any)

--- a/vector/vbuild/enum.go
+++ b/vector/vbuild/enum.go
@@ -18,6 +18,9 @@ func newEnumBuilder(typ *super.TypeEnum) Builder {
 }
 
 func (a *enumBuilder) Write(vec vector.Any) {
+	if vec.Len() == 0 {
+		return
+	}
 	var index []uint32
 	if view, ok := vec.(*vector.View); ok {
 		index = view.Index

--- a/vector/vbuild/error.go
+++ b/vector/vbuild/error.go
@@ -11,6 +11,9 @@ type errorBuilder struct {
 }
 
 func (e *errorBuilder) Write(vec vector.Any) {
+	if vec.Len() == 0 {
+		return
+	}
 	e.vals.Write(vec.(*vector.Error).Vals)
 }
 

--- a/vector/vbuild/fusion.go
+++ b/vector/vbuild/fusion.go
@@ -19,6 +19,9 @@ func newFusionBuilder(typ *super.TypeFusion) *fusionBuilder {
 }
 
 func (f *fusionBuilder) Write(vec vector.Any) {
+	if vec.Len() == 0 {
+		return
+	}
 	if view, ok := vec.(*vector.View); ok {
 		fusion := view.Any.(*vector.Fusion)
 		f.vals.Write(vector.Pick(fusion.Values, view.Index))

--- a/vector/vbuild/generic.go
+++ b/vector/vbuild/generic.go
@@ -14,6 +14,9 @@ type genericBuilder[E comparable] struct {
 }
 
 func (b *genericBuilder[E]) Write(vec vector.Any) {
+	if vec.Len() == 0 {
+		return
+	}
 	if b.writer == nil {
 		b.writer = &genericConstWriter[E]{
 			valuesOf: b.valuesOf,
@@ -46,6 +49,9 @@ type genericConstWriter[E comparable] struct {
 }
 
 func (c *genericConstWriter[E]) Write(vec vector.Any) genericWriter {
+	if vec.Len() == 0 {
+		return c
+	}
 	if const_, ok := vec.(*vector.Const); ok {
 		vals := c.valuesOf(const_.Any)
 		if c.len == 0 {
@@ -80,6 +86,9 @@ type genericDictWriter[E comparable] struct {
 }
 
 func (d *genericDictWriter[E]) Write(vec vector.Any) genericWriter {
+	if vec.Len() == 0 {
+		return d
+	}
 	switch vec := vec.(type) {
 	case *vector.Const:
 		vals := d.valuesOf(vec.Any)
@@ -143,6 +152,9 @@ type genericFlatWriter[E comparable] struct {
 }
 
 func (f *genericFlatWriter[E]) Write(vec vector.Any) genericWriter {
+	if vec.Len() == 0 {
+		return f
+	}
 	switch vec := vec.(type) {
 	case *vector.Const:
 		vals := f.valuesOf(vec.Any)

--- a/vector/vbuild/map.go
+++ b/vector/vbuild/map.go
@@ -24,6 +24,9 @@ func newMapBuilder(typ *super.TypeMap) Builder {
 
 func (m *mapBuilder) Write(vec vector.Any) {
 	n := vec.Len()
+	if n == 0 {
+		return
+	}
 	var index []uint32
 	if view, ok := vec.(*vector.View); ok {
 		index = view.Index

--- a/vector/vbuild/none.go
+++ b/vector/vbuild/none.go
@@ -9,7 +9,7 @@ type noneBuilder struct {
 }
 
 func (n *noneBuilder) Write(vec vector.Any) {
-	n.len += vec.(*vector.None).Len()
+	n.len += vec.Len()
 }
 
 func (n *noneBuilder) Build() vector.Any {
@@ -21,7 +21,7 @@ type nullBuilder struct {
 }
 
 func (n *nullBuilder) Write(vec vector.Any) {
-	n.len += vec.(*vector.Null).Len()
+	n.len += vec.Len()
 }
 
 func (n *nullBuilder) Build() vector.Any {

--- a/vector/vbuild/record.go
+++ b/vector/vbuild/record.go
@@ -25,8 +25,11 @@ func newRecordBuilder(typ *super.TypeRecord) Builder {
 	}
 }
 
-func (r *recordBuilder) Write(in vector.Any) {
-	vec := in
+func (r *recordBuilder) Write(vec vector.Any) {
+	n := vec.Len()
+	if n == 0 {
+		return
+	}
 	var index []uint32
 	if view, ok := vec.(*vector.View); ok {
 		vec = view.Any
@@ -40,7 +43,7 @@ func (r *recordBuilder) Write(in vector.Any) {
 		}
 		r.fields[i].Write(vec)
 	}
-	r.len += in.Len()
+	r.len += n
 }
 
 func (r *recordBuilder) Build() vector.Any {


### PR DESCRIPTION
Any vbuild.Builder.Write implementation can receive a vector.Empty as its vector.Any parameter but many don't expect that and panic.  Fix that by checking for a zero-length parameter in all implementations (except noneBuilder and nullBuilder, where we can just call vector.Any.Len).