### PR TITLE
Install and point at Chrome to be used by linkspector

### DIFF
--- a/.github/workflows/markdown-lint.yaml
+++ b/.github/workflows/markdown-lint.yaml
@@ -15,10 +15,20 @@ jobs:
     - uses: actions/checkout@v4
     - name: Lint
       run: make markdown-lint
+
+    - id: setup-chrome
+      uses: browser-actions/setup-chrome@v2
+      with:
+        chrome-version: stable
+
+    - name: Point Puppeteer at the installed Chrome
+      run: echo "PUPPETEER_EXECUTABLE_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> "$GITHUB_ENV"
+
     - uses: umbrelladocs/action-linkspector@v1
       with:
         fail_on_error: true
         filter_mode: nofilter
+
     - name: Inform Slack users of link check failures
       uses: tiloio/slack-webhook-action@v1.1.2
       if: failure() && github.ref_name == 'main'
@@ -27,5 +37,5 @@ jobs:
         slack_json: |
           {
             "username": "markdown-link",
-            "text": "Markdown link check failed: ${{ github.event.workflow_run.html_url }}"
+            "text": "Markdown link check failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           }


### PR DESCRIPTION
## What's Changing

In the Actions workflow that runs the link checker, Chrome is now explicitly installed in an earlier step.

I fixed a buggy URL in the Action's Slack notification step while I was at it.

## Why

There's an open issue https://github.com/UmbrellaDocs/action-linkspector/issues/62 that has not been addressed which is causing our link checker jobs to fail.

## Details

As I understand it, linkspector uses [Puppeteer](https://pptr.dev/) to drive a headless Chrome browser through which it checks links. It seems the Puppeteer reference inside linkspector's dependency tree may be floating such that it now points at a Chrome version different than whatever Chrome has been getting provisioned on the Runner.