### PR TITLE
vam: use vector.Apply in expr/function.defuse.eval

### DIFF
--- a/runtime/vam/expr/function/defuse.go
+++ b/runtime/vam/expr/function/defuse.go
@@ -44,14 +44,8 @@ func (d *defuse) eval(in vector.Any) vector.Any {
 	case vector.KindMap:
 		return d.defuseMap(in)
 	case vector.KindUnion:
-		// XXX This should use vector.Apply but right now Apply defuses fusion
-		// values and we do not want this here.
-		dynamic := vector.Deunion(in).(*vector.Dynamic)
-		var vecs []vector.Any
-		for _, vec := range dynamic.Values {
-			vecs = append(vecs, d.eval(vec))
-		}
-		return vector.NewDynamic(dynamic.Tags, vecs)
+		u := in.(*vector.Union)
+		return vector.Apply(vector.ApplyNone, d.Call, u.Dynamic().Values...)
 	case vector.KindError:
 		return d.defuseError(in)
 	case vector.KindFusion:


### PR DESCRIPTION
There's no longer any need to avoid vector.Apply since it hasn't defused values since #6936.