### PR TITLE
vam function calls: rip fusion and unions by default

### DIFF
--- a/runtime/sam/expr/function/upcast.go
+++ b/runtime/sam/expr/function/upcast.go
@@ -17,7 +17,7 @@ func NewUpcast(sctx *super.Context) *Upcast {
 }
 
 func (u *Upcast) Call(args []super.Value) super.Value {
-	from, to := args[0], args[1]
+	from, to := args[0].SuperDeunion(), args[1]
 	if _, ok := to.Type().(*super.TypeOfType); !ok {
 		return u.sctx.WrapError("upcast: type argument not a type", to)
 	}

--- a/runtime/vam/expr/eval.go
+++ b/runtime/vam/expr/eval.go
@@ -28,22 +28,22 @@ func CheckForNullThenError(vecs []vector.Any) (vector.Any, bool) {
 }
 
 type Call struct {
-	fn        Function
-	exprs     []Evaluator
-	ripUnions bool
-	args      []vector.Any
+	fn       Function
+	exprs    []Evaluator
+	applyOpt vector.ApplyOpt
+	args     []vector.Any
 }
 
 func NewCall(fn Function, exprs []Evaluator) *Call {
-	ripUnions := true
-	if fn, ok := fn.(interface{ RipUnions() bool }); ok {
-		ripUnions = fn.RipUnions()
+	opt := vector.ApplyRipUnions | vector.ApplyRipFusions
+	if fn, ok := fn.(interface{ ApplyOpt() vector.ApplyOpt }); ok {
+		opt = fn.ApplyOpt()
 	}
 	return &Call{
-		fn:        fn,
-		exprs:     exprs,
-		ripUnions: ripUnions,
-		args:      make([]vector.Any, len(exprs)),
+		fn:       fn,
+		exprs:    exprs,
+		applyOpt: opt,
+		args:     make([]vector.Any, len(exprs)),
 	}
 }
 
@@ -51,9 +51,5 @@ func (c *Call) Eval(this vector.Any) vector.Any {
 	for k, e := range c.exprs {
 		c.args[k] = e.Eval(this)
 	}
-	var opts vector.ApplyOpt
-	if c.ripUnions {
-		opts = vector.ApplyRipUnions
-	}
-	return vector.Apply(opts, c.fn.Call, c.args...)
+	return vector.Apply(c.applyOpt, c.fn.Call, c.args...)
 }

--- a/runtime/vam/expr/function/coalesce.go
+++ b/runtime/vam/expr/function/coalesce.go
@@ -9,7 +9,7 @@ import (
 
 type Coalesce struct{}
 
-func (*Coalesce) RipUnions() bool { return false }
+func (*Coalesce) ApplyOpt() vector.ApplyOpt { return vector.ApplyNone }
 
 func (c *Coalesce) Call(vecs ...vector.Any) vector.Any {
 	for i, vec := range vecs {

--- a/runtime/vam/expr/function/defuse.go
+++ b/runtime/vam/expr/function/defuse.go
@@ -24,7 +24,7 @@ func newDefuse(sctx *super.Context) *defuse {
 	return d
 }
 
-func (*defuse) RipUnions() bool { return false }
+func (*defuse) ApplyOpt() vector.ApplyOpt { return vector.ApplyNone }
 
 func (d *defuse) Call(args ...vector.Any) vector.Any {
 	return d.eval(args[0])

--- a/runtime/vam/expr/function/downcast.go
+++ b/runtime/vam/expr/function/downcast.go
@@ -20,6 +20,8 @@ func newDowncast(sctx *super.Context) *downcast {
 	return newDefuse(sctx).downcast
 }
 
+func (d *downcast) ApplyOpt() vector.ApplyOpt { return vector.ApplyRipUnions }
+
 func (d *downcast) Call(vecs ...vector.Any) vector.Any {
 	from, to := vecs[0], vecs[1]
 	if to.Kind() != vector.KindType {

--- a/runtime/vam/expr/function/errors.go
+++ b/runtime/vam/expr/function/errors.go
@@ -40,4 +40,4 @@ func (q *Quiet) call(args ...vector.Any) vector.Any {
 	return vector.NewError(arg.Typ, vec)
 }
 
-func (q *Quiet) RipUnions() bool { return false }
+func (q *Quiet) ApplyOpt() vector.ApplyOpt { return vector.ApplyNone }

--- a/runtime/vam/expr/function/types.go
+++ b/runtime/vam/expr/function/types.go
@@ -112,7 +112,7 @@ func (i *Is) Call(args ...vector.Any) vector.Any {
 	return out
 }
 
-func (i *Is) RipUnions() bool { return false }
+func (i *Is) ApplyOpt() vector.ApplyOpt { return vector.ApplyNone }
 
 type IsErr struct{}
 
@@ -158,7 +158,7 @@ func (t *TypeOf) Call(args ...vector.Any) vector.Any {
 	return vector.NewConstType(t.sctx, args[0].Type(), args[0].Len())
 }
 
-func (t *TypeOf) RipUnions() bool { return false }
+func (t *TypeOf) ApplyOpt() vector.ApplyOpt { return vector.ApplyNone }
 
 type TypeName struct {
 	sctx *super.Context
@@ -194,7 +194,7 @@ func (e *Error) Call(args ...vector.Any) vector.Any {
 	return vector.NewError(e.sctx.LookupTypeError(vec.Type()), vec)
 }
 
-func (e *Error) RipUnions() bool { return false }
+func (e *Error) ApplyOpt() vector.ApplyOpt { return vector.ApplyNone }
 
 type Kind struct {
 	sctx *super.Context
@@ -218,9 +218,7 @@ func (k *Kind) Call(args ...vector.Any) vector.Any {
 	return out
 }
 
-func (*Kind) RipUnions() bool {
-	return false
-}
+func (*Kind) ApplyOpt() vector.ApplyOpt { return vector.ApplyNone }
 
 type Unblend struct {
 	sctx *super.Context

--- a/runtime/ztests/expr/function/upcast.yaml
+++ b/runtime/ztests/expr/function/upcast.yaml
@@ -66,7 +66,7 @@ output: |
   fusion(map{1:fusion(map{2:fusion(3::(int64|null),<int64>)},<map{int64:int64}>),4:fusion(map{5:fusion(null::(int64|null),<null>)},<map{int64:null}>)},<map{int64:map{int64:int64}|map{int64:null}}>)
   fusion("x"::enum(x,y,z),<enum(x,y)>)
   error({message:"upcast: value not a subtype of fusion(enum(y,z))",on:"x"::enum(x,y)})
-  fusion(1::(int64|string),<int64|string>)
+  fusion(1::(int64|string),<int64>)
   type n31=int64
   1::n31
   type n46=int64

--- a/value.go
+++ b/value.go
@@ -419,6 +419,21 @@ func (v *Value) MissingAsNull() Value {
 	return *v
 }
 
+// SuperDeunion deunions and returns the super value of arbitrarily nested
+// union and fusion values.
+func (v Value) SuperDeunion() Value {
+	for {
+		switch typ := v.Type().(type) {
+		case *TypeUnion:
+			v = NewValue(typ.Untag(v.bytes()))
+		case *TypeFusion:
+			v = NewValue(typ.DerefFusion(v.bytes()))
+		default:
+			return v
+		}
+	}
+}
+
 // Deunion returns v if it is not an anonymous union and otherwise detags v
 // to its underlying value.  It does not Deunion union values that are named types.
 func (v Value) Deunion() Value {


### PR DESCRIPTION
This commit reworks the rip logic for function calls where both fusions and unions are both automatically ripped.

The interface RipUnions() is replaced by ApplyOpts() so that individual function calls can specificy which ApplyOpts it wants.