### PR TITLE
Trigger Python client CI when super PRs merge

### DIFF
--- a/.github/workflows/notify-downstream-merge.yaml
+++ b/.github/workflows/notify-downstream-merge.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        repo: [zui]
+        repo: [zui, superdb-python]
     steps:
     - name: Populate "merged" variable
       run: |


### PR DESCRIPTION
This change makes it such that the Python client CI test added in https://github.com/brimdata/superdb-python/pull/1 is triggered whenever PRs merge in the super repo.