### PR TITLE
vector: don't pass NoRip vectors to Super in Apply

### DIFF
--- a/runtime/ztests/expr/array-expr.yaml
+++ b/runtime/ztests/expr/array-expr.yaml
@@ -10,6 +10,7 @@ input: |
   {a:"foo",b:1,c:127.0.0.1}
   {a:"bar",b:2,c:127.0.0.2}
   {a:0,b:"1"::(int64|string),c:null::(int64|string|null)}
+  {a:0,b:1,c:fusion([2]::(null|[int64]),<[int64]>)}
 
 output: |
   [error("missing"),error("quiet"),null]
@@ -20,6 +21,7 @@ output: |
   ["foo",1,127.0.0.1]
   ["bar",2,127.0.0.2]
   [0,"1",null]
+  [0,1,fusion([2]::(null|[int64]),<[int64]>)]
 
 ---
 

--- a/vector/apply.go
+++ b/vector/apply.go
@@ -22,7 +22,9 @@ type NoRip struct {
 func Apply(opt ApplyOpt, eval func(...Any) Any, vecs ...Any) Any {
 	if opt&ApplyRipFusions != 0 {
 		for k, vec := range vecs {
-			vecs[k] = Super(vec)
+			if _, ok := vec.(*NoRip); !ok {
+				vecs[k] = Super(vec)
+			}
 		}
 	}
 	if opt&ApplyRipUnions != 0 {


### PR DESCRIPTION
Fixes #7033.