### PR TITLE
fuse: Defuse fusion values

### DIFF
--- a/runtime/sam/op/fuse/fuse.go
+++ b/runtime/sam/op/fuse/fuse.go
@@ -108,9 +108,10 @@ type valueFuser struct {
 	vals    []super.Value
 	spiller *spill.File
 
-	fuser  *agg.Fuser
-	caster function.Caster
-	typ    super.Type
+	fuser   *agg.Fuser
+	caster  function.Caster
+	defuser *function.Defuse
+	typ     super.Type
 }
 
 // newValueFuser returns a new valueFuser that buffers values in memory until
@@ -122,6 +123,7 @@ func newValueFuser(sctx *super.Context, memMaxBytes int, complete bool) *valueFu
 		memMaxBytes: memMaxBytes,
 		fuser:       agg.NewFuser(sctx, complete),
 		caster:      function.NewUpcast(sctx),
+		defuser:     function.NewDefuse(sctx),
 	}
 }
 
@@ -138,6 +140,7 @@ func (v *valueFuser) Write(val super.Value) error {
 	if v.typ != nil {
 		panic("fuser: write after read")
 	}
+	val = v.defuser.Call([]super.Value{val})
 	v.fuser.Fuse(val.Type())
 	if v.spiller != nil {
 		return v.spiller.Write(val)

--- a/runtime/vam/expr/function/defuse.go
+++ b/runtime/vam/expr/function/defuse.go
@@ -8,15 +8,15 @@ import (
 	"github.com/brimdata/super/vector/vbuild"
 )
 
-type defuse struct {
+type Defuse struct {
 	sctx     *super.Context
 	downcast *downcast
 	// This is used only for HasFusion func.
 	samdefuse *samfunc.Defuse
 }
 
-func newDefuse(sctx *super.Context) *defuse {
-	d := &defuse{
+func NewDefuse(sctx *super.Context) *Defuse {
+	d := &Defuse{
 		sctx:      sctx,
 		downcast:  &downcast{sctx: sctx},
 		samdefuse: samfunc.NewDefuse(sctx),
@@ -25,13 +25,13 @@ func newDefuse(sctx *super.Context) *defuse {
 	return d
 }
 
-func (*defuse) ApplyOpt() vector.ApplyOpt { return vector.ApplyNone }
+func (*Defuse) ApplyOpt() vector.ApplyOpt { return vector.ApplyNone }
 
-func (d *defuse) Call(args ...vector.Any) vector.Any {
+func (d *Defuse) Call(args ...vector.Any) vector.Any {
 	return d.eval(args[0])
 }
 
-func (d *defuse) eval(in vector.Any) vector.Any {
+func (d *Defuse) eval(in vector.Any) vector.Any {
 	if !d.samdefuse.HasFusion(in.Type()) {
 		return in
 	}
@@ -59,7 +59,7 @@ func (d *defuse) eval(in vector.Any) vector.Any {
 	}
 }
 
-func (d *defuse) defuseRecord(vec vector.Any) vector.Any {
+func (d *Defuse) defuseRecord(vec vector.Any) vector.Any {
 	rec := vector.PushView(vec).(*vector.Record)
 	var vecs []vector.Any
 	for _, vec := range rec.Fields {
@@ -83,7 +83,7 @@ func (d *defuse) defuseRecord(vec vector.Any) vector.Any {
 	}, vecs...)
 }
 
-func (d *defuse) defuseArray(in vector.Any) vector.Any {
+func (d *Defuse) defuseArray(in vector.Any) vector.Any {
 	array := vector.PushView(in).(*vector.Array)
 	inner := mergeSameTypes(d.eval(array.Values))
 	if !vector.IsDynamic(inner) {
@@ -101,7 +101,7 @@ func (d *defuse) defuseArray(in vector.Any) vector.Any {
 	return vals[0]
 }
 
-func (d *defuse) defuseSet(in vector.Any) vector.Any {
+func (d *Defuse) defuseSet(in vector.Any) vector.Any {
 	set := vector.PushView(in).(*vector.Set)
 	inner := mergeSameTypes(d.eval(set.Values))
 	if !vector.IsDynamic(inner) {
@@ -119,7 +119,7 @@ func (d *defuse) defuseSet(in vector.Any) vector.Any {
 	return vals[0]
 }
 
-func (d *defuse) defuseMap(in vector.Any) vector.Any {
+func (d *Defuse) defuseMap(in vector.Any) vector.Any {
 	vmap := vector.PushView(in).(*vector.Map)
 	keys := d.eval(vmap.Values)
 	vals := d.eval(vmap.Values)
@@ -162,7 +162,7 @@ func mergeSameTypes(vec vector.Any) vector.Any {
 	return vec
 }
 
-func (d *defuse) defuseError(in vector.Any) vector.Any {
+func (d *Defuse) defuseError(in vector.Any) vector.Any {
 	errVec := vector.PushView(in).(*vector.Error)
 	valsVec := d.eval(errVec.Vals)
 	return vector.Apply(vector.ApplyNone, func(vecs ...vector.Any) vector.Any {

--- a/runtime/vam/expr/function/downcast.go
+++ b/runtime/vam/expr/function/downcast.go
@@ -13,11 +13,11 @@ import (
 
 type downcast struct {
 	sctx    *super.Context
-	defuser *defuse
+	defuser *Defuse
 }
 
 func newDowncast(sctx *super.Context) *downcast {
-	return newDefuse(sctx).downcast
+	return NewDefuse(sctx).downcast
 }
 
 func (d *downcast) ApplyOpt() vector.ApplyOpt { return vector.ApplyRipUnions }

--- a/runtime/vam/expr/function/function.go
+++ b/runtime/vam/expr/function/function.go
@@ -47,7 +47,7 @@ func New(sctx *super.Context, name string, narg int) (expr.Function, error) {
 		argmax = 2
 		f = &DatePart{sctx}
 	case "defuse":
-		f = newDefuse(sctx)
+		f = NewDefuse(sctx)
 	case "downcast":
 		argmin = 2
 		argmax = 2

--- a/runtime/vam/op/fuse.go
+++ b/runtime/vam/op/fuse.go
@@ -17,6 +17,7 @@ type Fuse struct {
 	fuser    *samagg.Fuser
 	vecs     []vector.Any
 	upcaster *function.Upcast
+	defuser  *function.Defuse
 }
 
 func NewFuse(sctx *super.Context, parent vio.Puller, complete bool) *Fuse {
@@ -25,6 +26,7 @@ func NewFuse(sctx *super.Context, parent vio.Puller, complete bool) *Fuse {
 		parent:   parent,
 		complete: complete,
 		upcaster: function.NewUpcast(sctx),
+		defuser:  function.NewDefuse(sctx),
 	}
 }
 
@@ -44,16 +46,7 @@ func (f *Fuse) Pull(done bool) (vector.Any, error) {
 			if vec == nil {
 				break
 			}
-			if d, ok := vec.(*vector.Dynamic); ok {
-				for _, vec := range d.Values {
-					if vec != nil {
-						f.fuser.Fuse(vec.Type())
-					}
-				}
-			} else {
-				f.fuser.Fuse(vec.Type())
-			}
-			f.vecs = append(f.vecs, vec)
+			f.vecs = append(f.vecs, vector.Apply(vector.ApplyNone, f.fuse, vec))
 		}
 	}
 	if len(f.vecs) == 0 {
@@ -65,6 +58,15 @@ func (f *Fuse) Pull(done bool) (vector.Any, error) {
 	f.vecs[0] = nil
 	f.vecs = f.vecs[1:]
 	return vector.Apply(vector.ApplyNone, f.upcast, vec), nil
+}
+
+func (f *Fuse) fuse(vecs ...vector.Any) vector.Any {
+	vec := f.defuser.Call(vecs[0])
+	vector.Apply(vector.ApplyNone, func(vecs ...vector.Any) vector.Any {
+		f.fuser.Fuse(vecs[0].Type())
+		return nil
+	}, vec)
+	return vec
 }
 
 func (f *Fuse) upcast(vecs ...vector.Any) vector.Any {

--- a/runtime/ztests/op/fuse.yaml
+++ b/runtime/ztests/op/fuse.yaml
@@ -162,3 +162,22 @@ output: |
   fusion(1::u1::u2::(a2|en1|er2|m3|p1|r2|s2|u2),<u2>)
   fusion("a"::en1::(a2|en1|er2|m3|p1|r2|s2|u2),<en1>)
   fusion(error(1)::er2::(a2|en1|er2|m3|p1|r2|s2|u2),<er2>)
+
+---
+
+# Test fuse on fusion values
+spq: unnest this into ( fuse )
+
+runtime: vam
+
+input: |
+  [fusion({x?:1,y?:_::int64},<{x:int64}>)]
+  [fusion({x?:1,y?:_::int64},<{x:int64}>),fusion({x?:_::int64,y?:2},<{y:int64}>)]
+  [1,fusion(2::(int64|null),<int64>)]
+
+output: |
+  {x:1}
+  fusion({x?:1,y?:_::int64},<{x:int64}>)
+  fusion({x?:_::int64,y?:2},<{y:int64}>)
+  1
+  2


### PR DESCRIPTION
This commits change the behavior of the fuse operator so that input fusion values are defused. Not doing this and just fusing the super value resulted in losing the original value when a fusion value is re-fused.