### PR TITLE
fix bug in super.Context.LookupByValue by copying parameter

### DIFF
--- a/context.go
+++ b/context.go
@@ -386,7 +386,7 @@ func (c *Context) LookupByValue(tv scode.Bytes) (Type, error) {
 	if rest == nil {
 		return nil, errors.New("bad type value encoding")
 	}
-	c.toValue[typ] = tv
+	c.toValue[typ] = slices.Clone(tv)
 	c.toType[string(tv)] = typ
 	return typ, nil
 }

--- a/context_test.go
+++ b/context_test.go
@@ -8,6 +8,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestContextLookupByValueAndLookupTypeValue(t *testing.T) {
+	sctx := super.NewContext()
+	recType := sctx.MustLookupTypeRecord(nil)
+
+	tv := super.EncodeTypeValue(recType)
+	typ, err := sctx.LookupByValue(tv)
+	require.NoError(t, err)
+	assert.Equal(t, recType, typ)
+
+	// Overwriting tv should not affect sctx's cached type value for recType.
+	super.AppendTypeValue(tv[:0], super.TypeNull)
+	val := sctx.LookupTypeValue(recType)
+	assert.Exactly(t, super.EncodeTypeValue(recType), val.Bytes())
+}
+
 func TestContextLookupTypeNamedErrors(t *testing.T) {
 	sctx := super.NewContext()
 


### PR DESCRIPTION
LookupByValue caches its parameter, a byte slice, in the context, so if the backing array is later modified through another reference, the cached value changes.  This can cause LookupTypeValue to return an incorrect result since it returns these cached values.  Fix this in LookupByValue by caching a copy of the parameter.