### PR TITLE
remove second super.Value.DerefByColumn return param

### DIFF
--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -371,7 +371,7 @@ func unmarshalHeaders(val super.Value) (map[string][]string, error) {
 	}
 	headers := map[string][]string{}
 	for i, f := range val.Fields() {
-		fieldVal, _ := val.DerefByColumn(i)
+		fieldVal := val.DerefByColumn(i)
 		if fieldVal == nil {
 			continue
 		}

--- a/sio/tableio/writer.go
+++ b/sio/tableio/writer.go
@@ -64,8 +64,7 @@ func (w *Writer) Write(r super.Value) error {
 	var out []string
 	for k, f := range r.Fields() {
 		var v string
-		valPtr, _ := r.DerefByColumn(k)
-		value := valPtr.MissingAsNull()
+		value := r.DerefByColumn(k).MissingAsNull()
 		if f.Type == super.TypeTime {
 			if !value.IsNull() {
 				v = super.DecodeTime(value.Bytes()).Time().Format(time.RFC3339Nano)

--- a/value.go
+++ b/value.go
@@ -307,42 +307,38 @@ func (r Value) Walk(rv Visitor) error {
 	return Walk(r.Type(), r.Bytes(), rv)
 }
 
-func (r Value) nth(n int) (scode.Bytes, bool, bool) {
+func (r Value) nth(n int) (scode.Bytes, bool) {
 	if typ := TypeRecordOf(r.typ); typ != nil {
 		var elem scode.Bytes
-		var none bool
 		for i, it := 0, r.Bytes().Iter(); i <= n; i++ {
 			if it.Done() {
-				return nil, false, false
+				return nil, false
 			}
 			elem = it.Next()
 		}
-		return elem, none, true
+		return elem, true
 	}
 	var zv scode.Bytes
 	for i, it := 0, r.Bytes().Iter(); i <= n; i++ {
 		if it.Done() {
-			return nil, false, false
+			return nil, false
 		}
 		zv = it.Next()
 	}
-	return zv, false, true
+	return zv, true
 }
 
 func (r Value) Fields() []Field {
 	return TypeRecordOf(r.Type()).Fields
 }
 
-func (v *Value) DerefByColumn(col int) (*Value, bool) {
+func (v *Value) DerefByColumn(col int) *Value {
 	if v != nil {
-		if bytes, none, ok := v.nth(col); ok {
-			if none {
-				return nil, true
-			}
-			return NewValue(v.Fields()[col].Type, bytes).Ptr(), false
+		if bytes, ok := v.nth(col); ok {
+			return NewValue(v.Fields()[col].Type, bytes).Ptr()
 		}
 	}
-	return nil, false
+	return nil
 }
 
 func (v Value) IndexOfField(field string) (int, bool) {
@@ -360,8 +356,7 @@ func (v *Value) Deref(field string) *Value {
 	if !ok {
 		return nil
 	}
-	val, _ := v.DerefByColumn(i)
-	return val
+	return v.DerefByColumn(i)
 }
 
 func (v *Value) DerefPath(path field.Path) *Value {


### PR DESCRIPTION
It's unused (and always false).