### PR TITLE
call super.Value.IsMissing instead of checking for nil

### DIFF
--- a/book/src/dev/libraries/go.md
+++ b/book/src/dev/libraries/go.md
@@ -53,7 +53,7 @@ func main() {
 			return
 		}
 		s := val.Deref("s")
-		if s == nil {
+		if s.IsMissing() {
 			s = sctx.Missing().Ptr()
 		}
 		fmt.Println(sup.String(s))
@@ -141,7 +141,7 @@ func main() {
 			return
 		}
 		s := val.Deref("s")
-		if s == nil {
+		if s.IsMissing() {
 			s = sctx.Missing().Ptr()
 		}
 		fmt.Println(sup.String(s))

--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -372,7 +372,7 @@ func unmarshalHeaders(val super.Value) (map[string][]string, error) {
 	headers := map[string][]string{}
 	for i, f := range val.Fields() {
 		fieldVal, _ := val.DerefByColumn(i)
-		if fieldVal == nil {
+		if fieldVal.IsMissing() {
 			continue
 		}
 		headerStrings, err := decodeStrings(fieldVal)

--- a/complex_test.go
+++ b/complex_test.go
@@ -37,7 +37,7 @@ set[1,2,3]`
 		}
 		require.NoError(t, err)
 		v := val.Deref("foo")
-		require.Nil(t, v)
+		require.True(t, v.IsMissing())
 	}
 }
 

--- a/runtime/sam/expr/agg/avg.go
+++ b/runtime/sam/expr/agg/avg.go
@@ -41,14 +41,14 @@ const (
 
 func (a *Avg) ConsumeAsPartial(partial super.Value) {
 	sumVal := partial.Deref(sumName)
-	if sumVal == nil {
+	if sumVal.IsMissing() {
 		panic(errors.New("avg: partial sum is missing"))
 	}
 	if sumVal.Type() != super.TypeFloat64 {
 		panic(fmt.Errorf("avg: partial sum has bad type: %s", sup.FormatValue(*sumVal)))
 	}
 	countVal := partial.Deref(countName)
-	if countVal == nil {
+	if countVal.IsMissing() {
 		panic("avg: partial count is missing")
 	}
 	if countVal.Type() != super.TypeUint64 {

--- a/runtime/sam/expr/eval.go
+++ b/runtime/sam/expr/eval.go
@@ -745,7 +745,7 @@ func indexRecordByName(sctx *super.Context, typ *super.TypeRecord, record scode.
 	}
 	field := super.DecodeString(index.Bytes())
 	val := super.NewValue(typ, record).Ptr().Deref(field)
-	if val == nil {
+	if val.IsMissing() {
 		return sctx.Missing()
 	}
 	return *val

--- a/runtime/sam/expr/function/cast.go
+++ b/runtime/sam/expr/function/cast.go
@@ -130,7 +130,7 @@ func (c *cast) toRecord(from super.Value, to *super.TypeRecord) (super.Value, bo
 	for i, f := range to.Fields {
 		var val2 super.Value
 		fieldVal := from.Deref(f.Name) // deref(fromRecType, from.Bytes(), f.Name)
-		if fieldVal == nil {
+		if fieldVal.IsMissing() {
 			// This field isn't present.  If the target type is optional,
 			// code a none value.  Otherwise, code error missing.
 			if optionType, _ := super.OptionUnion(f.Type); optionType != nil {


### PR DESCRIPTION
Calling IsMissing is to check for a missing value is clearer.