### PR TITLE
Add registered trademark symbol (®) to docs

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -11,4 +11,4 @@ whitespace: true
 MD010:
   code_blocks: false # Disallow hard tabs except in code blocks.
 MD033:
-  allowed_elements: ["p","br"]
+  allowed_elements: ["p","br","span"]

--- a/book/book.toml
+++ b/book/book.toml
@@ -8,7 +8,7 @@ title = "SuperDB"
 enable = true
 
 [output.html]
-additional-css = ["super-example/super-example.css", "copy-button/copy-button.css", "admonitions/admonitions.css"]
+additional-css = ["super-example/super-example.css", "copy-button/copy-button.css", "admonitions/admonitions.css", "trademark/trademark.css"]
 additional-js = ["super-example.bundle.js", "copy-button/copy-button.js"]
 git-repository-url = "https://github.com/brimdata/super/tree/main/book"
 no-section-label = true

--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -1,6 +1,6 @@
 # Introduction
 
-SuperDB is a new type of analytics database that promises an easier approach
+SuperDB<span class="tm">®</span> is a new type of analytics database that promises an easier approach
 to modern data because it unifies relational tables and eclectic JSON in a
 powerful, new data model called [_super-structured data_](formats/model.md).
 SuperDB's query language is a

--- a/book/src/super-sql/intro.md
+++ b/book/src/super-sql/intro.md
@@ -1,6 +1,6 @@
-# SuperSQL
+# SuperSQL<span class="tm">®</span>
 
-SuperSQL is a
+SuperSQL<span class="tm">®</span> is a
 [Pipe SQL](https://research.google/pubs/sql-has-problems-we-can-fix-them-pipe-syntax-in-sql/)
 adapted for
 [super-structured data](../formats/model.md).

--- a/book/trademark/trademark.css
+++ b/book/trademark/trademark.css
@@ -1,0 +1,18 @@
+/* Trademark / registered-trademark marks rendered small and raised, per the
+   common typographic convention, so they aren't visually disruptive. */
+
+.tm {
+  font-size: 0.6em;
+  vertical-align: super;
+  line-height: 0;
+}
+
+/* The book title in the top menu bar comes from book.toml as plain text, so the
+   registered-trademark mark is injected and styled here rather than inline. */
+.menu-title::after {
+  content: "\00AE"; /* ® (registered trademark) */
+  font-size: 0.6em;
+  vertical-align: super;
+  line-height: 0;
+  margin-left: 0.05em;
+}


### PR DESCRIPTION
## What's Changing

The registered trademark symbol (®) is added to the prominent "SuperDB" and "SuperSQL" usages in the book docs.

## Why

Aligns with registration references SUPERDB (Reg. 8056005, registered Dec 9, 2025) and SUPERSQL (Reg. 8300225, registered Jun 16, 2026).

## Details

The symbol is rendered small/raised (superscript-style) via CSS so it reads as a conventional trademark mark and can be easily adjusted. Here's how it looks rendered currently at each page.

<img width="1290" height="1002" alt="image" src="https://github.com/user-attachments/assets/65a9fc54-8e12-43dd-afad-fa35b3f2fa67" />

<img width="1290" height="1002" alt="image" src="https://github.com/user-attachments/assets/5c6a7e07-f8b0-49aa-bfca-51f063b2f9fb" />