### PR TITLE
docs: add docstring for Slice function

### DIFF
--- a/pkg/plural/plural.go
+++ b/pkg/plural/plural.go
@@ -1,5 +1,6 @@
 package plural
 
+// Slice returns an empty string if the slice has exactly one element, otherwise returns the given suffix string. This is useful for handling pluralization in output strings.
 func Slice[S ~[]E, E any](s S, suffix string) string {
 	if len(s) == 1 {
 		return ""


### PR DESCRIPTION
### 问题背景
`Slice` 函数是 `pkg/plural` 包中的公共函数，用于处理复数形式的输出。然而，它缺少文档字符串，这违反了 Go 代码的最佳实践，降低了代码的可读性和维护性。为公共函数添加清晰的文档有助于其他开发者快速理解其用途，尤其是在协作开发中。

### 修改内容
- **为 `Slice` 函数添加了 docstring**：在函数定义前添加了文档字符串，描述其行为：如果切片元素数为1，返回空字符串；否则返回给定的后缀字符串。这明确了函数在复数处理中的作用，提升了代码的可解释性和自文档性。
- **为什么这样改**：遵循 Go 社区的惯例，为所有公共函数提供文档字符串，以增强代码质量和可维护性。这不改变任何功能逻辑，只是添加了必要的注释。

### 验证方式
- **运行现有测试**：通过执行 `go test ./pkg/plural/...` 来验证修改没有引入任何功能变化，所有测试应继续通过。
- **手动检查**：确认 docstring 内容准确描述了函数行为，并符合 Go 文档格式。

### 其他信息
- **没有 breaking changes**：此修改仅添加了文档字符串，不影响函数签名、行为或公共 API。
- **不需要更新外部文档**：docstring 已包含在代码中，为内联文档提供支持，无需额外文档更新。
- **已知限制**：无。