### PR TITLE
remove super.Value.Deoption

### DIFF
--- a/runtime/sam/expr/function/cast.go
+++ b/runtime/sam/expr/function/cast.go
@@ -69,7 +69,7 @@ func deoptionType(sctx *super.Context, typ super.Type) super.Type {
 
 func (c *cast) Cast(from super.Value, to super.Type) (super.Value, bool) {
 	if optionType, _ := super.OptionUnion(to); optionType != nil {
-		val := from.Deoption()
+		val := from.Deunion()
 		if val.Type() == super.TypeNone {
 			return super.None(optionType), true
 		}

--- a/value.go
+++ b/value.go
@@ -447,13 +447,6 @@ func (v Value) DeoptionWithMissing(sctx *Context) Value {
 	return v
 }
 
-func (v Value) Deoption() Value {
-	if union, _ := OptionUnion(v.Type()); union != nil {
-		return v.Deunion()
-	}
-	return v
-}
-
 func (v Value) IsNone() bool {
 	if IsOptionType(v.Type()) {
 		return v.Deunion().Type() == TypeNone


### PR DESCRIPTION
It has only one call site, and it is equivalent to super.Value.Deunion there.