### PR TITLE
add super.Arena to batch value copies in sbuf.Array

### DIFF
--- a/arena.go
+++ b/arena.go
@@ -1,0 +1,47 @@
+package super
+
+import "github.com/brimdata/super/scode"
+
+// arenaChunkSize is the size of each backing chunk an Arena allocates. Values
+// larger than this get their own chunk.
+const arenaChunkSize = 1 << 16 // 64 KiB
+
+// Arena copies the byte payloads of non-native Values into large contiguous
+// chunks. Retaining many values then costs O(total bytes / arenaChunkSize)
+// allocations instead of one bytes.Clone per value. A chunk is never
+// reallocated once it holds a value, so values copied earlier stay valid as
+// later ones are appended; when a chunk runs out of room a fresh one is
+// allocated and the old one is kept alive by the values that reference it.
+//
+// The zero Arena is ready to use. An Arena is not safe for concurrent use.
+type Arena struct {
+	chunk scode.Bytes
+}
+
+// Copy returns a copy of v whose bytes are owned by the arena, equivalent to
+// v.Copy() but without a per-value allocation. Native values carry their
+// payload inline and are returned unchanged. A value with no bytes (including
+// a null) is returned with its bytes unchanged, preserving the nil-vs-empty
+// distinction that bytes.Clone would.
+func (a *Arena) Copy(v Value) Value {
+	if _, ok := v.native(); ok {
+		return v
+	}
+	b := v.bytes()
+	n := len(b)
+	if n == 0 {
+		return NewValue(v.Type(), b)
+	}
+	if cap(a.chunk)-len(a.chunk) < n {
+		size := arenaChunkSize
+		if n > size {
+			size = n
+		}
+		a.chunk = make(scode.Bytes, 0, size)
+	}
+	off := len(a.chunk)
+	a.chunk = append(a.chunk, b...)
+	// Three-index slice so appends to the returned value's bytes can never
+	// scribble into the arena's spare capacity.
+	return NewValue(v.Type(), a.chunk[off:off+n:off+n])
+}

--- a/arena_test.go
+++ b/arena_test.go
@@ -1,0 +1,61 @@
+package super_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/brimdata/super"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArenaCopy(t *testing.T) {
+	t.Run("native value is returned unchanged", func(t *testing.T) {
+		var a super.Arena
+		c := a.Copy(super.NewInt64(42))
+		assert.Equal(t, super.TypeInt64, c.Type())
+		assert.Equal(t, int64(42), super.DecodeInt(c.Bytes()))
+	})
+
+	t.Run("byte-backed copy is independent of its source", func(t *testing.T) {
+		var a super.Arena
+		buf := []byte("hello")
+		c := a.Copy(super.NewValue(super.TypeString, buf))
+		// Overwriting the original backing must not change the arena copy.
+		copy(buf, "world")
+		assert.Equal(t, "hello", string(c.Bytes()))
+	})
+
+	t.Run("null preserves nil bytes", func(t *testing.T) {
+		var a super.Arena
+		c := a.Copy(super.NewValue(super.TypeString, nil))
+		assert.Nil(t, []byte(c.Bytes()))
+	})
+
+	t.Run("values spanning many chunks all survive", func(t *testing.T) {
+		var a super.Arena
+		const n = 20000 // ~30 bytes each => well over the 64 KiB chunk size
+		copies := make([]super.Value, n)
+		want := make([]string, n)
+		for i := range copies {
+			s := fmt.Sprintf("value-%020d", i)
+			want[i] = s
+			copies[i] = a.Copy(super.NewValue(super.TypeString, []byte(s)))
+		}
+		// Every earlier value must survive the chunk allocations triggered by
+		// later ones.
+		for i, c := range copies {
+			require.Equal(t, want[i], string(c.Bytes()))
+		}
+	})
+
+	t.Run("value larger than a chunk is copied correctly", func(t *testing.T) {
+		var a super.Arena
+		big := make([]byte, 1<<17) // 128 KiB > chunk size
+		for i := range big {
+			big[i] = byte(i)
+		}
+		c := a.Copy(super.NewValue(super.TypeString, big))
+		assert.Equal(t, big, []byte(c.Bytes()))
+	})
+}

--- a/sbuf/array.go
+++ b/sbuf/array.go
@@ -9,6 +9,7 @@ import (
 // the Reader interfaces.
 type Array struct {
 	values []super.Value
+	arena  super.Arena
 }
 
 var _ Batch = (*Array)(nil)
@@ -38,7 +39,7 @@ func (a *Array) Append(r super.Value) {
 }
 
 func (a *Array) Write(r super.Value) error {
-	a.Append(r.Copy())
+	a.Append(a.arena.Copy(r))
 	return nil
 }
 


### PR DESCRIPTION
Closes #7064.

### Problem

`sbuf.Array.Write` copies every value with `Value.Copy` → `bytes.Clone`, so it
allocates once per non-native value. Reading a large input into an `Array`
allocates proportionally to the value count — `BenchmarkReadBSUP` (10M values)
does ~10M allocations.

### Change

Add a chunked `super.Arena` and have `sbuf.Array` copy through it:

- value payloads are appended into 64 KiB chunks;
- a chunk is **never reallocated once it holds a value**, so values copied
  earlier remain valid as later ones are appended (when a chunk fills, a fresh
  one is allocated and the old one is kept alive by the values referencing it);
- **native** values carry their payload inline and are returned unchanged (no
  allocation), matching `Value.Copy`;
- a value with **no bytes** (including a null) is returned with its bytes
  unchanged, preserving the nil-vs-empty distinction `bytes.Clone` would;
- the returned bytes use a 3-index slice so appends can't scribble into the
  arena's spare capacity.

### Result

`BenchmarkReadBSUP`:

| | before | after | delta |
|---|---|---|---|
| allocs/op | 10,000,416 | 904 | **−99.99%** |
| B/op | 1.63 Gi | 1.59 Gi | −2.6% |

`ns/op` is unchanged (the benchmark is GC/bandwidth-bound); the win is the
collapse in allocation count and the resulting GC pressure on large reads.

### Testing

- `TestArenaCopy` covers native values, source-buffer independence, null
  (nil-bytes) preservation, values spanning many chunks, and a value larger
  than one chunk.
- `go test -short ./...` passes across the repo (round-trips unchanged).
