### PR TITLE
fix playground examples with input data

### DIFF
--- a/book/super-example/main.go
+++ b/book/super-example/main.go
@@ -64,25 +64,19 @@ func run(opts opts) wasm.Promise {
 		default:
 			return "", errInvalidInput
 		}
-		zctx := super.NewContext()
-		var readers []sio.Reader
-		if r != nil {
-			rc, err := anyio.NewReader(zctx, r, anyio.ReaderOpts{Format: opts.InputFormat})
-			if err != nil {
-				return "", err
-			}
-			defer rc.Close()
-			readers = []sio.Reader{rc}
-		}
 		var buf bytes.Buffer
 		zwc, err := anyio.NewWriter(sio.NopCloser(&buf), anyio.WriterOpts{Format: opts.OutputFormat})
 		if err != nil {
 			return "", err
 		}
 		defer zwc.Close()
-		local := storage.NewLocalEngine()
-		comp := compiler.NewCompiler(local)
-		query, err := runtime.CompileQuery(context.Background(), zctx, comp, flowgraph, readers)
+		eng := storage.NewInternalEngine()
+		if r != nil {
+			flowgraph.PrependFileScan([]string{"stdio:stdin"})
+			eng.AddReader("stdio:stdin", r)
+		}
+		comp := compiler.NewCompiler(eng)
+		query, err := runtime.CompileQuery(context.Background(), super.NewContext(), comp, flowgraph, nil)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
Playground examples that include input data broke with #7049.  They were calling os.Stdin.ReadAt in sio/anyio.FileType (a bug since they read input from runtime/exec.Environment.Stdin, not os.Stdin) and that would fail on wasm/js, causing FileType to return successfully.  For an unclear reason, the change from ReadAt to Stat in #7049 causes FileType to read from os.Stdin, which always fails, causing FileType to return an error.

Fix this by changing book/super-example/main.go to provide input data through os.Stdin (via a storage.InternalEngine) instead of exec.Environment.Stdin (via runtime.CompileQuery's readers parameter).

Fixes #7066.