### PR TITLE
compiler/optimizer: handle runtimes identically in optimizeSourcePaths

### DIFF
--- a/compiler/optimizer/optimizer.go
+++ b/compiler/optimizer/optimizer.go
@@ -249,21 +249,12 @@ func (o *Optimizer) optimizeSourcePaths(seq dag.Seq) (dag.Seq, error) {
 			seq = append(seq, chain...)
 		case *dag.FileScan:
 			o.nent++
-			if o.env.UseVAM() {
-				// Here, we install the filter without a projection.
-				// The demand pass comes subsequently and will add
-				// the projection.
-				op.Pushdown.MetaFilter = newMetaFilter(filter)
-				// Vector file readers don't support DataFilter pushdown yet so no need
-				// to install the filter here.  But we will eventually and this is
-				// where it should be set.
-				return seq, nil
-			}
-			if filter != nil {
-				// Filter without projection.  Projection added later.
-				op.Pushdown.DataFilter = &dag.ScanFilter{Expr: filter}
-			}
-			seq = append(dag.Seq{op}, chain...)
+			// Here, we install the filter without a projection.
+			// The demand pass comes subsequently and will add
+			// the projection.
+			op.Pushdown.DataFilter = &dag.ScanFilter{Expr: filter}
+			op.Pushdown.MetaFilter = newMetaFilter(filter)
+			return seq, nil
 		case *dag.CommitMetaScan:
 			o.nent++
 			if op.Tap {

--- a/compiler/ztests/lift-filters.yaml
+++ b/compiler/ztests/lift-filters.yaml
@@ -1,5 +1,3 @@
-runtime: sam
-
 script: |
   super compile -C -O -dynamic 'from f | values {a:b,c:d} | where a==1 and c==2'
   echo ===
@@ -16,18 +14,34 @@ outputs:
   - name: stdout
     data: |
       file f fields b,d filter (b==1 and d==2)
+         pruner (
+           expr compare(1, b.min, true)>=0 and compare(1, b.max, true)<=0 and compare(2, d.min, true)>=0 and compare(2, d.max, true)<=0
+           fields b.max,b.min,d.max,d.min
+        )
+      | where b==1 and d==2
       | values {a:b,c:d}
       | output main
       ===
       file f fields a filter (a.b==1)
+         pruner (
+           expr compare(1, a.b.min, true)>=0 and compare(1, a.b.max, true)<=0
+           fields a.b.max,a.b.min
+        )
+      | where a.b==1
       | values {...a}
       | output main
       ===
       file f fields c filter (c==1)
+         pruner (
+           expr compare(1, c.min, true)>=0 and compare(1, c.max, true)<=0
+           fields c.max,c.min
+        )
+      | where c==1
       | values {a:{b:c}}
       | output main
       ===
       file f fields b,c,d filter (b+1>=c and b+1<=d)
+      | where b+1>=c and b+1<=d
       | values {a:b,c:c,d:d}
       | output main
       ===

--- a/compiler/ztests/merge-filters.yaml
+++ b/compiler/ztests/merge-filters.yaml
@@ -1,5 +1,3 @@
-runtime: sam
-
 script: |
   super compile -C -O 'from /dev/null | where a | where b'
   echo ===
@@ -13,14 +11,17 @@ outputs:
   - name: stdout
     data: |
       file /dev/null filter (a and b)
+      | where a and b
       | output main
       ===
       fork
         (
           file /dev/null unordered filter (b and c and g)
+          | where b and c and g
         )
         (
           file /dev/zero unordered filter (e and f and g)
+          | where e and f and g
         )
       | output main
       ===

--- a/compiler/ztests/par-count.yaml
+++ b/compiler/ztests/par-count.yaml
@@ -1,7 +1,7 @@
 # Test ensures that flowgraphs utilizing the count operator
 # are not parallelized.
 script: |
-  super compile -vam -C -P 2 'from /dev/null | count {...this,row_number} | aggregate sum(x)'
+  super compile -C -P 2 'from /dev/null | count {...this,row_number} | aggregate sum(x)'
 
 outputs:
   - name: stdout

--- a/compiler/ztests/par-switch.yaml
+++ b/compiler/ztests/par-switch.yaml
@@ -1,6 +1,6 @@
 # A switch operator containing an aggregate operator cannot be parallelized.
 script: |
-  super compile -vam -C -P 2 'from /dev/null | switch default ( aggregate count() ) | sort count'
+  super compile -C -P 2 'from /dev/null | switch default ( aggregate count() ) | sort count'
 
 outputs:
   - name: stdout

--- a/compiler/ztests/pruner-in.yaml
+++ b/compiler/ztests/pruner-in.yaml
@@ -7,7 +7,7 @@ script: |
 outputs:
   - name: stdout
     data: |
-      file test.csup format csup
+      file test.csup format csup filter (x in ["foo","bar"])
          pruner (
            expr compare("foo", x.min, true)>=0 and compare("foo", x.max, true)<=0 or compare("bar", x.min, true)>=0 and compare("bar", x.max, true)<=0
            fields x.max,x.min
@@ -15,7 +15,7 @@ outputs:
       | where x in ["foo","bar"]
       | output main
       // ===
-      file test.csup format csup
+      file test.csup format csup filter (x in {c0:"foo",c1:"bar"})
          pruner (
            expr compare("foo", x.min, true)>=0 and compare("foo", x.max, true)<=0 or compare("bar", x.min, true)>=0 and compare("bar", x.max, true)<=0
            fields x.max,x.min

--- a/compiler/ztests/pruner-regexp.yaml
+++ b/compiler/ztests/pruner-regexp.yaml
@@ -14,7 +14,7 @@ script: |
 outputs:
   - name: stdout
     data: |
-      file test.csup format csup
+      file test.csup format csup filter (regexp_search(r"(?s)^cslab.*?$", x))
          pruner (
            expr compare("cslab", x.max, true)<=0 and compare("cslac", x.min, true)>0
            fields x.max,x.min
@@ -22,7 +22,7 @@ outputs:
       | where regexp_search(r"(?s)^cslab.*?$", x)
       | output main
       // ===
-      file test.csup format csup
+      file test.csup format csup filter (regexp_search(r"^csla[bB].*", x))
          pruner (
            expr compare("csla", x.max, true)<=0 and compare("cslb", x.min, true)>0
            fields x.max,x.min
@@ -30,7 +30,7 @@ outputs:
       | where regexp_search(r"^csla[bB].*", x)
       | output main
       // ===
-      file test.csup format csup
+      file test.csup format csup filter (regexp_search(r"csla[bB].*", x))
       | where regexp_search(r"csla[bB].*", x)
       | output main
       // ===

--- a/compiler/ztests/pushdown.yaml
+++ b/compiler/ztests/pushdown.yaml
@@ -1,5 +1,3 @@
-runtime: sam
-
 script: |
   echo === debug
   super compile -C -O 'from /dev/null | debug a | values b'
@@ -118,6 +116,11 @@ outputs:
       | output main
       === where
       file /dev/null fields a,b,c,d,e filter (a==1 or e==2)
+         pruner (
+           expr compare(1, a.min, true)>=0 and compare(1, a.max, true)<=0 or compare(2, e.min, true)>=0 and compare(2, e.max, true)<=0
+           fields a.max,a.min,e.max,e.min
+        )
+      | where a==1 or e==2
       | values c, b, d
       | output main
       ===

--- a/compiler/ztests/remove-passops.yaml
+++ b/compiler/ztests/remove-passops.yaml
@@ -1,9 +1,12 @@
-runtime: sam
-
 script: super compile -O -C 'from /dev/null | x>1 | pass | pass | x>2 | pass'
 
 outputs:
   - name: stdout
     data: |
       file /dev/null filter (x>1 and x>2)
+         pruner (
+           expr compare(x.max, 1, true)>0 and compare(x.max, 2, true)>0
+           fields x.max
+        )
+      | where x>1 and x>2
       | output main


### PR DESCRIPTION
When compiler/optimizer.Optimizer.optimizeSourcePaths encounters a dag.FileScan followed by a dag.FilterOp, it drops sets FilterOp.PushDown.DataFilter and drops the FilterOp for sam but not vam, and it sets FilterOp.PushDown.MetaFilter for vam but not sam.

Change optimizeSourcePaths to set both DataFilter and MetaFilter and to keep the FilterOp for both runtimes.  This will make for a smaller diff when sam is removed.