### PR TITLE
Add registered trademark symbol in one more SuperSQL appearance

### DIFF
--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -302,7 +302,7 @@ $ super -c "SELECT a, typeof(a) as type FROM 'example2.json'"
 {a:1,type:<int64>}
 ```
 
-## SuperSQL
+## SuperSQL<span class="tm">®</span>
 
 Since super-structured data is a superset of the relational model, it turns out that
 a query language for super-structured data can be devised that is a superset of SQL.

--- a/book/trademark/trademark.css
+++ b/book/trademark/trademark.css
@@ -10,7 +10,7 @@
 /* The sidebar's "on this page" list is built by cloning heading markup
    (toc.js filterHeader), which copies the ® span into the nav. The mark belongs
    on the headings themselves, not in navigation, so hide it in the sidebar. */
-#mdbook-sidebar .tm {
+.sidebar .tm {
   display: none;
 }
 

--- a/book/trademark/trademark.css
+++ b/book/trademark/trademark.css
@@ -7,6 +7,13 @@
   line-height: 0;
 }
 
+/* The sidebar's "on this page" list is built by cloning heading markup
+   (toc.js filterHeader), which copies the ® span into the nav. The mark belongs
+   on the headings themselves, not in navigation, so hide it in the sidebar. */
+#mdbook-sidebar .tm {
+  display: none;
+}
+
 /* The book title in the top menu bar comes from book.toml as plain text, so the
    registered-trademark mark is injected and styled here rather than inline. */
 .menu-title::after {


### PR DESCRIPTION
At separate times when both @mccanne and I went looking for the (®) registered trademark symbols added in #7057, we instinctively reached for this reference to "SuperSQL" in the left hand nav, though the spot where it was added in the the PR was attached to the "SuperSQL" reference further down the left hand nav where it was the top-level header of a bigger page. But I take this as a sign that the symbol probably belongs in this other spot too, so, adding it here.

<img width="1568" height="1124" alt="image" src="https://github.com/user-attachments/assets/e0bbeda3-809d-47f8-820c-aaf04a2de2ae" />
