### PR TITLE
fix panic on named type in count by string

### DIFF
--- a/runtime/vam/op/aggregate/aggtable.go
+++ b/runtime/vam/op/aggregate/aggtable.go
@@ -161,7 +161,7 @@ func (c *countByString) update(keys, vals []vector.Any) {
 		c.updatePartial(keys[0], vals[0])
 		return
 	}
-	switch val := keys[0].(type) {
+	switch val := vector.Under(keys[0]).(type) {
 	case *vector.String:
 		c.count(val)
 	case *vector.Dict:

--- a/runtime/ztests/op/aggregate/count-by-string.yaml
+++ b/runtime/ztests/op/aggregate/count-by-string.yaml
@@ -1,0 +1,26 @@
+spq: count() by x | sort x
+
+input: |
+  type s = string
+  {x:"a"::s}
+  {x:"b"::s}
+  {x:"c"::s}
+  {x:"d"::s}
+  {x:"e"::s}
+  {x:"a"}
+  {x:"b"}
+  {x:"c"}
+  {x:"d"}
+  {x:"a"}
+  {x:"b"}
+  {x:"c"}
+  {x:"a"}
+  {x:"b"}
+  {x:"a"}
+
+output: |
+  {x:"a",count:5}
+  {x:"b",count:4}
+  {x:"c",count:3}
+  {x:"d",count:2}
+  {x:"e",count:1}


### PR DESCRIPTION
runtime/vam/op/aggregate.countByString.update panics on vector.Named.

Fixes #7074.