### PR TITLE
Expand "from" error message to be explicit about f-string parameter

### DIFF
--- a/book/src/super-sql/operators/from.md
+++ b/book/src/super-sql/operators/from.md
@@ -293,7 +293,7 @@ _Only an f-string source lets `from` take input from upstream (any other source 
 echo '1 2' | super -s -c "values this | from inputfile" -
 ```
 ```mdtest-output
-from operator cannot read from a parent operator unless its argument is an f-string evaluated for each input value at line 1, column 20:
+from operator cannot have parent unless its argument is a non-constant f-string at line 1, column 20:
 values this | from inputfile
                    ~~~~~~~~~
 ```

--- a/book/src/super-sql/operators/from.md
+++ b/book/src/super-sql/operators/from.md
@@ -287,7 +287,7 @@ echo '"a.sup" "b.sup"' | super -s -c "from f'{this}' | c:=coalesce(a,b)+1" -
 {b:4,c:5}
 ```
 
-_Only an f-string source lets `from` take input from upstream (any other source is an error)_
+_Only a non-constant f-string source lets `from` take input from upstream (any other source is an error)_
 
 ```mdtest-command fails
 echo '1 2' | super -s -c "values this | from inputfile" -

--- a/book/src/super-sql/operators/from.md
+++ b/book/src/super-sql/operators/from.md
@@ -271,7 +271,7 @@ super -s -c 'from https://api.github.com/repos/brimdata/super | values name'
 
 ---
 
-## F-String Example
+## F-String Examples
 
 _Read from dynamically defined files and add a column_
 
@@ -285,6 +285,17 @@ echo '"a.sup" "b.sup"' | super -s -c "from f'{this}' | c:=coalesce(a,b)+1" -
 {a:2,c:3}
 {b:3,c:4}
 {b:4,c:5}
+```
+
+_Only an f-string source lets `from` take input from upstream (any other source is an error)_
+
+```mdtest-command fails
+echo '1 2' | super -s -c "values this | from inputfile" -
+```
+```mdtest-output
+from operator cannot read from a parent operator unless its argument is an f-string evaluated for each input value at line 1, column 20:
+values this | from inputfile
+                   ~~~~~~~~~
 ```
 
 ---

--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -222,7 +222,7 @@ func hasError(val super.Value) bool {
 
 func (t *translator) hasFromParent(loc ast.Node, seq sem.Seq) sem.Seq {
 	if len(seq) > 0 {
-		t.error(loc, errors.New("from operator cannot have parent unless from argument is an expression"))
+		t.error(loc, errors.New("from operator cannot read from a parent operator unless its argument is an f-string evaluated for each input value"))
 		return append(seq, badOp)
 	}
 	return nil

--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -222,7 +222,7 @@ func hasError(val super.Value) bool {
 
 func (t *translator) hasFromParent(loc ast.Node, seq sem.Seq) sem.Seq {
 	if len(seq) > 0 {
-		t.error(loc, errors.New("from operator cannot read from a parent operator unless its argument is an f-string evaluated for each input value"))
+		t.error(loc, errors.New("from operator cannot have parent unless its argument is a non-constant f-string"))
 		return append(seq, badOp)
 	}
 	return nil


### PR DESCRIPTION
## What's Changing

A `from` error message is made more explicit, and a docs example is also added that shows the triggering of that error.

## Why

A user asked, in their own words:

> I am a bit mesmerized by this message: `from operator cannot have parent unless from argument is an expression` :slightly_smiling_face:
> I get this from time to time and I don't seem to be getting the reason why!

I explained it to them by pointing at the relevant portions of the current `from` docs, but seeing it through their eyes I understood why it was confusing and we agreed that the error message and docs could be improved.
