### PR TITLE
Don't check sqlite links due to HTTP 503 errors

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -16,3 +16,6 @@ ignorePatterns:
   - pattern: '^https://www.researchgate.net/publication/221325979_Union_Types_for_Semistructured_Data$'
   - pattern: '^https://db.cs.cmu.edu/papers/2024/whatgoesaround-sigmodrec2024.pdf$'
   - pattern: '^https://openproceedings.org/2017/conf/edbt/paper-62.pdf$'
+
+# Not crawling the following due to persistent HTTP 503 errors
+  - pattern: '^https://sqlite.org'


### PR DESCRIPTION
For weeks now the link checker has been failing when trying to crawl the sqlite URL that's in our docs. It fails when attempted as a user too:

<img width="759" height="272" alt="image" src="https://github.com/user-attachments/assets/41387c3f-47c5-4694-b41a-b005e3ed525e" />

I figured at some point they'd care enough and fix it, but I'm sick of waiting, so, adding an exception.