### PR TITLE
preserve named types in count by string

### DIFF
--- a/runtime/vam/op/aggregate/aggregate.go
+++ b/runtime/vam/op/aggregate/aggregate.go
@@ -179,7 +179,7 @@ func (a *Aggregate) newAggTable(keyTypes []super.Type) aggTable {
 	// Check if we can us an optimized table, else go slow path.
 	if a.isCountByString(keyTypes) && len(a.aggs) == 1 && a.aggs[0].Where == nil {
 		// countByString.update does not handle nulls in its vals param.
-		return newCountByString(a.builder, a.partialsIn)
+		return newCountByString(keyTypes[0], a.builder, a.partialsIn)
 	}
 	return &superTable{
 		aggs:        a.aggs,

--- a/runtime/vam/op/aggregate/aggtable.go
+++ b/runtime/vam/op/aggregate/aggtable.go
@@ -142,14 +142,16 @@ func (s *superTable) materializeAgg(i int) vector.Any {
 }
 
 type countByString struct {
+	typ        super.Type
 	nulls      int64
 	table      map[string]int64
 	builder    *vector.RecordBuilder
 	partialsIn bool
 }
 
-func newCountByString(b *vector.RecordBuilder, partialsIn bool) aggTable {
+func newCountByString(typ super.Type, b *vector.RecordBuilder, partialsIn bool) aggTable {
 	return &countByString{
+		typ:        typ,
 		builder:    b,
 		table:      make(map[string]int64),
 		partialsIn: partialsIn,
@@ -176,7 +178,7 @@ func (c *countByString) update(keys, vals []vector.Any) {
 }
 
 func (c *countByString) updatePartial(keyvec, valvec vector.Any) {
-	key, ok1 := keyvec.(*vector.String)
+	key, ok1 := vector.Under(keyvec).(*vector.String)
 	val, ok2 := valvec.(*vector.Int)
 	if !ok1 || !ok2 {
 		panic("count by string: invalid partials in")
@@ -236,7 +238,10 @@ func (c *countByString) materialize() vector.Any {
 		counts = append(counts, c.nulls)
 		offs = append(offs, uint32(len(bytes)))
 	}
-	keyVec := vector.NewString(vector.NewBytesTable(offs, bytes))
+	keyVec := vector.Any(vector.NewString(vector.NewBytesTable(offs, bytes)))
+	if n, ok := c.typ.(*super.TypeNamed); ok {
+		keyVec = vector.NewNamed(n, keyVec)
+	}
 	countVec := vector.NewInt(super.TypeInt64, counts)
 	return c.builder.New([]vector.Any{keyVec, countVec})
 }

--- a/runtime/ztests/op/aggregate/count-by-string.yaml
+++ b/runtime/ztests/op/aggregate/count-by-string.yaml
@@ -1,7 +1,7 @@
 spq: count() by x | sort x
 
 input: |
-  type s = string
+  type s=string
   {x:"a"::s}
   {x:"b"::s}
   {x:"c"::s}
@@ -19,8 +19,13 @@ input: |
   {x:"a"}
 
 output: |
-  {x:"a",count:5}
-  {x:"b",count:4}
-  {x:"c",count:3}
-  {x:"d",count:2}
-  {x:"e",count:1}
+  type s=string
+  {x:"a"::s,count:1}
+  {x:"a",count:4}
+  {x:"b"::s,count:1}
+  {x:"b",count:3}
+  {x:"c"::s,count:1}
+  {x:"c",count:2}
+  {x:"d"::s,count:1}
+  {x:"d",count:1}
+  {x:"e"::s,count:1}

--- a/runtime/ztests/op/aggregate/count-by-string.yaml
+++ b/runtime/ztests/op/aggregate/count-by-string.yaml
@@ -1,12 +1,8 @@
-spq: count() by x | sort x
+spq: count() by x | sort typeof(x), x
 
 input: |
   type s=string
   {x:"a"::s}
-  {x:"b"::s}
-  {x:"c"::s}
-  {x:"d"::s}
-  {x:"e"::s}
   {x:"a"}
   {x:"b"}
   {x:"c"}
@@ -22,10 +18,6 @@ output: |
   type s=string
   {x:"a"::s,count:1}
   {x:"a",count:4}
-  {x:"b"::s,count:1}
   {x:"b",count:3}
-  {x:"c"::s,count:1}
   {x:"c",count:2}
-  {x:"d"::s,count:1}
   {x:"d",count:1}
-  {x:"e"::s,count:1}

--- a/sio/bsupio/ztests/zctx-named-reset-2.yaml
+++ b/sio/bsupio/ztests/zctx-named-reset-2.yaml
@@ -1,5 +1,3 @@
-skip: panics
-
 # Test that type names are properly reset and reusable after stream boundaries.
 script: |
   super -c "head 1" in.sup > t1.bsup


### PR DESCRIPTION
runtime/ztests/op/aggregate.countByString discards named types. Match the behavior of superTable by preserving them.

@mattnibs: This turned out to be much simpler than I had suggested.