### PR TITLE
compiler/semantic: fix duplicate errors for cut operator

### DIFF
--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -732,7 +732,10 @@ func (t *translator) semOp(o ast.Op, seq sem.Seq, inType super.Type) (sem.Seq, s
 		// anyway, but we don't want to change cut until we're ready to do that work.
 		for k, arg := range o.Args {
 			if arg.LHS == nil {
+				// Push and pop to prevent duplicating errors from t.assignments below.
+				t.checker.pushErrs()
 				rhs, _ := t.expr(arg.RHS, inType)
+				t.checker.popErrs()
 				if _, ok := isLval(rhs); ok {
 					o.Args[k].LHS = arg.RHS
 				}

--- a/compiler/ztests/cut.yaml
+++ b/compiler/ztests/cut.yaml
@@ -1,0 +1,21 @@
+script: |
+  super compile -C -dag 'values {x:1} | cut x'
+  ! super compile -C -dag 'cut x'
+  ! super compile -C -dag 'values {x:1} | cut x,y'
+
+
+outputs:
+  - name: stdout
+    data: |
+      null
+      | values {x:1}
+      | cut x:=x
+      | output main
+  - name: stderr
+    data: |
+      no such field "x" at line 1, column 5:
+      cut x
+          ~
+      no such field "y" at line 1, column 22:
+      values {x:1} | cut x,y
+                           ~


### PR DESCRIPTION
Errors for cut operator field assignments without an RHS (e.g., `cut x`) are duplicated.  Fix that by discarding any errors when checker.semOp is trying to infer the RHS.

Fixes #7085.