### PR TITLE
vam: handle view of union in defuse()

### DIFF
--- a/runtime/vam/expr/function/defuse.go
+++ b/runtime/vam/expr/function/defuse.go
@@ -45,7 +45,7 @@ func (d *Defuse) eval(in vector.Any) vector.Any {
 	case vector.KindMap:
 		return d.defuseMap(in)
 	case vector.KindUnion:
-		u := in.(*vector.Union)
+		u := vector.PushView(in).(*vector.Union)
 		return vector.Apply(vector.ApplyNone, d.Call, u.Dynamic())
 	case vector.KindError:
 		return d.defuseError(in)


### PR DESCRIPTION
This doesn't include a test because we don't have a reliable way to write ztests that will create views.