### PR TITLE
Add Fused Type Info to CSUP file

### DIFF
--- a/cmd/super/dev/csup/command.go
+++ b/cmd/super/dev/csup/command.go
@@ -1,7 +1,6 @@
 package csup
 
 import (
-	"bufio"
 	"errors"
 	"flag"
 	"fmt"
@@ -10,10 +9,10 @@ import (
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/cli/outputflags"
 	"github.com/brimdata/super/cmd/super/dev"
+	"github.com/brimdata/super/csup"
 	"github.com/brimdata/super/sbuf"
 	"github.com/brimdata/super/vector/vio"
 
-	"github.com/brimdata/super/csup"
 	"github.com/brimdata/super/pkg/charm"
 	"github.com/brimdata/super/pkg/storage"
 	"github.com/brimdata/super/sio/bsupio"
@@ -36,11 +35,13 @@ func init() {
 type Command struct {
 	*dev.Command
 	outputFlags outputflags.Flags
+	printTypes  bool
 }
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*dev.Command)}
 	c.outputFlags.SetFlags(f)
+	f.BoolVar(&c.printTypes, "type", false, "output fused type of file")
 	return c, nil
 }
 
@@ -67,31 +68,87 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	sctx := super.NewContext()
-	reader := bufio.NewReader(r)
-	vals, err := readMeta(sctx, reader)
-	if err == nil {
-		err = vio.Copy(writer, sbuf.NewDematerializer(sctx, sbuf.NewPuller(vals)))
+	if c.printTypes {
+		return c.types(r, writer)
 	}
+	var vals []super.Value
+	sctx := super.NewContext()
+	marshaler := sup.NewBSUPMarshalerWithContext(sctx)
+	for {
+		hdr, err := readHeader(r)
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+		val, err := marshaler.Marshal(hdr)
+		if err != nil {
+			return err
+		}
+		vals = append(vals, val)
+		switch hdr.SectionType {
+		case csup.SectionObject:
+			vals, err = readObject(sctx, marshaler, r, vals)
+			if err != nil {
+				return err
+			}
+		case csup.SectionFooter:
+			vals, err = readFooter(sctx, marshaler, r, vals)
+			if err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("invalid CSUP section type: %c", hdr.SectionType)
+		}
+	}
+	err = writer.Push(sbuf.Dematerialize(sctx, sbuf.NewArray(vals)))
 	if err2 := writer.Close(); err == nil {
 		err = err2
 	}
 	return err
 }
 
-func readMeta(sctx *super.Context, r *bufio.Reader) (*sbuf.Array, error) {
-	marshaler := sup.NewBSUPMarshalerWithContext(sctx)
-	hdr, err := readHeader(r)
-	if err != nil && err != io.EOF {
-		return nil, err
+func (c *Command) types(r storage.Reader, w vio.PushCloser) error {
+	sctx := super.NewContext()
+	typ, err := csup.FusedType(sctx, r)
+	if err != nil {
+		return err
 	}
-	metaReader := bsupio.NewReader(sctx, io.LimitReader(r, int64(hdr.MetaSize)))
+	val := sctx.LookupTypeValue(typ)
+	err = w.Push(sbuf.Dematerialize(sctx, sbuf.NewArray([]super.Value{val})))
+	if err2 := w.Close(); err == nil {
+		err = err2
+	}
+	return err
+}
+
+func readHeader(r io.Reader) (csup.Header, error) {
+	var bytes [csup.HeaderSize]byte
+	_, err := io.ReadFull(r, bytes[:])
+	if err != nil {
+		return csup.Header{}, err
+	}
+	var hdr csup.Header
+	err = hdr.Deserialize(bytes[:])
+	return hdr, err
+}
+
+func readObject(sctx *super.Context, marshaler *sup.MarshalBSUPContext, r io.Reader, vals []super.Value) ([]super.Value, error) {
+	var bytes [csup.DataHeaderSize]byte
+	if _, err := io.ReadFull(r, bytes[:]); err != nil {
+		return vals, err
+	}
+	var hdr csup.DataHeader
+	if err := hdr.Deserialize(bytes[:]); err != nil {
+		return vals, err
+	}
 	val, err := marshaler.Marshal(hdr)
 	if err != nil {
-		return nil, err
+		return vals, err
 	}
-	var vals []super.Value
 	vals = append(vals, val)
+	metaReader := bsupio.NewReader(sctx, io.LimitReader(r, int64(hdr.MetaSize)))
 	for {
 		val, err := metaReader.Read()
 		if err != nil {
@@ -127,31 +184,47 @@ func readMeta(sctx *super.Context, r *bufio.Reader) (*sbuf.Array, error) {
 	if valp != nil {
 		return nil, errors.New("CSUP type section has more than one value")
 	}
-	return sbuf.NewArray(vals), skip(r, int(hdr.DataSize))
+	buf, err := io.ReadAll(io.LimitReader(r, int64(hdr.DataSize)))
+	if err == nil && len(buf) != int(hdr.DataSize) {
+		err = fmt.Errorf("truncated CSUP data: data section %d but read only %d", hdr.DataSize, len(buf))
+	}
+	return vals, err
 }
 
-func readHeader(r io.Reader) (csup.Header, error) {
-	var bytes [csup.HeaderSize]byte
-	cc, err := r.Read(bytes[:])
+func readFooter(sctx *super.Context, marshaler *sup.MarshalBSUPContext, r io.Reader, vals []super.Value) ([]super.Value, error) {
+	var bytes [csup.FooterSize]byte
+	if _, err := io.ReadFull(r, bytes[:]); err != nil {
+		return vals, err
+	}
+	var f csup.Footer
+	f.Deserialize(bytes[:])
+	val, err := marshaler.Marshal(f)
 	if err != nil {
-		return csup.Header{}, err
+		return vals, err
 	}
-	if cc != csup.HeaderSize {
-		return csup.Header{}, fmt.Errorf("truncated CSUP file: %d bytes of %d read", cc, csup.HeaderSize)
+	vals = append(vals, val)
+	typeBytes := make([]byte, f.MetaSize)
+	if _, err := io.ReadFull(r, typeBytes); err != nil {
+		return vals, err
 	}
-	var h csup.Header
-	if err := h.Deserialize(bytes[:]); err != nil {
-		return csup.Header{}, err
+	typ, err := sctx.LookupByValue(typeBytes)
+	if err != nil {
+		return vals, err
 	}
-	return h, nil
-}
-
-func skip(r *bufio.Reader, n int) error {
-	got, err := r.Discard(n)
-	if n != got {
-		return fmt.Errorf("truncated CSUP data: data section %d but read only %d", n, got)
+	vals = append(vals, sctx.LookupTypeValue(typ))
+	var trailerBytes [csup.TrailerSize]byte
+	if _, err := io.ReadFull(r, trailerBytes[:]); err != nil {
+		return vals, err
 	}
-	return err
+	var t csup.Trailer
+	if err := t.Deserialize(trailerBytes[:]); err != nil {
+		return vals, err
+	}
+	if val, err = marshaler.Marshal(t); err != nil {
+		return vals, err
+	}
+	vals = append(vals, val)
+	return vals, nil
 }
 
 func marshalTypeDefs(marshaler *sup.MarshalBSUPContext, vals []super.Value, bytes []byte) ([]super.Value, error) {

--- a/csup/fusedtype.go
+++ b/csup/fusedtype.go
@@ -1,0 +1,50 @@
+package csup
+
+import (
+	"errors"
+	"io"
+	"math"
+
+	"github.com/brimdata/super"
+	"github.com/brimdata/super/runtime/sam/expr/agg"
+)
+
+func FusedType(sctx *super.Context, r io.ReaderAt) (super.Type, error) {
+	s, ok := r.(io.Seeker)
+	if !ok {
+		return nil, errors.New("reading file type requires seekable input")
+	}
+	size, err := s.Seek(0, io.SeekEnd)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := s.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+	fuser := agg.NewFuser(super.NewContext(), false)
+	for size > 0 {
+		typ, n, err := readPart(sctx, r, size)
+		if err != nil {
+			if err == io.EOF {
+				err = nil
+			}
+			return nil, err
+		}
+		fuser.Fuse(typ)
+		size -= n
+	}
+	return fuser.Type(), nil
+}
+
+func readPart(sctx *super.Context, s io.ReaderAt, size int64) (super.Type, int64, error) {
+	t, err := ReadTrailer(io.NewSectionReader(s, size-TrailerSize, math.MaxInt64))
+	if err != nil {
+		return nil, 0, err
+	}
+	bytes := make([]byte, t.MetaSize)
+	if _, err := io.ReadFull(io.NewSectionReader(s, size-TrailerSize-int64(t.MetaSize), int64(t.MetaSize)), bytes); err != nil {
+		return nil, 0, err
+	}
+	typ, err := sctx.LookupByValue(bytes)
+	return typ, int64(t.Size), err
+}

--- a/csup/header.go
+++ b/csup/header.go
@@ -5,65 +5,92 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 )
 
 const (
-	Version     = 22
-	HeaderSize  = 36
-	MaxMetaSize = 100 * 1024 * 1024
-	MaxTypeSize = 100 * 1024 * 1024
-	MaxDataSize = 2 * 1024 * 1024 * 1024
+	Version        = 23
+	HeaderSize     = 9
+	DataHeaderSize = 36
+	FooterSize     = 4
+	TrailerSize    = 16
+	MaxMetaSize    = 100 * 1024 * 1024
+	MaxTypeSize    = 100 * 1024 * 1024
+	MaxDataSize    = 2 * 1024 * 1024 * 1024
 )
 
-type Header struct {
-	Version  uint32
-	MetaSize uint64
-	TypeSize uint64
-	DataSize uint64
-	Root     uint32
+type SectionType byte
+
+const (
+	SectionObject SectionType = 'O'
+	SectionFooter SectionType = 'F'
+)
+
+type Section struct {
+	Type   SectionType
+	Object DataHeader
+	Footer Footer
 }
 
-func (h Header) Serialize() []byte {
+func ReadSection(r io.ReaderAt) (Section, error) {
+	h, err := ReadHeader(r)
+	if err != nil {
+		return Section{}, err
+	}
+	s := Section{Type: h.SectionType}
+	switch h.SectionType {
+	case SectionObject:
+		s.Object, err = ReadDataHeader(io.NewSectionReader(r, int64(h.Size()), math.MaxInt64))
+	case SectionFooter:
+		s.Footer, err = ReadFooter(io.NewSectionReader(r, int64(h.Size()), math.MaxInt64))
+	default:
+		panic(fmt.Sprintf("invalid CSUP section type: %c", h.SectionType))
+	}
+	if err == io.EOF {
+		err = io.ErrUnexpectedEOF
+	}
+	return s, err
+}
+
+func (s *Section) Size() uint64 {
+	if s.Type == SectionObject {
+		return HeaderSize + s.Object.Size()
+	}
+	return HeaderSize + s.Footer.Size()
+}
+
+type Header struct {
+	Version     uint32
+	SectionType SectionType
+}
+
+func (o Header) Serialize() []byte {
 	var bytes [HeaderSize]byte
 	bytes[0] = 'C'
 	bytes[1] = 'S'
 	bytes[2] = 'U'
 	bytes[3] = 'P'
-	binary.LittleEndian.PutUint32(bytes[4:], h.Version)
-	binary.LittleEndian.PutUint64(bytes[8:], h.MetaSize)
-	binary.LittleEndian.PutUint64(bytes[16:], h.TypeSize)
-	binary.LittleEndian.PutUint64(bytes[24:], h.DataSize)
-	binary.LittleEndian.PutUint32(bytes[32:], h.Root)
+	binary.LittleEndian.PutUint32(bytes[4:], o.Version)
+	bytes[8] = byte(o.SectionType)
 	return bytes[:]
 }
 
-func (h *Header) Deserialize(bytes []byte) error {
+func (o *Header) Deserialize(bytes []byte) error {
 	if len(bytes) != HeaderSize || bytes[0] != 'C' || bytes[1] != 'S' || bytes[2] != 'U' || bytes[3] != 'P' {
 		return errors.New("invalid CSUP header")
 	}
-	h.Version = binary.LittleEndian.Uint32(bytes[4:])
-	h.MetaSize = binary.LittleEndian.Uint64(bytes[8:])
-	h.TypeSize = binary.LittleEndian.Uint64(bytes[16:])
-	h.DataSize = binary.LittleEndian.Uint64(bytes[24:])
-	h.Root = binary.LittleEndian.Uint32(bytes[32:])
-	if h.Version != Version {
-		return fmt.Errorf("CSUP version mismatch: expected %d, found %d", Version, h.Version)
+	o.Version = binary.LittleEndian.Uint32(bytes[4:])
+	o.SectionType = SectionType(bytes[8])
+	if o.Version != Version {
+		return fmt.Errorf("CSUP version mismatch: expected %d, found %d", Version, o.Version)
 	}
-	if h.MetaSize > MaxMetaSize {
-		return fmt.Errorf("CSUP metadata section too big: %d bytes", h.MetaSize)
-	}
-	if h.MetaSize > MaxTypeSize {
-		return fmt.Errorf("CSUP type section too big: %d bytes", h.TypeSize)
-	}
-	if h.DataSize > MaxDataSize {
-		return fmt.Errorf("CSUP data section too big: %d bytes", h.DataSize)
+	if o.SectionType != SectionObject && o.SectionType != SectionFooter {
+		return fmt.Errorf("invalid CSUP section type %c", o.SectionType)
 	}
 	return nil
 }
 
-func (h *Header) ObjectSize() uint64 {
-	return HeaderSize + h.MetaSize + h.TypeSize + h.DataSize
-}
+func (o *Header) Size() uint64 { return HeaderSize }
 
 func ReadHeader(r io.ReaderAt) (Header, error) {
 	var bytes [HeaderSize]byte
@@ -79,4 +106,128 @@ func ReadHeader(r io.ReaderAt) (Header, error) {
 		return Header{}, err
 	}
 	return h, nil
+}
+
+type DataHeader struct {
+	MetaSize uint64
+	TypeSize uint64
+	DataSize uint64
+	Root     uint32
+}
+
+func ReadDataHeader(r io.ReaderAt) (DataHeader, error) {
+	var bytes [DataHeaderSize]byte
+	n, err := r.ReadAt(bytes[:], 0)
+	if err != nil {
+		return DataHeader{}, err
+	}
+	if n < DataHeaderSize {
+		return DataHeader{}, fmt.Errorf("short CSUP object header: %d bytes read", n)
+	}
+	var h DataHeader
+	if err := h.Deserialize(bytes[:]); err != nil {
+		return DataHeader{}, err
+	}
+	return h, nil
+}
+
+func (o *DataHeader) Size() uint64 {
+	return DataHeaderSize + o.MetaSize + o.TypeSize + o.DataSize
+}
+
+func (o DataHeader) Serialize() []byte {
+	var bytes [DataHeaderSize]byte
+	binary.LittleEndian.PutUint64(bytes[:], o.MetaSize)
+	binary.LittleEndian.PutUint64(bytes[8:], o.TypeSize)
+	binary.LittleEndian.PutUint64(bytes[16:], o.DataSize)
+	binary.LittleEndian.PutUint32(bytes[24:], o.Root)
+	return bytes[:]
+}
+
+func (o *DataHeader) Deserialize(bytes []byte) error {
+	o.MetaSize = binary.LittleEndian.Uint64(bytes)
+	o.TypeSize = binary.LittleEndian.Uint64(bytes[8:])
+	o.DataSize = binary.LittleEndian.Uint64(bytes[16:])
+	o.Root = binary.LittleEndian.Uint32(bytes[24:])
+	if o.MetaSize > MaxMetaSize {
+		return fmt.Errorf("CSUP metadata section too big: %d bytes", o.MetaSize)
+	}
+	if o.MetaSize > MaxTypeSize {
+		return fmt.Errorf("CSUP type section too big: %d bytes", o.TypeSize)
+	}
+	if o.DataSize > MaxDataSize {
+		return fmt.Errorf("CSUP data section too big: %d bytes", o.DataSize)
+	}
+	return nil
+}
+
+type Footer struct {
+	MetaSize uint32
+}
+
+func ReadFooter(r io.ReaderAt) (Footer, error) {
+	var bytes [FooterSize]byte
+	cc, err := r.ReadAt(bytes[:], 0)
+	if err != nil {
+		return Footer{}, err
+	}
+	if cc < FooterSize {
+		return Footer{}, fmt.Errorf("short CSUP footer: %d bytes read", cc)
+	}
+	var f Footer
+	f.Deserialize(bytes[:])
+	return f, nil
+}
+
+func (f Footer) Serialize() []byte {
+	var bytes [FooterSize]byte
+	binary.LittleEndian.PutUint32(bytes[:], f.MetaSize)
+	return bytes[:]
+}
+
+func (f *Footer) Deserialize(bytes []byte) {
+	f.MetaSize = binary.LittleEndian.Uint32(bytes)
+}
+
+func (f *Footer) Size() uint64 {
+	return FooterSize + uint64(f.MetaSize) + TrailerSize
+}
+
+type Trailer struct {
+	Size     uint64
+	MetaSize uint32
+}
+
+func ReadTrailer(r io.ReaderAt) (Trailer, error) {
+	var bytes [TrailerSize]byte
+	cc, err := r.ReadAt(bytes[:], 0)
+	if err != nil {
+		return Trailer{}, err
+	}
+	if cc < TrailerSize {
+		return Trailer{}, fmt.Errorf("short CSUP trailer: %d bytes read", cc)
+	}
+	var t Trailer
+	t.Deserialize(bytes[:])
+	return t, nil
+}
+
+func (t Trailer) Serialize() []byte {
+	var bytes [TrailerSize]byte
+	binary.LittleEndian.PutUint64(bytes[:], t.Size)
+	binary.LittleEndian.PutUint32(bytes[8:], t.MetaSize)
+	bytes[12] = 'C'
+	bytes[13] = 'S'
+	bytes[14] = 'U'
+	bytes[15] = 'P'
+	return bytes[:]
+}
+
+func (t *Trailer) Deserialize(bytes []byte) error {
+	if len(bytes) != TrailerSize || string(bytes[12:16]) != "CSUP" {
+		return errors.New("invalid CSUP trailer")
+	}
+	t.Size = binary.LittleEndian.Uint64(bytes)
+	t.MetaSize = binary.LittleEndian.Uint32(bytes[8:])
+	return nil
 }

--- a/csup/object.go
+++ b/csup/object.go
@@ -17,6 +17,7 @@
 package csup
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -28,29 +29,33 @@ import (
 type Object struct {
 	cctx     *Context
 	readerAt io.ReaderAt
-	header   Header
+	header   DataHeader
 }
 
 func NewObject(r io.ReaderAt) (*Object, error) {
-	hdr, err := ReadHeader(r)
+	s, err := ReadSection(r)
 	if err != nil {
 		return nil, err
 	}
-	return NewObjectFromHeader(r, hdr)
+	if s.Type != SectionObject {
+		return nil, errors.New("cannot create object from footer section")
+	}
+	return NewObjectFromHeader(r, s.Object)
 }
 
-func NewObjectFromHeader(r io.ReaderAt, hdr Header) (*Object, error) {
+func NewObjectFromHeader(r io.ReaderAt, hdr DataHeader) (*Object, error) {
 	cctx := NewContext()
-	if err := cctx.readMeta(io.NewSectionReader(r, HeaderSize, int64(hdr.MetaSize))); err != nil {
+	off := int64(HeaderSize + DataHeaderSize)
+	if err := cctx.readMeta(io.NewSectionReader(r, off, int64(hdr.MetaSize))); err != nil {
 		return nil, err
 	}
 	if hdr.Root >= uint32(len(cctx.values)) {
 		return nil, fmt.Errorf("CSUP root ID %d larger than values table (len %d)", hdr.Root, len(cctx.values))
 	}
-	cctx.subtypesReader = io.NewSectionReader(r, int64(HeaderSize+hdr.MetaSize), int64(hdr.TypeSize))
+	cctx.subtypesReader = io.NewSectionReader(r, off+int64(hdr.MetaSize), int64(hdr.TypeSize))
 	return &Object{
 		cctx:     cctx,
-		readerAt: io.NewSectionReader(r, int64(HeaderSize+hdr.MetaSize+hdr.TypeSize), int64(hdr.DataSize)),
+		readerAt: io.NewSectionReader(r, off+int64(hdr.MetaSize+hdr.TypeSize), int64(hdr.DataSize)),
 		header:   hdr,
 	}, nil
 }
@@ -75,7 +80,7 @@ func (o *Object) DataReader() io.ReaderAt {
 }
 
 func (o *Object) Size() uint64 {
-	return o.header.ObjectSize()
+	return HeaderSize + o.header.Size()
 }
 
 func (o *Object) ProjectMetadata(sctx *super.Context, projection field.Projection) []super.Value {

--- a/csup/writer.go
+++ b/csup/writer.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/brimdata/super"
+	"github.com/brimdata/super/runtime/sam/expr/agg"
 	"github.com/brimdata/super/sio"
 	"github.com/brimdata/super/sio/bsupio"
 	"github.com/brimdata/super/sup"
@@ -19,8 +20,11 @@ var maxObjectSize uint32 = 120_000
 // Serializer implements the vio.Pusher interface. A Pusher creates a vector
 // CSUP object from a stream of vector.Any.
 type Serializer struct {
-	writer  io.WriteCloser
-	dynamic *vbuild.DynamicBuilder
+	writer    io.WriteCloser
+	dynamic   *vbuild.DynamicBuilder
+	fuser     *agg.Fuser
+	fuserSctx *super.Context
+	size      uint64
 }
 
 var _ vio.Pusher = (*Serializer)(nil)
@@ -34,6 +38,9 @@ func NewSerializer(w io.WriteCloser) *Serializer {
 
 func (w *Serializer) Close() error {
 	firstErr := w.finalizeObject()
+	if firstErr == nil {
+		firstErr = w.writeFooter()
+	}
 	if err := w.writer.Close(); err != nil && firstErr == nil {
 		firstErr = err
 	}
@@ -55,6 +62,7 @@ func (w *Serializer) finalizeObject() error {
 	if vec.Len() == 0 {
 		return nil
 	}
+	w.fuse(vec)
 	enc := NewDynamicEncoder(vec)
 	root, dataSize, err := enc.Encode()
 	if err != nil {
@@ -84,11 +92,16 @@ func (w *Serializer) finalizeObject() error {
 	}
 	zw.EndStream()
 	typeSize := zw.Position() - metaSize
-
 	// Header
-	if _, err := w.writer.Write(Header{Version, uint64(metaSize), uint64(typeSize), dataSize, uint32(root)}.Serialize()); err != nil {
+	if _, err := w.writer.Write(Header{Version, SectionObject}.Serialize()); err != nil {
 		return fmt.Errorf("system error: could not write CSUP header: %w", err)
 	}
+	// DataHeader
+	o := DataHeader{uint64(metaSize), uint64(typeSize), dataSize, uint32(root)}
+	if _, err := w.writer.Write(o.Serialize()); err != nil {
+		return fmt.Errorf("system error: could not write CSUP header: %w", err)
+	}
+	w.size += HeaderSize + o.Size()
 	// Metadata section
 	if _, err := w.writer.Write(metaBuf.Bytes()); err != nil {
 		return fmt.Errorf("system error: could not write CSUP metadata section: %w", err)
@@ -99,6 +112,42 @@ func (w *Serializer) finalizeObject() error {
 	}
 	// Set new dynamic so we can write the next object.
 	w.dynamic = vbuild.NewDynamicBuilder()
+	return nil
+}
+
+func (w *Serializer) fuse(dynamic *vector.Dynamic) {
+	if w.fuser == nil {
+		w.fuserSctx = super.NewContext()
+		w.fuser = agg.NewFuser(w.fuserSctx, false)
+	}
+	for _, vec := range dynamic.Values {
+		typ, err := w.fuserSctx.TranslateType(vec.Type())
+		if err != nil {
+			panic(err)
+		}
+		w.fuser.Fuse(typ)
+	}
+}
+
+func (w *Serializer) writeFooter() error {
+	if w.fuser == nil {
+		return nil
+	}
+	fusedBytes := super.EncodeTypeValue(w.fuser.Type())
+	if _, err := w.writer.Write(Header{Version, SectionFooter}.Serialize()); err != nil {
+		return err
+	}
+	f := Footer{uint32(len(fusedBytes))}
+	if _, err := w.writer.Write(f.Serialize()); err != nil {
+		return err
+	}
+	if _, err := w.writer.Write(fusedBytes); err != nil {
+		return err
+	}
+	w.size += HeaderSize + f.Size()
+	if _, err := w.writer.Write(Trailer{w.size, uint32(len(fusedBytes))}.Serialize()); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/csup/ztests/cat-files.yaml
+++ b/csup/ztests/cat-files.yaml
@@ -1,0 +1,27 @@
+script: |
+  super -f csup -o a.csup a.sup
+  super -f csup -o b.csup b.sup
+  cat a.csup b.csup > test.csup
+  super -s test.csup
+  echo // ===
+  super dev csup -s -type test.csup
+
+inputs:
+  - name: a.sup
+    data: |
+      {a:1}
+      {b:2}
+  - name: b.sup
+    data: |
+      {c:3}
+      {d:4}
+
+outputs:
+  - name: stdout
+    data: |
+      {a:1}
+      {b:2}
+      {c:3}
+      {d:4}
+      // ===
+      <{c?:int64,d?:int64,a?:int64,b?:int64}>

--- a/csup/ztests/const.yaml
+++ b/csup/ztests/const.yaml
@@ -12,6 +12,11 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      {Version:22::uint32,MetaSize:45::uint64,TypeSize:6::uint64,DataSize:0::uint64,Root:0::uint32}
+      {Version:23::uint32,SectionType:79::uint8}
+      {MetaSize:45::uint64,TypeSize:6::uint64,DataSize:0::uint64,Root:0::uint32}
       type Const={Value:any,Count:uint32}
       {Value:1::any,Count:3}::Const
+      {Version:23::uint32,SectionType:70::uint8}
+      {MetaSize:1::uint32}
+      <int64>
+      {Size:126::uint64,MetaSize:1::uint32}

--- a/service/ztests/curl-load-error.yaml
+++ b/service/ztests/curl-load-error.yaml
@@ -16,7 +16,7 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      {"type":"Error","kind":"invalid operation","error":"format detection error\n\tarrows: schema message length exceeds 1 MiB\n\tbsup: BSUP version mismatch: expected 5, found 0\n\tcsup: file size too small\n\tcsv: line 1: EOF\n\tjson: invalid character 'T' looking for beginning of value\n\tline: auto-detection not supported\n\tparquet: invalid header\n\tsup: line 1: syntax error\n\ttsv: line 1: EOF\n\tzeek: line 1: bad types/fields definition in zeek header"}
+      {"type":"Error","kind":"invalid operation","error":"format detection error\n\tarrows: schema message length exceeds 1 MiB\n\tbsup: BSUP version mismatch: expected 5, found 0\n\tcsup: invalid CSUP header\n\tcsv: line 1: EOF\n\tjson: invalid character 'T' looking for beginning of value\n\tline: auto-detection not supported\n\tparquet: invalid header\n\tsup: line 1: syntax error\n\ttsv: line 1: EOF\n\tzeek: line 1: bad types/fields definition in zeek header"}
       code 400
       {"type":"Error","kind":"invalid operation","error":"unsupported MIME type: unsupported"}
       code 400

--- a/service/ztests/load-garbage.yaml
+++ b/service/ztests/load-garbage.yaml
@@ -15,7 +15,7 @@ outputs:
       stdio:stdin: format detection error
       	arrows: schema message length exceeds 1 MiB
       	bsup: BSUP version mismatch: expected 5, found 0
-      	csup: file size too small
+      	csup: invalid CSUP header
       	csv: line 1: delimiter ',' not found
       	json: invalid character 'T' looking for beginning of value
       	line: auto-detection not supported

--- a/sio/csupio/stream.go
+++ b/sio/csupio/stream.go
@@ -19,11 +19,11 @@ type stream struct {
 
 type result struct {
 	off    int64
-	header csup.Header
+	header csup.DataHeader
 	err    error
 }
 
-func (s *stream) next() (*csup.Header, int64, error) {
+func (s *stream) next() (*csup.DataHeader, int64, error) {
 	s.once.Do(func() {
 		s.ch = make(chan result, runtime.GOMAXPROCS(0))
 		go s.run()
@@ -45,16 +45,18 @@ func (s *stream) next() (*csup.Header, int64, error) {
 func (s *stream) run() {
 	var off int64
 	for {
-		hdr, err := csup.ReadHeader(io.NewSectionReader(s.r, off, math.MaxInt64))
-		select {
-		case s.ch <- result{off, hdr, err}:
-		case <-s.ctx.Done():
-			return
+		section, err := csup.ReadSection(io.NewSectionReader(s.r, off, math.MaxInt64))
+		if err != nil || section.Type == csup.SectionObject {
+			select {
+			case s.ch <- result{off, section.Object, err}:
+			case <-s.ctx.Done():
+				return
+			}
 		}
 		if err != nil {
 			close(s.ch)
 			break
 		}
-		off += int64(hdr.ObjectSize())
+		off += int64(section.Size())
 	}
 }


### PR DESCRIPTION
This commit adds a footer section to CSUP files that includes the fused type of the data in a given file. In a future commit this will be used to efficiently retrieve the fused type of a CSUP file for type checking.