### PR TITLE
parquetio.VectorReader: Fix panic on null value

### DIFF
--- a/sio/parquetio/vectorreader.go
+++ b/sio/parquetio/vectorreader.go
@@ -326,7 +326,7 @@ func (v *vectorBuilder) build(a arrow.Array, nullable bool) (vector.Any, error) 
 			for i, vec := range fieldVecs {
 				arrowField := arrowStructType.Field(i)
 				typ := vec.Type()
-				if arrowField.Nullable {
+				if arrowField.Nullable && typ != super.TypeNull {
 					typ = v.sctx.Nullable(typ)
 				}
 				fields[i] = super.NewField(arrowField.Name, typ)

--- a/sio/parquetio/ztests/vectorreader-null.yaml
+++ b/sio/parquetio/ztests/vectorreader-null.yaml
@@ -1,0 +1,13 @@
+script: |
+  super -f parquet -o test.parquet in.sup
+  # from operator uses NewVectorReader
+  super -s -c 'from test.parquet'
+
+inputs:
+  - name: in.sup
+    data: &in |
+      {s:null}
+
+outputs:
+  - name: stdout
+    data: *in


### PR DESCRIPTION
This commit fixes a panic when reading a field with a null type.