### PR TITLE
csup: fix metadata filtering for unions

### DIFF
--- a/csup/metadata.go
+++ b/csup/metadata.go
@@ -5,7 +5,9 @@ import (
 	"slices"
 
 	"github.com/brimdata/super"
+	"github.com/brimdata/super/order"
 	"github.com/brimdata/super/pkg/field"
+	"github.com/brimdata/super/runtime/sam/expr"
 	"github.com/brimdata/super/scode"
 )
 
@@ -303,6 +305,12 @@ func (d *Dynamic) Len(*Context) uint32 {
 	return d.Length
 }
 
+func newMetadataValue(cctx *Context, sctx *super.Context, b *scode.Builder, id ID, p field.Projection) super.Value {
+	b.Truncate()
+	typ := metadataValue(cctx, sctx, b, id, p)
+	return super.NewValue(typ, b.Bytes().Body())
+}
+
 func metadataValue(cctx *Context, sctx *super.Context, b *scode.Builder, id ID, projection field.Projection) super.Type {
 	m := cctx.Lookup(id)
 	switch m := under(cctx, m).(type) {
@@ -332,6 +340,28 @@ func metadataValue(cctx *Context, sctx *super.Context, b *scode.Builder, id ID, 
 		}
 		b.EndContainer()
 		return sctx.MustLookupTypeRecord(fields)
+	case *Union:
+		cmp := expr.NewValueCompareFn(order.Asc, order.NullsLast)
+		var bb scode.Builder
+		var min, max *super.Value
+		for _, id := range m.Values {
+			val := newMetadataValue(cctx, sctx, &bb, id, projection)
+			if val.IsNull() {
+				continue
+			}
+			min2, max2 := val.Deref("min"), val.Deref("max")
+			if min == nil || (min2 != nil && cmp(*min, *min2) > 0) {
+				min = new(min2.Copy())
+			}
+			if max == nil || (max2 != nil && cmp(*max, *max2) < 0) {
+				max = new(max2.Copy())
+			}
+		}
+		if min == nil {
+			b.Append(nil)
+			return super.TypeNull
+		}
+		return metadataLeaf(sctx, b, *min, *max)
 	case *Int:
 		return metadataLeaf(sctx, b, super.NewInt(m.Typ, m.Min), super.NewInt(m.Typ, m.Max))
 	case *Uint:

--- a/csup/object_test.go
+++ b/csup/object_test.go
@@ -37,3 +37,27 @@ func TestObjectProjectMetadata(t *testing.T) {
 	require.Len(t, values, 1)
 	require.Equal(t, "{b:{d:{min:0.7,max:0.9}},a:{min:1,max:3}}", sup.FormatValue(values[0]))
 }
+
+func TestObjectProjectMetadataForUnion(t *testing.T) {
+	sctx := super.NewContext()
+	supValues := []string{
+		"{a:1::(int64|string),b?:2,c:3::(int64|null)}",
+		`{a:"s"::(int64|string),b?:_::int64,c:null::(int64|null)}`,
+	}
+	builder := vector.NewDynamicValueBuilder()
+	for _, s := range supValues {
+		builder.Write(sup.MustParseValue(sctx, s))
+	}
+	var b bytes.Buffer
+	w := csup.NewSerializer(sio.NopCloser(&b))
+	require.NoError(t, w.Push(builder.Build(sctx)))
+	require.NoError(t, w.Close())
+	csupBytes := b.Bytes()
+
+	o, err := csup.NewObject(bytes.NewReader(csupBytes))
+	require.NoError(t, err)
+	p := field.NewProjection(field.DottedList("a,b,c"))
+	values := o.ProjectMetadata(super.NewContext(), p)
+	require.Len(t, values, 1)
+	require.Equal(t, `{a:{min:1,max:"s"},b:{min:2,max:2},c:{min:3,max:3}}`, sup.FormatValue(values[0]))
+}

--- a/csup/ztests/issue-7061.yaml
+++ b/csup/ztests/issue-7061.yaml
@@ -1,0 +1,14 @@
+script: |
+  super -f csup -o test.csup -
+  super -s -c 'from test.csup | where b==1'
+
+inputs:
+  - name: stdin
+    data: |
+      {a:1,b?:1}
+      {a:2,b?:_::int64}
+
+outputs:
+  - name: stdout
+    data: |
+      {a:1,b?:1}


### PR DESCRIPTION
Metadata filtering produces false negatives for union fields.  Fix that in csup.metadataValue by computing min and max values for unions.

Fixes #7061.