### PR TITLE
add super.Context.MustLookupTypeUnion

### DIFF
--- a/compiler/semantic/checker.go
+++ b/compiler/semantic/checker.go
@@ -630,11 +630,7 @@ func (c *checker) dropPath(typ super.Type, drop path) super.Type {
 	}
 	types[pick] = c.t.sctx.MustLookupTypeRecord(fields)
 	if len(types) > 1 {
-		typ, ok := c.t.sctx.LookupTypeUnion(super.Flatten(types))
-		if !ok {
-			panic(types)
-		}
-		return typ
+		return c.t.sctx.MustLookupTypeUnion(super.Flatten(types))
 	}
 	return types[0]
 }

--- a/context.go
+++ b/context.go
@@ -208,6 +208,14 @@ func badUnion(types []Type) bool {
 	return false
 }
 
+func (c *Context) MustLookupTypeUnion(types []Type) *TypeUnion {
+	typ, ok := c.LookupTypeUnion(types)
+	if !ok {
+		panic(types)
+	}
+	return typ
+}
+
 func (c *Context) LookupTypeEnum(symbols []string) *TypeEnum {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -687,11 +695,7 @@ func (c *Context) Nullable(typ Type) *TypeUnion {
 	} else {
 		types = []Type{typ}
 	}
-	out, ok := c.LookupTypeUnion(append(types, TypeNull))
-	if !ok {
-		panic(typ)
-	}
-	return out
+	return c.MustLookupTypeUnion(append(types, TypeNull))
 }
 
 func NullableUnion(typ Type) (*TypeUnion, int) {
@@ -717,11 +721,7 @@ func (c *Context) Option(typ Type) *TypeUnion {
 	} else {
 		types = []Type{typ}
 	}
-	out, ok := c.LookupTypeUnion(append(types, TypeNone))
-	if !ok {
-		panic(typ)
-	}
-	return out
+	return c.MustLookupTypeUnion(append(types, TypeNone))
 }
 
 func OptionUnion(typ Type) (*TypeUnion, int) {

--- a/csup/union_test.go
+++ b/csup/union_test.go
@@ -14,7 +14,7 @@ import (
 func TestDivergentUnions(t *testing.T) {
 	types := super.UniqueTypes([]super.Type{super.TypeInt64, super.TypeFloat64})
 	sctx := super.NewContext()
-	utype, _ := sctx.LookupTypeUnion(types)
+	utype := sctx.MustLookupTypeUnion(types)
 	i1 := vector.NewInt(super.TypeInt64, []int64{1, 2})
 	f1 := vector.NewFloat(super.TypeFloat64, []float64{3.0})
 	vecs1 := []vector.Any{i1, f1}

--- a/fuzz/fuzz.go
+++ b/fuzz/fuzz.go
@@ -360,8 +360,7 @@ func GenType(b *bytes.Reader, context *super.Context, depth int) super.Type {
 			if len(unionTypes) == 0 {
 				return super.TypeNull
 			}
-			out, _ := context.LookupTypeUnion(unionTypes)
-			return out
+			return context.MustLookupTypeUnion(unionTypes)
 		default:
 			panic("Unreachable")
 		}

--- a/runtime/sam/expr/agg/collect.go
+++ b/runtime/sam/expr/agg/collect.go
@@ -53,10 +53,7 @@ func newArray(sctx *super.Context, vals []super.Value) super.Value {
 		}
 		typ = types[0]
 	} else {
-		union, ok := sctx.LookupTypeUnion(types)
-		if !ok {
-			panic(types)
-		}
+		union := sctx.MustLookupTypeUnion(types)
 		for _, val := range vals {
 			val = val.Deunion()
 			super.BuildUnion(&b, union.TagOf(val.Type()), val.Bytes())

--- a/runtime/sam/expr/agg/collectmap.go
+++ b/runtime/sam/expr/agg/collectmap.go
@@ -92,9 +92,5 @@ func unionOf(sctx *super.Context, types []super.Type) (super.Type, int) {
 	if len(types) == 1 {
 		return types[0], 1
 	}
-	typ, ok := sctx.LookupTypeUnion(types)
-	if !ok {
-		panic(types)
-	}
-	return typ, len(types)
+	return sctx.MustLookupTypeUnion(types), len(types)
 }

--- a/runtime/sam/expr/agg/fuser.go
+++ b/runtime/sam/expr/agg/fuser.go
@@ -100,10 +100,7 @@ func (f *Fuser) fuse(a, b super.Type) super.Type {
 		if len(types) == 1 {
 			return types[0]
 		}
-		union, ok := f.sctx.LookupTypeUnion(super.Flatten(types))
-		if !ok {
-			panic(types)
-		}
+		union := f.sctx.MustLookupTypeUnion(super.Flatten(types))
 		return f.fusion(union)
 	case *super.TypeEnum:
 		if b, ok := b.(*super.TypeEnum); ok {
@@ -137,11 +134,8 @@ func (f *Fuser) fuse(a, b super.Type) super.Type {
 	if _, ok := b.(*super.TypeUnion); ok {
 		return f.fuse(b, a)
 	}
-	union, ok := f.sctx.LookupTypeUnion([]super.Type{a, b})
-	if !ok {
-		panic("a or b can't be anonymous unions at this point")
-	}
-	return f.fusion(union)
+	// Neither a nor b can be an anonymous union at this point.
+	return f.fusion(f.sctx.MustLookupTypeUnion([]super.Type{a, b}))
 }
 
 func (f *Fuser) makeOption(t super.Type) super.Type {
@@ -187,11 +181,7 @@ func (f *Fuser) fuseInternal(typ super.Type) super.Type {
 		if len(types) == 1 {
 			out = types[0]
 		} else {
-			var ok bool
-			out, ok = f.sctx.LookupTypeUnion(super.Flatten(types))
-			if !ok {
-				panic(types)
-			}
+			out = f.sctx.MustLookupTypeUnion(super.Flatten(types))
 		}
 	case *super.TypeEnum:
 		return typ

--- a/runtime/sam/expr/agg/union.go
+++ b/runtime/sam/expr/agg/union.go
@@ -70,12 +70,9 @@ func (u *Union) Result(sctx *super.Context) super.Value {
 	var inner super.Type
 	var b scode.Builder
 	if len(types) > 1 {
-		union, ok := sctx.LookupTypeUnion(types)
-		if !ok {
-			// Values are always deunioned when entering into the unioned set,
-			// so there should never be anonymous unions in the types set.
-			panic(u)
-		}
+		// Values are always deunioned when entering into the unioned set,
+		// so there should never be anonymous unions in the types set.
+		union := sctx.MustLookupTypeUnion(types)
 		inner = union
 		for typ, m := range u.types {
 			for v := range m {

--- a/runtime/sam/expr/function/cast.go
+++ b/runtime/sam/expr/function/cast.go
@@ -59,11 +59,7 @@ func deoptionType(sctx *super.Context, typ super.Type) super.Type {
 		types := slices.DeleteFunc(slices.Clone(union.Types), func(t super.Type) bool {
 			return t == super.TypeNone
 		})
-		out, ok := sctx.LookupTypeUnion(types)
-		if !ok {
-			panic(types)
-		}
-		return out
+		return sctx.MustLookupTypeUnion(types)
 	}
 	return typ
 }
@@ -220,10 +216,7 @@ func (c *cast) maybeConvertToUnion(vals []super.Value, types map[super.Type]stru
 	if len(typesSlice) == 1 {
 		return typesSlice[0], true
 	}
-	union, ok := c.sctx.LookupTypeUnion(typesSlice)
-	if !ok {
-		panic(typesSlice)
-	}
+	union := c.sctx.MustLookupTypeUnion(typesSlice)
 	aok := true
 	for i, val := range vals {
 		var ok bool

--- a/runtime/sam/expr/function/defuse.go
+++ b/runtime/sam/expr/function/defuse.go
@@ -127,11 +127,8 @@ func (d *Defuse) unify(elems []super.Value) (super.Type, scode.Bytes) {
 		}
 		return types[0], b.Bytes()
 	}
+	union := d.sctx.MustLookupTypeUnion(types)
 	var b scode.Builder
-	union, ok := d.sctx.LookupTypeUnion(types)
-	if !ok {
-		panic(types)
-	}
 	for _, e := range elems {
 		super.BuildUnion(&b, union.TagOf(e.Type()), e.Bytes())
 	}
@@ -154,11 +151,7 @@ func (d *Defuse) unifyType(vals []super.Value) super.Type {
 	case 1:
 		return types[0]
 	default:
-		union, ok := d.sctx.LookupTypeUnion(types)
-		if !ok {
-			panic(types)
-		}
-		return union
+		return d.sctx.MustLookupTypeUnion(types)
 	}
 }
 

--- a/runtime/sam/expr/function/flatten.go
+++ b/runtime/sam/expr/function/flatten.go
@@ -42,11 +42,7 @@ func (n *Flatten) innerTypeOf(typ *super.TypeRecord, b scode.Bytes) super.Type {
 	if len(unique) == 1 {
 		return unique[0]
 	}
-	union, ok := n.sctx.LookupTypeUnion(unique)
-	if !ok {
-		panic(unique)
-	}
-	return union
+	return n.sctx.MustLookupTypeUnion(unique)
 }
 
 func (n *Flatten) appendTypes(types []super.Type, b scode.Bytes, typ *super.TypeRecord) []super.Type {

--- a/runtime/sam/expr/function/unblend.go
+++ b/runtime/sam/expr/function/unblend.go
@@ -109,11 +109,8 @@ func (u *unblend) unify(elems []super.Value) (super.Type, scode.Bytes) {
 		}
 		return types[0], b.Bytes()
 	}
+	union := u.sctx.MustLookupTypeUnion(types)
 	var b scode.Builder
-	union, ok := u.sctx.LookupTypeUnion(types)
-	if !ok {
-		panic(types)
-	}
 	for _, e := range elems {
 		super.BuildUnion(&b, union.TagOf(e.Type()), e.Bytes())
 	}
@@ -136,10 +133,6 @@ func (u *unblend) unifyType(vals []super.Value) super.Type {
 	case 1:
 		return types[0]
 	default:
-		union, ok := u.sctx.LookupTypeUnion(types)
-		if !ok {
-			panic(types)
-		}
-		return union
+		return u.sctx.MustLookupTypeUnion(types)
 	}
 }

--- a/runtime/sam/expr/map.go
+++ b/runtime/sam/expr/map.go
@@ -68,9 +68,5 @@ func (a *mapCall) innerType(types []super.Type) super.Type {
 	if len(types) == 1 {
 		return types[0]
 	}
-	union, ok := a.sctx.LookupTypeUnion(types)
-	if !ok {
-		panic(types)
-	}
-	return union
+	return a.sctx.MustLookupTypeUnion(types)
 }

--- a/runtime/sam/expr/values.go
+++ b/runtime/sam/expr/values.go
@@ -419,6 +419,5 @@ func unionOf(sctx *super.Context, types []super.Type) super.Type {
 	if len(unique) == 1 {
 		return unique[0]
 	}
-	out, _ := sctx.LookupTypeUnion(unique)
-	return out
+	return sctx.MustLookupTypeUnion(unique)
 }

--- a/runtime/sam/op/infer/infer.go
+++ b/runtime/sam/op/infer/infer.go
@@ -126,13 +126,9 @@ func (i *inferNode) typeof(sctx *super.Context, typ super.Type) super.Type {
 		if len(types) == 1 {
 			return types[0]
 		}
-		out, ok := sctx.LookupTypeUnion(types)
-		if !ok {
-			// infer does not create new unions so there should be
-			// no way to get an anonymous union inserted into an existing union.
-			panic(types)
-		}
-		return out
+		// infer does not create new unions so there should be
+		// no way to get an anonymous union inserted into an existing union.
+		return sctx.MustLookupTypeUnion(types)
 	default:
 		return typ
 	}

--- a/runtime/vam/expr/unblend.go
+++ b/runtime/vam/expr/unblend.go
@@ -265,9 +265,5 @@ func typeOfRange(sctx *super.Context, dynamic *vector.Dynamic, alltypes []super.
 	for _, tag := range uniq {
 		types = append(types, alltypes[tag])
 	}
-	out, ok := sctx.LookupTypeUnion(types)
-	if !ok {
-		panic(types)
-	}
-	return out
+	return sctx.MustLookupTypeUnion(types)
 }

--- a/runtime/vcache/union.go
+++ b/runtime/vcache/union.go
@@ -63,10 +63,7 @@ func (u *union) project(loader *loader, projection field.Projection) vector.Any 
 		vecs = append(vecs, vec)
 		types = append(types, vec.Type())
 	}
-	utyp, ok := loader.sctx.LookupTypeUnion(types)
-	if !ok {
-		panic(types)
-	}
+	utyp := loader.sctx.MustLookupTypeUnion(types)
 	tags := u.load(loader)
 	if len(utyp.Types) == 2 {
 		return vector.NewUnionFromRLE(utyp, tags, vecs)

--- a/sio/arrowio/reader.go
+++ b/sio/arrowio/reader.go
@@ -305,10 +305,7 @@ Loop:
 			}
 		}
 	}
-	superUnion, ok := r.sctx.LookupTypeUnion(uniqueTypes)
-	if !ok {
-		panic(uniqueTypes)
-	}
+	superUnion := r.sctx.MustLookupTypeUnion(uniqueTypes)
 	r.unionTagMappings[superUnion] = x
 	return superUnion, nil
 }

--- a/sio/fjsonio/jsonvec/materialize.go
+++ b/sio/fjsonio/jsonvec/materialize.go
@@ -70,10 +70,7 @@ func (m *materializer) union(u *Union) (vector.Any, []uint32) {
 		types = append(types, super.TypeNone)
 		vecs = append(vecs, vector.NewEmpty(super.TypeNone))
 	}
-	utyp, ok := m.sctx.LookupTypeUnion(super.UniqueTypes(types))
-	if !ok {
-		panic(types)
-	}
+	utyp := m.sctx.MustLookupTypeUnion(super.UniqueTypes(types))
 	subtypes := m.makeUnionSubtypes(u.Tags, dynamic, fixed)
 	typ := m.sctx.LookupTypeFusion(utyp)
 	loader := &subtypesLoader{

--- a/sio/jsonio/builder.go
+++ b/sio/jsonio/builder.go
@@ -97,10 +97,7 @@ func (b *builder) endArray() {
 			container.zb.Append(items[i].zb.Bytes().Body())
 		}
 	default:
-		union, ok := b.sctx.LookupTypeUnion(b.types)
-		if !ok {
-			panic(b.types)
-		}
+		union := b.sctx.MustLookupTypeUnion(b.types)
 		container.typ = b.sctx.LookupTypeArray(union)
 		for i := range items {
 			tag := union.TagOf(items[i].typ)

--- a/sio/parquetio/vectorreader.go
+++ b/sio/parquetio/vectorreader.go
@@ -408,10 +408,7 @@ func (v *vectorBuilder) build(a arrow.Array, nullable bool) (vector.Any, error) 
 }
 
 func (v *vectorBuilder) buildNullableUnion(vec vector.Any, a arrow.Array) vector.Any {
-	unionType, ok := v.sctx.LookupTypeUnion([]super.Type{vec.Type(), super.TypeNull})
-	if !ok {
-		panic(vec)
-	}
+	unionType := v.sctx.MustLookupTypeUnion([]super.Type{vec.Type(), super.TypeNull})
 	nullTag, vecTag, _ := arrowio.NullableUnionTagsAndType(unionType)
 	tags := make([]uint32, vec.Len())
 	var vecIndex []uint32

--- a/sup/marshal.go
+++ b/sup/marshal.go
@@ -500,10 +500,7 @@ func (m *MarshalBSUPContext) encodeArray(arrayVal reflect.Value) (super.Type, er
 	case 1:
 		innerType = types[0]
 	default:
-		unionType, ok := m.Context.LookupTypeUnion(uniqueTypes)
-		if !ok {
-			panic(uniqueTypes)
-		}
+		unionType := m.Context.MustLookupTypeUnion(uniqueTypes)
 		// Convert each container element to the union type.
 		m.Builder.TransformContainer(func(bytes scode.Bytes) scode.Bytes {
 			var b scode.Builder

--- a/vector/union.go
+++ b/vector/union.go
@@ -49,11 +49,7 @@ func NewUnionFromDynamic(sctx *super.Context, d *Dynamic) *Union {
 	for _, vec := range d.Values {
 		types = append(types, vec.Type())
 	}
-	unionType, ok := sctx.LookupTypeUnion(types)
-	if !ok {
-		panic(types)
-	}
-	return &Union{dynamic: d, Typ: unionType}
+	return &Union{dynamic: d, Typ: sctx.MustLookupTypeUnion(types)}
 }
 
 func NewUnionFromRLE(typ *super.TypeUnion, rle []uint32, vecs []Any) *Union {

--- a/vector/union_test.go
+++ b/vector/union_test.go
@@ -10,7 +10,7 @@ import (
 func TestNewUnionVerifyPanics(t *testing.T) {
 	sctx := super.NewContext()
 	intVec := NewInt(super.TypeInt64, nil)
-	utyp, _ := sctx.LookupTypeUnion([]super.Type{super.TypeInt64, super.TypeString})
+	utyp := sctx.MustLookupTypeUnion([]super.Type{super.TypeInt64, super.TypeString})
 	require.PanicsWithValue(t, "NewUnion: must have one vector for each type", func() {
 		NewUnion(utyp, nil, []Any{intVec})
 	})
@@ -26,7 +26,7 @@ func TestNewUnionVerifyPanics(t *testing.T) {
 func TestNewUnionFromRLEVerifyPanics(t *testing.T) {
 	sctx := super.NewContext()
 	intVec := NewInt(super.TypeInt64, nil)
-	utyp, _ := sctx.LookupTypeUnion([]super.Type{super.TypeInt64, super.TypeString})
+	utyp := sctx.MustLookupTypeUnion([]super.Type{super.TypeInt64, super.TypeString})
 	require.PanicsWithValue(t, "NewUnion: must have one vector for each type", func() {
 		NewUnionFromRLE(utyp, nil, []Any{intVec})
 	})


### PR DESCRIPTION
It's more concise than explicitly calling LookupTypeUnion and panicking if it fails.