### PR TITLE
sio/parquetio: fix VectorReader <[null]> and <set[null]> handling

### DIFF
--- a/sio/parquetio/vectorreader.go
+++ b/sio/parquetio/vectorreader.go
@@ -300,12 +300,7 @@ func (v *vectorBuilder) build(a arrow.Array, nullable bool) (vector.Any, error) 
 		offsets := byteconv.ReinterpretSlice[uint32](arr.Offsets())
 		typ, ok := v.types[dt]
 		if !ok {
-			inner := values.Type()
-			if nullable {
-				inner = v.sctx.Nullable(inner)
-
-			}
-			typ = v.sctx.LookupTypeArray(inner)
+			typ = v.sctx.LookupTypeArray(values.Type())
 			v.types[dt] = typ
 		}
 		out = vector.NewArray(typ.(*super.TypeArray), offsets, values)
@@ -324,12 +319,7 @@ func (v *vectorBuilder) build(a arrow.Array, nullable bool) (vector.Any, error) 
 		if !ok {
 			fields := make([]super.Field, arr.NumField())
 			for i, vec := range fieldVecs {
-				arrowField := arrowStructType.Field(i)
-				typ := vec.Type()
-				if arrowField.Nullable && typ != super.TypeNull {
-					typ = v.sctx.Nullable(typ)
-				}
-				fields[i] = super.NewField(arrowField.Name, typ)
+				fields[i] = super.NewField(arrowStructType.Field(i).Name, vec.Type())
 			}
 			arrowio.UniquifyFieldNames(fields)
 			var err error
@@ -355,15 +345,7 @@ func (v *vectorBuilder) build(a arrow.Array, nullable bool) (vector.Any, error) 
 		offsets := byteconv.ReinterpretSlice[uint32](arr.Offsets())
 		typ, ok := v.types[dt]
 		if !ok {
-			keyType := keys.Type()
-			if nullable {
-				keyType = v.sctx.Nullable(keyType)
-			}
-			valType := vals.Type()
-			if nullable {
-				valType = v.sctx.Nullable(valType)
-			}
-			typ = v.sctx.LookupTypeMap(keyType, valType)
+			typ = v.sctx.LookupTypeMap(keys.Type(), vals.Type())
 			v.types[dt] = typ
 		}
 		out = vector.NewMap(typ.(*super.TypeMap), offsets, keys, vals)
@@ -381,11 +363,7 @@ func (v *vectorBuilder) build(a arrow.Array, nullable bool) (vector.Any, error) 
 		}
 		typ, ok := v.types[dt]
 		if !ok {
-			inner := values.Type()
-			if nullable {
-				inner = v.sctx.Nullable(inner)
-			}
-			typ = v.sctx.LookupTypeArray(inner)
+			typ = v.sctx.LookupTypeArray(values.Type())
 			v.types[dt] = typ
 		}
 		out = vector.NewArray(typ.(*super.TypeArray), offsets, values)

--- a/sio/parquetio/ztests/types.yaml
+++ b/sio/parquetio/ztests/types.yaml
@@ -29,8 +29,12 @@ inputs:
         nul: null,
         err: error("err"),
         rec: {a:1},
-        lst: [1,null],
-        set: set[1,null],
+        lst1: [1,null],
+        lst2: [null],
+        lst3: [],
+        set1: set[1,null],
+        set2: set[null],
+        set3: set[],
         map: map{1:"one",2:null},
       }
 
@@ -61,14 +65,22 @@ outputs:
         rec: {
           a: 1
         },
-        lst: [
+        lst1: [
           1,
           null
         ],
-        set: [
+        lst2: [
+          null
+        ],
+        lst3: []::[null],
+        set1: [
           1,
           null
         ],
+        set2: [
+          null
+        ],
+        set3: []::[null],
         map: map{
           1: "one",
           2: null


### PR DESCRIPTION
Reading values of these types passes super.TypeNull to super.Context.Nullable, creating a malformed super.TypeUnion containing two occurrences of TypeNull.  (This is the same problem fixed for records with TypeNull fields in #7097.)  Fix this by removing the Nullable calls, which are not needed because
parquetio.vectorBuilder.buildNullableUnion already handles creation of nullable TypeUnions and is never called for vector.Null.