### PR TITLE
anyio.NewReader: Return vio.Puller

### DIFF
--- a/cmd/super/db/load/command.go
+++ b/cmd/super/db/load/command.go
@@ -21,6 +21,7 @@ import (
 	"github.com/brimdata/super/pkg/display"
 	"github.com/brimdata/super/pkg/storage"
 	"github.com/brimdata/super/pkg/units"
+	"github.com/brimdata/super/sbuf"
 	"github.com/brimdata/super/sio"
 	"github.com/brimdata/super/sio/anyio"
 	"github.com/paulbellamy/ratecounter"
@@ -128,7 +129,7 @@ func (c *Command) open(ctx context.Context, sctx *super.Context, paths []string)
 			fmt.Fprintf(os.Stderr, "%s: %s\n", path, err)
 			continue
 		}
-		readers = append(readers, file)
+		readers = append(readers, sbuf.PullerReader(sbuf.NewMaterializer(file)))
 	}
 	return readers, nil
 }

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -11,7 +11,7 @@ import (
 	"github.com/brimdata/super/pkg/storage"
 	"github.com/brimdata/super/runtime"
 	"github.com/brimdata/super/runtime/exec"
-	"github.com/brimdata/super/sio"
+	"github.com/brimdata/super/vector/vio"
 )
 
 var Parallelism = goruntime.GOMAXPROCS(0) //XXX
@@ -35,7 +35,7 @@ func NewCompilerWithEnv(env *exec.Environment) runtime.Compiler {
 	return &compiler{env}
 }
 
-func (c *compiler) NewQuery(rctx *runtime.Context, ast *parser.AST, readers []sio.Reader, parallelism int) (runtime.Query, error) {
+func (c *compiler) NewQuery(rctx *runtime.Context, ast *parser.AST, readers []vio.Puller, parallelism int) (runtime.Query, error) {
 	if parallelism == 0 {
 		parallelism = Parallelism
 	}

--- a/compiler/package.go
+++ b/compiler/package.go
@@ -16,7 +16,6 @@ import (
 	"github.com/brimdata/super/runtime/exec"
 	"github.com/brimdata/super/runtime/vam/op"
 	"github.com/brimdata/super/sbuf"
-	"github.com/brimdata/super/sio"
 	"github.com/brimdata/super/vector/vio"
 )
 
@@ -61,10 +60,10 @@ func BuildWithBuilder(rctx *runtime.Context, main *dag.Main, env *exec.Environme
 	return outputs, debugs, b, nil
 }
 
-func CompileWithAST(rctx *runtime.Context, ast *parser.AST, env *exec.Environment, optimize bool, parallel int, readers []sio.Reader) (*exec.Query, error) {
+func CompileWithAST(rctx *runtime.Context, ast *parser.AST, env *exec.Environment, optimize bool, parallel int, readers []vio.Puller) (*exec.Query, error) {
 	if len(readers) > 0 {
 		env = new(*env)
-		env.Stdin = sio.ConcatReader(readers...)
+		env.Stdin = vio.ConcatPuller(readers...)
 	}
 	main, err := Analyze(rctx, ast, env, len(readers) > 0)
 	if err != nil {
@@ -83,7 +82,7 @@ func CompileWithAST(rctx *runtime.Context, ast *parser.AST, env *exec.Environmen
 	return exec.NewQuery(rctx, bundleOutputs(rctx, outputs, debugs), meter), nil
 }
 
-func Compile(rctx *runtime.Context, env *exec.Environment, optimize bool, parallel int, readers []sio.Reader, inputs []srcfiles.Input) (*exec.Query, error) {
+func Compile(rctx *runtime.Context, env *exec.Environment, optimize bool, parallel int, readers []vio.Puller, inputs []srcfiles.Input) (*exec.Query, error) {
 	ast, err := parser.ParseFiles(inputs)
 	if err != nil {
 		return nil, err

--- a/compiler/rungen/op.go
+++ b/compiler/rungen/op.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 	"sync"
 
 	"github.com/brimdata/super"
@@ -173,9 +172,6 @@ func (b *Builder) compileLeaf(o dag.Op, parent sbuf.Puller) (sbuf.Puller, error)
 			pushdown = &deleter{pushdown, b, v.Where}
 		}
 		return meta.NewDeleter(b.rctx, parent, pool, pushdown, pruner, b.progress, b.deletes), nil
-	case *dag.HTTPScan:
-		body := strings.NewReader(v.Body)
-		return b.env.OpenHTTP(b.rctx.Context, b.sctx(), v.URL, v.Format, v.Method, v.Headers, body, nil)
 	case *dag.ListerScan:
 		if parent != nil {
 			return nil, errors.New("internal error: data source cannot have a parent operator")

--- a/compiler/rungen/vop.go
+++ b/compiler/rungen/vop.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/compiler/dag"
@@ -246,6 +247,9 @@ func (b *Builder) compileVamLeaf(o dag.Op, parent vio.Puller) (vio.Puller, error
 		return vamop.NewFilter(b.sctx(), parent, e), nil
 	case *dag.FuseOp:
 		return vamop.NewFuse(b.sctx(), parent, o.Complete), nil
+	case *dag.HTTPScan:
+		body := strings.NewReader(o.Body)
+		return b.env.OpenHTTP(b.rctx.Context, b.sctx(), o.URL, o.Format, o.Method, o.Headers, body, nil)
 	case *dag.HeadOp:
 		return vamop.NewHead(parent, o.Count), nil
 	case *dag.OutputOp:

--- a/fuzz/fuzz.go
+++ b/fuzz/fuzz.go
@@ -27,6 +27,7 @@ import (
 	"github.com/brimdata/super/sio/bsupio"
 	"github.com/brimdata/super/sio/csupio"
 	"github.com/brimdata/super/sup"
+	"github.com/brimdata/super/vector/vio"
 	"github.com/stretchr/testify/require"
 	"github.com/x448/float16"
 )
@@ -73,28 +74,29 @@ func WriteCSUP(t testing.TB, valuesIn []super.Value, buf *bytes.Buffer) {
 
 func RunQueryBSUP(t testing.TB, buf *bytes.Buffer, querySource string) []super.Value {
 	sctx := super.NewContext()
-	readers := []sio.Reader{bsupio.NewReader(sctx, buf)}
-	defer sio.CloseReaders(readers)
-	return RunQuery(t, sctx, readers, querySource, func(_ demand.Demand) {})
+	s, err := bsupio.NewReader(sctx, buf).NewScanner(t.Context(), nil)
+	require.NoError(t, err)
+	p := sbuf.NewDematerializer(sctx, s)
+	defer p.Pull(true)
+	return RunQuery(t, sctx, p, querySource, func(_ demand.Demand) {})
 }
 
 func RunQueryCSUP(t testing.TB, buf *bytes.Buffer, querySource string) []super.Value {
 	sctx := super.NewContext()
-	reader, err := csupio.NewReader(sctx, bytes.NewReader(buf.Bytes()), nil)
+	p, err := csupio.NewVectorReader(t.Context(), sctx, bytes.NewReader(buf.Bytes()), nil, 1)
 	require.NoError(t, err)
-	readers := []sio.Reader{reader}
-	defer sio.CloseReaders(readers)
-	return RunQuery(t, sctx, readers, querySource, func(_ demand.Demand) {})
+	defer p.Pull(true)
+	return RunQuery(t, sctx, p, querySource, func(_ demand.Demand) {})
 }
 
-func RunQuery(t testing.TB, sctx *super.Context, readers []sio.Reader, querySource string, useDemand func(demandIn demand.Demand)) []super.Value {
+func RunQuery(t testing.TB, sctx *super.Context, p vio.Puller, querySource string, useDemand func(demandIn demand.Demand)) []super.Value {
 	// Compile query
 	comp := compiler.NewCompiler(nil)
 	ast, err := parser.ParseText(querySource)
 	if err != nil {
 		t.Skipf("%v", err)
 	}
-	query, err := runtime.CompileQuery(t.Context(), sctx, comp, ast, readers)
+	query, err := runtime.CompileQuery(t.Context(), sctx, comp, ast, []vio.Puller{p})
 	if err != nil {
 		t.Skipf("%v", err)
 	}

--- a/runtime/compiler.go
+++ b/runtime/compiler.go
@@ -6,13 +6,12 @@ import (
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/compiler/parser"
 	"github.com/brimdata/super/dbid"
-	"github.com/brimdata/super/sio"
 	"github.com/brimdata/super/vector/vio"
 	"github.com/segmentio/ksuid"
 )
 
 type Compiler interface {
-	NewQuery(*Context, *parser.AST, []sio.Reader, int) (Query, error)
+	NewQuery(*Context, *parser.AST, []vio.Puller, int) (Query, error)
 	NewDeleteQuery(*Context, *parser.AST, *dbid.Commitish) (DeleteQuery, error)
 }
 
@@ -27,7 +26,7 @@ type DeleteQuery interface {
 	DeletionSet() []ksuid.KSUID
 }
 
-func CompileQuery(ctx context.Context, sctx *super.Context, c Compiler, ast *parser.AST, readers []sio.Reader) (Query, error) {
+func CompileQuery(ctx context.Context, sctx *super.Context, c Compiler, ast *parser.AST, readers []vio.Puller) (Query, error) {
 	rctx := NewContext(ctx, sctx)
 	q, err := c.NewQuery(rctx, ast, readers, 0)
 	if err != nil {

--- a/runtime/exec/environment.go
+++ b/runtime/exec/environment.go
@@ -5,26 +5,22 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sync"
 
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/compiler/dag"
 	"github.com/brimdata/super/db"
 	"github.com/brimdata/super/dbid"
 	"github.com/brimdata/super/order"
-	"github.com/brimdata/super/pkg/field"
 	"github.com/brimdata/super/pkg/storage"
 	"github.com/brimdata/super/sbuf"
-	"github.com/brimdata/super/sio"
 	"github.com/brimdata/super/sio/anyio"
-	"github.com/brimdata/super/sio/csupio"
-	"github.com/brimdata/super/sio/fjsonio"
-	"github.com/brimdata/super/sio/parquetio"
 	"github.com/brimdata/super/vector"
 	"github.com/brimdata/super/vector/vio"
 	"github.com/segmentio/ksuid"
 )
 
-type VectorConcurrentPuller interface {
+type ConcurrentPuller interface {
 	vio.Puller
 	ConcurrentPull(done bool, id int) (vector.Any, error)
 }
@@ -37,7 +33,7 @@ type Environment struct {
 	IgnoreOpenErrors bool
 	ReaderOpts       anyio.ReaderOpts
 	SampleSize       int
-	Stdin            sio.Reader
+	Stdin            vio.Puller
 }
 
 func NewEnvironment(engine storage.Engine, d *db.Root) *Environment {
@@ -82,41 +78,31 @@ func (e *Environment) SortKeys(ctx context.Context, src dag.Op) order.SortKeys {
 	return nil
 }
 
-func (e *Environment) Open(ctx context.Context, sctx *super.Context, path, format string, pushdown sbuf.Pushdown) (sbuf.Puller, error) {
+func (e *Environment) Open(ctx context.Context, sctx *super.Context, path, format string, p sbuf.Pushdown, concurrentReaders int) (ConcurrentPuller, error) {
 	if path == "-" {
 		path = "stdio:stdin"
 	}
-	var fields []field.Path
-	if pushdown != nil {
-		if proj := pushdown.Projection(); proj != nil {
-			fields = proj.Paths()
-		}
-	}
 	if path == "stdio:stdin" && e.Stdin != nil {
-		return sbuf.NewScanner(ctx, e.Stdin, pushdown)
+		return newConcurrentPuller(path, e.Stdin), nil
 	}
-	file, err := anyio.Open(ctx, sctx, e.engine, path, e.readerOpts(fields, format))
+	file, err := anyio.Open(ctx, sctx, e.engine, path, e.readerOpts(p, format, concurrentReaders))
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", path, err)
 	}
-	scanner, err := sbuf.NewScanner(ctx, file, pushdown)
-	if err != nil {
-		file.Close()
-		return nil, err
-	}
-	return &closePuller{scanner, file}, nil
+	return newConcurrentPuller(path, file.Puller), nil
 }
 
-func (e *Environment) readerOpts(fields []field.Path, format string) anyio.ReaderOpts {
+func (e *Environment) readerOpts(p sbuf.Pushdown, format string, concurrentReaders int) anyio.ReaderOpts {
 	o := e.ReaderOpts
-	o.Fields = fields
+	o.Pushdown = p
+	o.ConcurrentReaders = concurrentReaders
 	if format != "" {
 		o.Format = format
 	}
 	return o
 }
 
-func (e *Environment) OpenHTTP(ctx context.Context, sctx *super.Context, url, format, method string, headers http.Header, body io.Reader, fields []field.Path) (sbuf.Puller, error) {
+func (e *Environment) OpenHTTP(ctx context.Context, sctx *super.Context, url, format, method string, headers http.Header, body io.Reader, p sbuf.Pushdown) (vio.Puller, error) {
 	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		return nil, err
@@ -126,76 +112,41 @@ func (e *Environment) OpenHTTP(ctx context.Context, sctx *super.Context, url, fo
 	if err != nil {
 		return nil, err
 	}
-	file, err := anyio.NewFile(sctx, resp.Body, url, e.readerOpts(fields, format))
+	file, err := anyio.NewFile(ctx, sctx, resp.Body, url, e.readerOpts(p, format, 1))
 	if err != nil {
 		resp.Body.Close()
 		return nil, fmt.Errorf("%s: %w", url, err)
 	}
-	scanner, err := sbuf.NewScanner(ctx, file, nil)
-	if err != nil {
-		file.Close()
-		return nil, err
-	}
-	return &closePuller{scanner, file}, nil
+	return file, nil
 }
 
-type closePuller struct {
-	p sbuf.Puller
-	c io.Closer
+func newConcurrentPuller(path string, puller vio.Puller) ConcurrentPuller {
+	cp, ok := puller.(ConcurrentPuller)
+	if !ok {
+		cp = &concurrentPuller{Puller: puller}
+	}
+	return &errorPrefixConcurrentPuller{cp, path}
 }
 
-func (c *closePuller) Pull(done bool) (sbuf.Batch, error) {
-	batch, err := c.p.Pull(done)
-	if batch == nil {
-		c.c.Close()
-	}
-	return batch, err
+type concurrentPuller struct {
+	vio.Puller
+	mu sync.Mutex
 }
 
-func (e *Environment) VectorOpen(ctx context.Context, sctx *super.Context, path, format string, p sbuf.Pushdown, concurrentReaders int) (VectorConcurrentPuller, error) {
-	if format != "csup" && format != "fjson" && format != "parquet" {
-		sbufPuller, err := e.Open(ctx, sctx, path, format, p)
-		if err != nil {
-			return nil, err
-		}
-		return sbuf.NewDematerializer(sctx, sbufPuller), nil
-	}
-	if path == "-" {
-		path = "stdio:stdin"
-	}
-	uri, err := storage.ParseURI(path)
-	if err != nil {
-		return nil, err
-	}
-	reader, err := e.engine.Get(ctx, uri)
-	if err != nil {
-		return nil, err
-	}
-	var puller VectorConcurrentPuller
-	switch format {
-	case "csup":
-		puller, err = csupio.NewVectorReader(ctx, sctx, reader, p, concurrentReaders)
-	case "parquet":
-		puller, err = parquetio.NewVectorReader(ctx, sctx, reader, p, concurrentReaders)
-	case "fjson":
-		puller = fjsonio.NewVectorReader(ctx, sctx, reader, p, concurrentReaders)
-	default:
-		panic(format)
-	}
-	if err != nil {
-		reader.Close()
-		return nil, fmt.Errorf("%s: %w", path, err)
-	}
-	return &errorPrefixConcurrentPuller{puller, path}, nil
+func (c *concurrentPuller) ConcurrentPull(done bool, id int) (vector.Any, error) {
+	c.mu.Lock()
+	// Defer to ensure lock is released if c.Puller.Pull panics.
+	defer c.mu.Unlock()
+	return c.Pull(done)
 }
 
 type errorPrefixConcurrentPuller struct {
-	VectorConcurrentPuller
+	ConcurrentPuller
 	prefix string
 }
 
 func (e *errorPrefixConcurrentPuller) ConcurrentPull(done bool, id int) (vector.Any, error) {
-	vec, err := e.VectorConcurrentPuller.ConcurrentPull(done, id)
+	vec, err := e.ConcurrentPuller.ConcurrentPull(done, id)
 	if err != nil {
 		err = fmt.Errorf("%s: %w", e.prefix, err)
 	}
@@ -203,7 +154,7 @@ func (e *errorPrefixConcurrentPuller) ConcurrentPull(done bool, id int) (vector.
 }
 
 func (e *errorPrefixConcurrentPuller) Pull(done bool) (vector.Any, error) {
-	vec, err := e.VectorConcurrentPuller.Pull(done)
+	vec, err := e.ConcurrentPuller.Pull(done)
 	if err != nil {
 		err = fmt.Errorf("%s: %w", e.prefix, err)
 	}

--- a/runtime/vam/op/aggregate/aggregate.go
+++ b/runtime/vam/op/aggregate/aggregate.go
@@ -96,7 +96,7 @@ func (a *Aggregate) Pull(done bool) (vector.Any, error) {
 
 func (a *Aggregate) consume(keys []vector.Any, vals []vector.Any) {
 	keys, vals, ok := removeQuietRows(keys, vals)
-	if !ok {
+	if !ok || keys[0].Len() == 0 {
 		return
 	}
 	var keyTypes []super.Type

--- a/runtime/vam/op/filescan.go
+++ b/runtime/vam/op/filescan.go
@@ -20,7 +20,7 @@ type FileScan struct {
 	pushdown sbuf.Pushdown
 
 	mu      sync.Mutex
-	current exec.VectorConcurrentPuller
+	current exec.ConcurrentPuller
 	next    int
 	numDone int
 	puller  vio.Puller
@@ -77,7 +77,7 @@ func (f *FileScan) done() {
 	}
 }
 
-func (f *FileScan) nextFile(current exec.VectorConcurrentPuller) (exec.VectorConcurrentPuller, error) {
+func (f *FileScan) nextFile(current exec.ConcurrentPuller) (exec.ConcurrentPuller, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if current != f.current {
@@ -86,7 +86,7 @@ func (f *FileScan) nextFile(current exec.VectorConcurrentPuller) (exec.VectorCon
 	for f.next < len(f.paths) {
 		path := f.paths[f.next]
 		f.next++
-		puller, err := f.env.VectorOpen(f.rctx.Context, f.rctx.Sctx, path, f.format, f.pushdown, len(f.pullers))
+		puller, err := f.env.Open(f.rctx.Context, f.rctx.Sctx, path, f.format, f.pushdown, len(f.pullers))
 		if err != nil {
 			if f.env.IgnoreOpenErrors {
 				fmt.Fprintln(os.Stderr, err)
@@ -105,7 +105,7 @@ type concurrentPuller struct {
 	id int
 
 	eos     bool
-	current exec.VectorConcurrentPuller
+	current exec.ConcurrentPuller
 	waitCh  chan struct{}
 }
 

--- a/runtime/vam/op/robot.go
+++ b/runtime/vam/op/robot.go
@@ -138,5 +138,5 @@ func (o *Robot) open(path string) (vio.Puller, error) {
 	if o.env.IsAttached() {
 		return nil, fmt.Errorf("%s: cannot open in a database environment", path)
 	}
-	return o.env.VectorOpen(o.rctx.Context, o.rctx.Sctx, path, o.format, o.pushdown, 1)
+	return o.env.Open(o.rctx.Context, o.rctx.Sctx, path, o.format, o.pushdown, 1)
 }

--- a/sbuf/file.go
+++ b/sbuf/file.go
@@ -3,16 +3,16 @@ package sbuf
 import (
 	"io"
 
-	"github.com/brimdata/super/sio"
+	"github.com/brimdata/super/vector/vio"
 )
 
 type File struct {
-	sio.Reader
+	vio.Puller
 	c    io.Closer
 	name string
 }
 
-func NewFile(r sio.Reader, c io.Closer, name string) *File {
+func NewFile(r vio.Puller, c io.Closer, name string) *File {
 	return &File{r, c, name}
 }
 

--- a/sbuf/scanner.go
+++ b/sbuf/scanner.go
@@ -48,13 +48,7 @@ func NewScanner(ctx context.Context, r sio.Reader, filterExpr Pushdown) (Scanner
 }
 
 func newScanner(ctx context.Context, r sio.Reader, filterExpr Pushdown) (Scanner, error) {
-	var sa ScannerAble
-	if zf, ok := r.(*File); ok {
-		sa, _ = zf.Reader.(ScannerAble)
-	} else {
-		sa, _ = r.(ScannerAble)
-	}
-	if sa != nil {
+	if sa, ok := r.(ScannerAble); ok {
 		return sa.NewScanner(ctx, filterExpr)
 	}
 	var f expr.Evaluator

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -455,13 +455,14 @@ func handleBranchLoad(c *Core, w *ResponseWriter, r *Request) {
 		BSUP: bsupio.ReaderOpts{Validate: true},
 	}
 	sctx := super.NewContext()
-	zrc, err := anyio.NewReader(sctx, reader, opts)
+	p, err := anyio.NewReader(r.Context(), sctx, reader, opts)
 	if err != nil {
 		w.Error(srverr.ErrInvalid(err))
 		return
 	}
-	defer zrc.Close()
-	wr := &warningsReader{zrc, []string{}}
+	defer p.Pull(true)
+	// XXX Load should handle vectors natively.
+	wr := &warningsReader{sbuf.PullerReader(sbuf.NewMaterializer(p)), []string{}}
 	kommit, err := branch.Load(r.Context(), sctx, wr, message.Author, message.Body, message.Meta)
 	if err != nil {
 		if errors.Is(err, commits.ErrEmptyTransaction) {

--- a/service/request.go
+++ b/service/request.go
@@ -175,13 +175,14 @@ func (r *Request) Unmarshal(w *ResponseWriter, body any, templates ...any) bool 
 	if !ok {
 		return false
 	}
-	zrc, err := anyio.NewReader(super.NewContext(), r.Body, anyio.ReaderOpts{Format: format})
+	p, err := anyio.NewReader(r.Context(), super.NewContext(), r.Body, anyio.ReaderOpts{Format: format})
 	if err != nil {
 		w.Error(srverr.ErrInvalid(err))
 		return false
 	}
-	defer zrc.Close()
-	zv, err := zrc.Read()
+	defer func() { p.Pull(true) }()
+	sr := sbuf.PullerReader(sbuf.NewMaterializer(p))
+	zv, err := sr.Read()
 	if err != nil {
 		w.Error(srverr.ErrInvalid(err))
 		return false

--- a/sio/anyio/file.go
+++ b/sio/anyio/file.go
@@ -30,7 +30,7 @@ func Open(ctx context.Context, sctx *super.Context, engine storage.Engine, path 
 			return
 		}
 		// NewFile reads from sr, which might block.
-		zf, err = NewFile(sctx, sr, path, opts)
+		zf, err = NewFile(ctx, sctx, sr, path, opts)
 		if err != nil {
 			sr.Close()
 		}
@@ -43,12 +43,12 @@ func Open(ctx context.Context, sctx *super.Context, engine storage.Engine, path 
 	}
 }
 
-func NewFile(sctx *super.Context, rc io.ReadCloser, path string, opts ReaderOpts) (*sbuf.File, error) {
+func NewFile(ctx context.Context, sctx *super.Context, rc io.ReadCloser, path string, opts ReaderOpts) (*sbuf.File, error) {
 	r, err := GzipReader(rc)
 	if err != nil {
 		return nil, err
 	}
-	zr, err := NewReader(sctx, r, opts)
+	zr, err := NewReader(ctx, sctx, r, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func FileType(ctx context.Context, sctx *super.Context, engine storage.Engine, p
 	if _, err := rs.Seek(0, io.SeekCurrent); err != nil {
 		return nil, nil
 	}
-	f, err := NewFile(sctx, r, path, opts)
+	f, err := NewFile(ctx, sctx, r, path, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -86,16 +86,17 @@ func FileType(ctx context.Context, sctx *super.Context, engine storage.Engine, p
 	// file, so it shares stdin's file offset. Reset to 0 so a re-open reads
 	// from the start instead of resuming where the last read left off.
 	defer rs.Seek(0, io.SeekStart)
-	if typed, ok := f.Reader.(sio.Typer); ok {
+	if typed, ok := f.Puller.(sio.Typer); ok {
 		return typed.Type()
 	}
 	if sampleSize < 1 {
 		sampleSize = math.MaxInt
 	}
 	// XXX this should pass super true when type checker can handle it
+	rr := sbuf.PullerReader(sbuf.NewMaterializer(f))
 	fuser := agg.NewFuser(sctx, false)
 	for range sampleSize {
-		val, err := f.Read()
+		val, err := rr.Read()
 		if val == nil || err != nil {
 			return fuser.Type(), err
 		}

--- a/sio/anyio/lookup.go
+++ b/sio/anyio/lookup.go
@@ -18,35 +18,46 @@ import (
 	"github.com/brimdata/super/sio/parquetio"
 	"github.com/brimdata/super/sio/supio"
 	"github.com/brimdata/super/sio/zeekio"
+	"github.com/brimdata/super/vector/vio"
 )
 
-func lookupReader(sctx *super.Context, r io.Reader, opts ReaderOpts) (sio.ReadCloser, error) {
+func lookupReader(ctx context.Context, sctx *super.Context, r io.Reader, opts ReaderOpts) (vio.Puller, error) {
 	switch opts.Format {
 	case "arrows":
-		return arrowio.NewReader(sctx, r)
+		r, err := arrowio.NewReader(sctx, r)
+		if err != nil {
+			return nil, err
+		}
+		return newVioPuller(sctx, r), nil
 	case "bsup":
-		return bsupio.NewReaderWithOpts(sctx, r, opts.BSUP), nil
+		scanner, err := bsupio.NewReaderWithOpts(sctx, r, opts.BSUP).NewScanner(ctx, opts.Pushdown)
+		if err != nil {
+			return nil, err
+		}
+		return sbuf.NewDematerializer(sctx, scanner), nil
 	case "csup":
-		return csupio.NewReader(sctx, r, opts.Fields)
+		return csupio.NewVectorReader(ctx, sctx, r, opts.Pushdown, opts.ConcurrentReaders)
 	case "csv":
-		return sio.NopReadCloser(csvio.NewReader(sctx, r, opts.CSV)), nil
+		return newVioPuller(sctx, csvio.NewReader(sctx, r, opts.CSV)), nil
 	case "line":
-		return sio.NopReadCloser(lineio.NewReader(r)), nil
+		return newVioPuller(sctx, lineio.NewReader(r)), nil
 	case "fjson":
-		v := fjsonio.NewVectorReader(context.Background(), sctx, r, nil, 1)
-		puller := sbuf.NewMaterializer(v)
-		return sio.NopReadCloser(sbuf.PullerReader(puller)), nil
+		return fjsonio.NewVectorReader(context.Background(), sctx, r, opts.Pushdown, opts.ConcurrentReaders), nil
 	case "json":
-		return sio.NopReadCloser(jsonio.NewReader(sctx, r)), nil
+		return newVioPuller(sctx, jsonio.NewReader(sctx, r)), nil
 	case "parquet":
-		return parquetio.NewReader(sctx, r, opts.Fields)
+		return parquetio.NewVectorReader(ctx, sctx, r, opts.Pushdown, opts.ConcurrentReaders)
 	case "sup":
-		return sio.NopReadCloser(supio.NewReader(sctx, r)), nil
+		return newVioPuller(sctx, supio.NewReader(sctx, r)), nil
 	case "tsv":
 		opts.CSV.Delim = '\t'
-		return sio.NopReadCloser(csvio.NewReader(sctx, r, opts.CSV)), nil
+		return newVioPuller(sctx, csvio.NewReader(sctx, r, opts.CSV)), nil
 	case "zeek":
-		return sio.NopReadCloser(zeekio.NewReader(sctx, r)), nil
+		return newVioPuller(sctx, zeekio.NewReader(sctx, r)), nil
 	}
 	return nil, fmt.Errorf("no such format: \"%s\"", opts.Format)
+}
+
+func newVioPuller(sctx *super.Context, r sio.Reader) vio.Puller {
+	return sbuf.NewDematerializer(sctx, sbuf.NewPuller(r))
 }

--- a/sio/anyio/reader.go
+++ b/sio/anyio/reader.go
@@ -3,6 +3,7 @@ package anyio
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -11,7 +12,7 @@ import (
 
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/csup"
-	"github.com/brimdata/super/pkg/field"
+	"github.com/brimdata/super/sbuf"
 	"github.com/brimdata/super/sio"
 	"github.com/brimdata/super/sio/arrowio"
 	"github.com/brimdata/super/sio/bsupio"
@@ -21,46 +22,52 @@ import (
 	"github.com/brimdata/super/sio/parquetio"
 	"github.com/brimdata/super/sio/supio"
 	"github.com/brimdata/super/sio/zeekio"
+	"github.com/brimdata/super/vector/vio"
 )
 
 type ReaderOpts struct {
-	Fields []field.Path
-	Format string
-	BSUP   bsupio.ReaderOpts
-	CSV    csvio.ReaderOpts
+	Format            string
+	Pushdown          sbuf.Pushdown
+	ConcurrentReaders int
+	BSUP              bsupio.ReaderOpts
+	CSV               csvio.ReaderOpts
 }
 
-func NewReader(sctx *super.Context, r io.Reader, opts ReaderOpts) (sio.ReadCloser, error) {
+func NewReader(ctx context.Context, sctx *super.Context, r io.Reader, opts ReaderOpts) (vio.Puller, error) {
+	if opts.ConcurrentReaders == 0 {
+		opts.ConcurrentReaders = 1
+	}
 	if opts.Format != "" && opts.Format != "auto" {
-		return lookupReader(sctx, r, opts)
+		return lookupReader(ctx, sctx, r, opts)
 	}
 
 	track := NewTrack(r)
 
 	csupErr := isCSUPStream(track)
 	if csupErr == nil {
-		return csupio.NewReader(sctx, track.Reader(), opts.Fields)
+		return csupio.NewVectorReader(ctx, sctx, track.Reader(), opts.Pushdown, opts.ConcurrentReaders)
 	}
 	csupErr = fmt.Errorf("csup: %w", csupErr)
 	track.Reset()
 
-	parquetErr := isParquetStream(track)
+	parquetErr := isParquetStream(ctx, track)
 	if parquetErr == nil {
-		return parquetio.NewReader(sctx, track.Reader(), opts.Fields)
+		return parquetio.NewVectorReader(ctx, sctx, track.Reader(), opts.Pushdown, opts.ConcurrentReaders)
 	}
 	parquetErr = fmt.Errorf("parquet: %w", parquetErr)
 	track.Reset()
 
 	arrowsErr := isArrowStream(track)
 	if arrowsErr == nil {
-		return arrowio.NewReader(sctx, track.Reader())
+		r, err := arrowio.NewReader(sctx, track.Reader())
+		return newVioPuller(sctx, r), err
 	}
 	arrowsErr = fmt.Errorf("arrows: %w", arrowsErr)
 	track.Reset()
 
 	zeekErr := match(zeekio.NewReader(super.NewContext(), track), "zeek", 1)
 	if zeekErr == nil {
-		return sio.NopReadCloser(zeekio.NewReader(sctx, track.Reader())), nil
+		return newVioPuller(sctx, zeekio.NewReader(sctx, track.Reader())), nil
 	}
 	track.Reset()
 
@@ -69,13 +76,13 @@ func NewReader(sctx *super.Context, r io.Reader, opts ReaderOpts) (sio.ReadClose
 	// sake of tests.
 	jsonErr := match(jsonio.NewReader(super.NewContext(), track), "json", 10)
 	if jsonErr == nil {
-		return sio.NopReadCloser(jsonio.NewReader(sctx, track.Reader())), nil
+		return newVioPuller(sctx, jsonio.NewReader(sctx, track.Reader())), nil
 	}
 	track.Reset()
 
 	supErr := match(supio.NewReader(super.NewContext(), track), "sup", 1)
 	if supErr == nil {
-		return sio.NopReadCloser(supio.NewReader(sctx, track.Reader())), nil
+		return newVioPuller(sctx, supio.NewReader(sctx, track.Reader())), nil
 	}
 	track.Reset()
 
@@ -89,19 +96,23 @@ func NewReader(sctx *super.Context, r io.Reader, opts ReaderOpts) (sio.ReadClose
 	// Close bsupReader to ensure that it does not continue to call track.Read.
 	bsupReader.Close()
 	if bsupErr == nil {
-		return bsupio.NewReaderWithOpts(sctx, track.Reader(), opts.BSUP), nil
+		scanner, err := bsupio.NewReaderWithOpts(sctx, track.Reader(), opts.BSUP).NewScanner(ctx, opts.Pushdown)
+		if err != nil {
+			return nil, err
+		}
+		return sbuf.NewDematerializer(sctx, scanner), nil
 	}
 	track.Reset()
 
 	csvErr := isCSVStream(track, ',', "csv")
 	if csvErr == nil {
-		return sio.NopReadCloser(csvio.NewReader(sctx, track.Reader(), csvio.ReaderOpts{Delim: ','})), nil
+		return newVioPuller(sctx, csvio.NewReader(sctx, track.Reader(), csvio.ReaderOpts{Delim: ','})), nil
 	}
 	track.Reset()
 
 	tsvErr := isCSVStream(track, '\t', "tsv")
 	if tsvErr == nil {
-		return sio.NopReadCloser(csvio.NewReader(sctx, track.Reader(), csvio.ReaderOpts{Delim: '\t'})), nil
+		return newVioPuller(sctx, csvio.NewReader(sctx, track.Reader(), csvio.ReaderOpts{Delim: '\t'})), nil
 	}
 	track.Reset()
 
@@ -182,7 +193,7 @@ func isCSVStream(track *Track, delim rune, name string) error {
 	return match(csvio.NewReader(super.NewContext(), track, csvio.ReaderOpts{Delim: delim}), name, 1)
 }
 
-func isParquetStream(track *Track) error {
+func isParquetStream(ctx context.Context, track *Track) error {
 	// a parquet stream starts with a 4-byte magic: PAR1 or PARE. If we find
 	// this we probably have a parquet but to be sure we'll have to read the
 	// entire stream till EOF and then check the footer.
@@ -201,7 +212,7 @@ func isParquetStream(track *Track) error {
 		}
 		*track = *NewTrack(bytes.NewReader(b))
 	}
-	_, err := parquetio.NewReader(super.NewContext(), track.Reader(), nil)
+	_, err := parquetio.NewVectorReader(ctx, super.NewContext(), track.Reader(), nil, 1)
 	return err
 }
 

--- a/sio/csupio/vectorreader.go
+++ b/sio/csupio/vectorreader.go
@@ -41,7 +41,7 @@ func NewVectorReader(ctx context.Context, sctx *super.Context, r io.Reader, p sb
 		return nil, errors.New("Super Columnar requires a seekable input")
 	}
 	var buf [1]byte
-	if _, err := ra.ReadAt(buf[:], 0); err != nil {
+	if _, err := ra.ReadAt(buf[:], 0); err != nil && !errors.Is(err, io.EOF) {
 		return nil, errors.New("Super Columnar requires a seekable input")
 	}
 	var metaFilters []*metafilter
@@ -117,14 +117,18 @@ func (v *VectorReader) ConcurrentPull(done bool, n int) (vector.Any, error) {
 		// able to build runtime expressions that use different type contexts.
 		if len(v.metaFilters) == 0 || !pruneObject(v.sctx, v.metaFilters[n], o) {
 			vo := vcache.NewObjectFromCSUP(o)
-			if v.pushdown.Unordered() {
-				v.vecs[n], err = vo.FetchUnordered(v.vecs[n][:0], v.sctx, v.pushdown.Projection())
+			var proj field.Projection
+			if v.pushdown != nil {
+				proj = v.pushdown.Projection()
+			}
+			if v.pushdown != nil && v.pushdown.Unordered() {
+				v.vecs[n], err = vo.FetchUnordered(v.vecs[n][:0], v.sctx, proj)
 				if err != nil {
 					v.close()
 					return nil, err
 				}
 			} else {
-				vec, err := vo.Fetch(v.sctx, v.pushdown.Projection())
+				vec, err := vo.Fetch(v.sctx, proj)
 				if err != nil {
 					v.close()
 					return nil, err

--- a/sio/parquetio/vectorreader.go
+++ b/sio/parquetio/vectorreader.go
@@ -16,6 +16,7 @@ import (
 	"github.com/apache/arrow-go/v18/parquet/pqarrow"
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/pkg/byteconv"
+	"github.com/brimdata/super/pkg/field"
 	"github.com/brimdata/super/runtime/sam/expr"
 	"github.com/brimdata/super/sbuf"
 	"github.com/brimdata/super/sio/arrowio"
@@ -65,7 +66,9 @@ func NewVectorReader(ctx context.Context, sctx *super.Context, r io.Reader, p sb
 	}
 	var metadataColIndexes []int
 	var metadataFilters []expr.Evaluator
+	var fields []field.Path
 	if p != nil {
+		fields = p.Projection().Paths()
 		filter, projection, err := p.MetaFilter()
 		if err != nil {
 			return nil, err
@@ -96,7 +99,7 @@ func NewVectorReader(ctx context.Context, sctx *super.Context, r io.Reader, p sb
 		ctx:                ctx,
 		sctx:               sctx,
 		fr:                 fr,
-		colIndexes:         columnIndexes(prmd.Schema, p.Projection().Paths()),
+		colIndexes:         columnIndexes(prmd.Schema, fields),
 		colIndexToField:    schemaManifest.ColIndexToField,
 		metadataColIndexes: metadataColIndexes,
 		metadataFilters:    metadataFilters,

--- a/spq_test.go
+++ b/spq_test.go
@@ -116,14 +116,15 @@ func isValid(t *testing.T, name, s string) bool {
 			t.Fatalf("boomerang panic reading test input: %s: %+v\n%s\n", name, r, debug.Stack())
 		}
 	}()
-	zrc, err := anyio.NewReader(super.NewContext(), strings.NewReader(s), anyio.ReaderOpts{})
+	p, err := anyio.NewReader(t.Context(), super.NewContext(), strings.NewReader(s), anyio.ReaderOpts{})
 	if err != nil {
 		return false
 	}
-	defer zrc.Close()
+	defer p.Pull(true)
+	r := sbuf.PullerReader(sbuf.NewMaterializer(p))
 	var foundValue bool
 	for {
-		val, err := zrc.Read()
+		val, err := r.Read()
 		if err != nil {
 			return false
 		}
@@ -147,16 +148,15 @@ func runAllBoomerangs(t *testing.T, format string, data map[string]string) {
 }
 
 func runOneBoomerang(t *testing.T, format, data string) {
-	// Create an auto-detecting reader for data.
+	// Create an auto-detecting puller for data.
 	sctx := super.NewContext()
-	dataReadCloser, err := anyio.NewReader(sctx, strings.NewReader(data), anyio.ReaderOpts{})
+	dataPuller, err := anyio.NewReader(t.Context(), sctx, strings.NewReader(data), anyio.ReaderOpts{})
 	require.NoError(t, err)
-	defer dataReadCloser.Close()
+	defer dataPuller.Pull(true)
 
-	dataPuller := vio.Puller(sbuf.NewDematerializer(sctx, sbuf.NewPuller(dataReadCloser)))
 	if format == "parquet" {
 		// Fuse data for formats that require uniform values.
-		q, err := newQuery(t.Context(), sctx, "fuse", dataReadCloser)
+		q, err := newQuery(t.Context(), sctx, "fuse", dataPuller)
 		require.NoError(t, err)
 		defer q.Pull(true)
 		dataPuller = q
@@ -172,16 +172,16 @@ func runOneBoomerang(t *testing.T, format, data string) {
 		t.Fatalf("unexpected error writing %s baseline: %s", format, err)
 	}
 
-	baselineReader, err := anyio.NewReader(super.NewContext(), strings.NewReader(baseline), anyio.ReaderOpts{
+	baselinePuller, err := anyio.NewReader(t.Context(), super.NewContext(), strings.NewReader(baseline), anyio.ReaderOpts{
 		Format: format,
 		BSUP: bsupio.ReaderOpts{
 			Validate: true,
 		},
 	})
 	require.NoError(t, err)
-	defer baselineReader.Close()
+	defer baselinePuller.Pull(true)
 
-	boomerang, err := serialize(sbuf.NewDematerializer(sctx, sbuf.NewPuller(baselineReader)), format)
+	boomerang, err := serialize(baselinePuller, format)
 	require.NoError(t, err)
 
 	require.Equal(t, baseline, boomerang, "baseline and boomerang differ")
@@ -202,12 +202,12 @@ func runAllFusionBoomerangs(t *testing.T, data map[string]string) {
 func runOneFusionBoomerang(t *testing.T, data string) {
 	// Create an auto-detecting reader for data.
 	dataSctx := super.NewContext()
-	dataReader, err := anyio.NewReader(dataSctx, strings.NewReader(data), anyio.ReaderOpts{})
+	dataPuller, err := anyio.NewReader(t.Context(), dataSctx, strings.NewReader(data), anyio.ReaderOpts{})
 	require.NoError(t, err)
-	defer dataReader.Close()
+	defer dataPuller.Pull(true)
 
 	// Serialize non-fusion values from dataReader to baseline as SUP.
-	r := &fusionRemovingReader{dataReader, hasFusion{}}
+	r := &fusionRemovingReader{sbuf.PullerReader(sbuf.NewMaterializer(dataPuller)), hasFusion{}}
 	puller := sbuf.NewDematerializer(dataSctx, sbuf.NewPuller(r))
 	baseline, err := serialize(puller, "sup")
 	require.NoError(t, err)
@@ -224,7 +224,8 @@ func runOneFusionBoomerang(t *testing.T, data string) {
 func fuseDefuse(ctx context.Context, s string) (string, error) {
 	sctx := super.NewContext()
 	r := supio.NewReader(sctx, strings.NewReader(s))
-	q, err := newQuery(ctx, sctx, "fuse | defuse(this)", r)
+	p := sbuf.NewDematerializer(sctx, sbuf.NewPuller(r))
+	q, err := newQuery(ctx, sctx, "fuse | defuse(this)", p)
 	if err != nil {
 		return "", err
 	}
@@ -232,13 +233,13 @@ func fuseDefuse(ctx context.Context, s string) (string, error) {
 	return serialize(q, "sup")
 }
 
-func newQuery(ctx context.Context, sctx *super.Context, spq string, r sio.Reader) (vio.Puller, error) {
+func newQuery(ctx context.Context, sctx *super.Context, spq string, p vio.Puller) (vio.Puller, error) {
 	ast, err := parser.ParseText(spq)
 	if err != nil {
 		return nil, err
 	}
 	rctx := runtime.NewContext(ctx, sctx)
-	q, err := compiler.NewCompiler(nil).NewQuery(rctx, ast, []sio.Reader{r}, 0)
+	q, err := compiler.NewCompiler(nil).NewQuery(rctx, ast, []vio.Puller{p}, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/vector/vio/io.go
+++ b/vector/vio/io.go
@@ -2,6 +2,7 @@ package vio
 
 import (
 	"io"
+	"slices"
 	"sync/atomic"
 
 	"github.com/brimdata/super/vector"
@@ -113,4 +114,36 @@ func CopyMux(outputs map[string]Pusher, parent Puller) error {
 			}
 		}
 	}
+}
+
+func ConcatPuller(readers ...Puller) Puller {
+	if len(readers) == 1 {
+		return readers[0]
+	}
+	return &concatReader{slices.Clone(readers)}
+}
+
+type concatReader struct {
+	pullers []Puller
+}
+
+func (c *concatReader) Pull(done bool) (vector.Any, error) {
+	if done {
+		var err error
+		for _, p := range c.pullers {
+			if _, perr := p.Pull(done); err == nil {
+				err = perr
+			}
+		}
+		c.pullers = nil
+		return nil, err
+	}
+	for len(c.pullers) > 0 {
+		vec, err := c.pullers[0].Pull(done)
+		if vec != nil || err != nil {
+			return vec, err
+		}
+		c.pullers = c.pullers[1:]
+	}
+	return nil, nil
 }


### PR DESCRIPTION
This commit changes anyio.NewReader so that a vio.Puller is returned. CSUP and Parquet return the native Vector Puller implementation, all other formats convert the input into vectors using sbuf.Dematerializer. This change has an intended downstream consequence that CSUP and Parquet files read anywhere will remain in their native vector format and not get converted to sequential then back to vectors as is the current state of affairs.