### PR TITLE
fjson: Fix incorrect line number on parse error

### DIFF
--- a/sio/fjsonio/valreader.go
+++ b/sio/fjsonio/valreader.go
@@ -62,7 +62,7 @@ func (r *valReader) Next() ([]byte, error) {
 			}
 			return nil, r.parseError()
 		}
-		b := r.cursor[start:end]
+		b := r.cursor[:end]
 		r.line += bytes.Count(b, []byte{'\n'})
 		r.cursor = r.cursor[end:]
 		return b, nil

--- a/sio/fjsonio/ztests/parser-error.yaml
+++ b/sio/fjsonio/ztests/parser-error.yaml
@@ -4,12 +4,16 @@ spq: pass
 input-flags: '-i fjson'
 
 input: |
+  1
+  null
   {"x":1}
+  true
+  [1,2]
   {"x":}
   {"x":1}
 
 error: |
-  stdio:stdin: line 2: invalid JSON value
+  stdio:stdin: line 6: invalid JSON value
 
 ---
 


### PR DESCRIPTION
sonic SkipLine normally skips opening whitespace characters, including new lines, so base count on full cursor to the end of the parsed buffer to get correct line numbers on parse errors.