### PR TITLE
fjson: Fix incorrect line number on parse error

### DIFF
--- a/sio/fjsonio/valreader.go
+++ b/sio/fjsonio/valreader.go
@@ -62,7 +62,7 @@ func (r *valReader) Next() ([]byte, error) {
 			}
 			return nil, r.parseError()
 		}
-		b := r.cursor[start:end]
+		b := r.cursor[:end]
 		r.line += bytes.Count(b, []byte{'\n'})
 		r.cursor = r.cursor[end:]
 		return b, nil

--- a/sio/fjsonio/ztests/parser-error.yaml
+++ b/sio/fjsonio/ztests/parser-error.yaml
@@ -4,12 +4,18 @@ spq: pass
 input-flags: '-i fjson'
 
 input: |
-  {"x":1}
+  1
+  null
+  {
+    "x":1
+  }
+  true
+  [1,2]
   {"x":}
   {"x":1}
 
 error: |
-  stdio:stdin: line 2: invalid JSON value
+  stdio:stdin: line 8: invalid JSON value
 
 ---
 


### PR DESCRIPTION
This commit fixes incorrect line numbers getting reported in fjson errors by counting all whitespace characters from the start of cursor- sonic.SkipLine skips prefix whitespace characters. We also add cursor[:end] to the parsed BytesTable so we will be able to recover line number of errors that occur when parsing JSON values.