### PR TITLE
change scode.Bytes to []byte for type value encodings

### DIFF
--- a/context.go
+++ b/context.go
@@ -35,7 +35,7 @@ type Context struct {
 	typedefs  *TypeDefs
 	named     map[string]*TypeNamed
 	stringErr atomic.Pointer[TypeError]
-	toValue   map[Type]scode.Bytes
+	toValue   map[Type][]byte
 	toType    map[string]Type
 }
 
@@ -390,12 +390,12 @@ func (c *Context) LookupTypeFusion(inner Type) *TypeFusion {
 // LookupByValue returns the Type indicated by a binary-serialized type value.
 // This provides a means to translate a type-context-independent serialized
 // encoding for an arbitrary type into the reciever Context.
-func (c *Context) LookupByValue(tv scode.Bytes) (Type, error) {
+func (c *Context) LookupByValue(tv []byte) (Type, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.toType == nil {
 		c.toType = make(map[string]Type)
-		c.toValue = make(map[Type]scode.Bytes)
+		c.toValue = make(map[Type][]byte)
 	}
 	typ, ok := c.toType[string(tv)]
 	if ok {
@@ -436,7 +436,7 @@ func (c *Context) LookupTypeValue(typ Type) Value {
 	return c.LookupTypeValue(typ)
 }
 
-func (c *Context) DecodeTypeValue(tv scode.Bytes) (Type, scode.Bytes) {
+func (c *Context) DecodeTypeValue(tv []byte) (Type, []byte) {
 	if len(tv) == 0 {
 		return nil, nil
 	}
@@ -601,7 +601,7 @@ func (c *Context) DecodeTypeValue(tv scode.Bytes) (Type, scode.Bytes) {
 	}
 }
 
-func DecodeName(tv scode.Bytes) (string, scode.Bytes) {
+func DecodeName(tv []byte) (string, []byte) {
 	namelen, tv := DecodeLength(tv)
 	if tv == nil || namelen > len(tv) {
 		return "", nil
@@ -609,12 +609,12 @@ func DecodeName(tv scode.Bytes) (string, scode.Bytes) {
 	return string(tv[:namelen]), tv[namelen:]
 }
 
-func MustDecodeName(tv scode.Bytes) (string, scode.Bytes) {
+func MustDecodeName(tv []byte) (string, []byte) {
 	namelen, tv := MustDecodeLength(tv)
 	return string(tv[:namelen]), tv[namelen:]
 }
 
-func DecodeLength(tv scode.Bytes) (int, scode.Bytes) {
+func DecodeLength(tv []byte) (int, []byte) {
 	namelen, n := binary.Uvarint(tv)
 	if n <= 0 {
 		return 0, nil
@@ -622,7 +622,7 @@ func DecodeLength(tv scode.Bytes) (int, scode.Bytes) {
 	return int(namelen), tv[n:]
 }
 
-func MustDecodeLength(tv scode.Bytes) (int, scode.Bytes) {
+func MustDecodeLength(tv []byte) (int, []byte) {
 	namelen, n := binary.Uvarint(tv)
 	if n <= 0 {
 		panic(tv)
@@ -740,7 +740,7 @@ func IsOptionType(typ Type) bool {
 	return u != nil
 }
 
-func IsNone(typ Type, bytes scode.Bytes) bool {
+func IsNone(typ Type, bytes []byte) bool {
 	if union, ok := TypeUnder(typ).(*TypeUnion); ok {
 		typ, _ := union.Untag(bytes)
 		return typ == TypeNone

--- a/context_test.go
+++ b/context_test.go
@@ -20,7 +20,7 @@ func TestContextLookupByValueAndLookupTypeValue(t *testing.T) {
 	// Overwriting tv should not affect sctx's cached type value for recType.
 	super.AppendTypeValue(tv[:0], super.TypeNull)
 	val := sctx.LookupTypeValue(recType)
-	assert.Exactly(t, super.EncodeTypeValue(recType), val.Bytes())
+	assert.Exactly(t, super.EncodeTypeValue(recType), []byte(val.Bytes()))
 }
 
 func TestContextLookupTypeNamedErrors(t *testing.T) {

--- a/type.go
+++ b/type.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-
-	"github.com/brimdata/super/scode"
 )
 
 var (
@@ -149,13 +147,12 @@ const (
 	TypeValueMax     = TypeValueFusion
 )
 
-// True iff the type id is encoded as a BSUP signed or unsigened integer scode.Bytes.
+// True iff the type id is a signed or unsigened integer.
 func IsInteger(id int) bool {
 	return id <= IDInt256
 }
 
-// True iff the type id is encoded as a BSUP signed or unsigned integer scode.Bytes,
-// float16 scode.Bytes, float32 scode.Bytes, or float64 scode.Bytes.
+// True iff the type id is a signed or unsigned integer, float16, float32, or float64.
 func IsNumber(id int) bool {
 	return id <= IDDecimal256
 }
@@ -503,16 +500,16 @@ func (t *TypeOfType) Kind() Kind {
 	return PrimitiveKind
 }
 
-func EncodeTypeValue(t Type) scode.Bytes {
+func EncodeTypeValue(t Type) []byte {
 	return AppendTypeValue(nil, t)
 }
 
-func AppendTypeValue(b scode.Bytes, t Type) scode.Bytes {
+func AppendTypeValue(b []byte, t Type) []byte {
 	var typedefs map[string]Type
 	return appendTypeValue(b, t, &typedefs)
 }
 
-func appendTypeValue(b scode.Bytes, t Type, typedefs *map[string]Type) scode.Bytes {
+func appendTypeValue(b []byte, t Type, typedefs *map[string]Type) []byte {
 	switch t := t.(type) {
 	case *TypeNamed:
 		if *typedefs == nil {
@@ -529,7 +526,7 @@ func appendTypeValue(b scode.Bytes, t Type, typedefs *map[string]Type) scode.Byt
 		}
 		b = append(b, id)
 		b = binary.AppendUvarint(b, uint64(len(t.Name)))
-		b = append(b, scode.Bytes(t.Name)...)
+		b = append(b, t.Name...)
 		if id == TypeValueNameRef {
 			return b
 		}


### PR DESCRIPTION
Type values are their own encoding and aren't scode.Bytes so change scode.Bytes to []byte in some places.