### PR TITLE
sio/csupio, sio/parquetio: fix non-Boolean metadata filter result handling

### DIFF
--- a/sio/csupio/vectorreader.go
+++ b/sio/csupio/vectorreader.go
@@ -142,7 +142,7 @@ func (v *VectorReader) ConcurrentPull(done bool, n int) (vector.Any, error) {
 func pruneObject(sctx *super.Context, mf *metafilter, o *csup.Object) bool {
 	vals := o.ProjectMetadata(sctx, mf.projection)
 	for _, val := range vals {
-		if mf.filter.Eval(val).Ptr().AsBool() {
+		if !mf.filter.Eval(val).Equal(super.False) {
 			return false
 		}
 	}

--- a/sio/csupio/ztests/metadata.yaml
+++ b/sio/csupio/ztests/metadata.yaml
@@ -1,0 +1,12 @@
+script: |
+  super -f csup -o t.csup -
+  super -s -c 'from t.csup | where x.y==1'
+
+inputs:
+  - name: stdin
+    data: &stdin |
+      {x?:{y:1}}
+
+outputs:
+  - name: stdout
+    data: *stdin

--- a/sio/parquetio/vectorreader.go
+++ b/sio/parquetio/vectorreader.go
@@ -145,7 +145,7 @@ func (p *VectorReader) ConcurrentPull(done bool, id int) (vector.Any, error) {
 			if len(p.metadataFilters) > 0 {
 				rgMetadata := pr.MetaData().RowGroup(rowGroup)
 				val := buildMetadataValue(p.sctx, rgMetadata, p.metadataColIndexes, p.colIndexToField)
-				if !p.metadataFilters[id].Eval(val).Ptr().AsBool() {
+				if p.metadataFilters[id].Eval(val).Equal(super.False) {
 					continue
 				}
 			}


### PR DESCRIPTION
csupio.VectorReader.ConcurrentPull can skip objects incorrectly because csupio.pruneObject can produce a false positive when the metadata filter evaluates to a non-Boolean value, like null or an error.  Fix this by checking explicitly for super.False instead of calling super.Value.AsBool.

parquet.VectorReader.ConcurrentPull has a similar problem and fix.