### PR TITLE
Fix upcasting dict/const values

### DIFF
--- a/runtime/vam/expr/function/upcast.go
+++ b/runtime/vam/expr/function/upcast.go
@@ -88,18 +88,6 @@ func (u *Upcast) upcast(vec vector.Any, to super.Type) vector.Any {
 	switch vec := vec.(type) {
 	case *vector.Fusion:
 		return u.upcast(vec.Values, to)
-	case *vector.Const:
-		vec2 := u.upcast(vec.Any, to)
-		if vec2 == nil {
-			return nil
-		}
-		return vector.NewConst(vec2, vec.Len())
-	case *vector.Dict:
-		vec2 := u.upcast(vec.Any, to)
-		if vec2 == nil {
-			return nil
-		}
-		return vector.NewDict(vec2, vec.Index, vec.Counts)
 	case *vector.View:
 		vec2 := u.upcast(vec.Any, to)
 		if vec2 == nil {


### PR DESCRIPTION
The commit fixes an issue when attempting to upcast vectors wrapped in dicts or consts to a fusion value- the way the code currently works is the dict/const ends up wrapping the output fusion vector. This issue is fixed by removing the code that does this; we don't switch on primitive types in upcast so the unwrapping of consts and dicts isn't needed anyways.