### PR TITLE
csup: fix nullable-union corruption from collapsed tag RLEs

### DIFF
--- a/sio/csupio/ztests/issue-7140.yaml
+++ b/sio/csupio/ztests/issue-7140.yaml
@@ -1,0 +1,50 @@
+# Regression test for https://github.com/brimdata/super/issues/7140
+# A two-typed union column (T|null) reaches the CSUP writer as separate
+# value and null batches.  The writer stitched the per-batch tag run-length
+# encodings together without materializing each batch's implicit trailing
+# value run, collapsing the runs and misaligning the null bitmap so nulls
+# landed on the wrong rows.  CSUP output must match the (correct) Parquet
+# output for the same input.
+script: |
+  super -f csup    -o repro.csup    -c "put v := v::float32::(float32|null)" repro.csv
+  super -f parquet -o repro.parquet -c "put v := v::float32::(float32|null)" repro.csv
+  super -f sup -c "sort id" repro.csup
+  echo ---
+  super -f sup -c "sort id" repro.parquet
+
+inputs:
+  - name: repro.csv
+    data: |
+      id,v
+      0,10
+      1,
+      2,30
+
+outputs:
+  - name: stdout
+    data: |
+      {
+        id: 0.,
+        v: 10.::float32::(float32|null)
+      }
+      {
+        id: 1.,
+        v: null::(float32|null)
+      }
+      {
+        id: 2.,
+        v: 30.::float32::(float32|null)
+      }
+      ---
+      {
+        id: 0.,
+        v: 10.::float32::(float32|null)
+      }
+      {
+        id: 1.,
+        v: null::(float32|null)
+      }
+      {
+        id: 2.,
+        v: 30.::float32::(float32|null)
+      }

--- a/vector/vbuild/union.go
+++ b/vector/vbuild/union.go
@@ -38,11 +38,14 @@ func (u *unionBuilder) Write(vec vector.Any) {
 	var vecs []vector.Any
 	if len(union.Typ.Types) == 2 {
 		// Code tags as run lengths.
-		rle := union.TagsRLE()
-		if rle == nil {
-			// Encoder returns nil for all tag 0
-			rle = []uint32{0, vec.Len()}
-		}
+		// TagsRLE encodes the tags as alternating runs of nones and
+		// values beginning with a none run.  The final value run is left
+		// implicit (e.g. a nil or [0] result for an all-values batch), so
+		// its length is not recoverable from the run slice alone.  Make
+		// the trailing value run explicit before stitching batches
+		// together; otherwise concatRLEs collapses adjacent batches and
+		// misaligns the null bitmap (see issue #7140).
+		rle := completeRLE(union.TagsRLE(), vec.Len())
 		vecs, rle = reorderRLE(union, rle)
 		u.rleOrTags = concatRLEs(u.rleOrTags, rle)
 	} else {
@@ -55,6 +58,29 @@ func (u *unionBuilder) Write(vec vector.Any) {
 			u.values[k].Write(vec)
 		}
 	}
+}
+
+// completeRLE returns a run-length tag slice whose runs cover exactly n
+// elements.  TagsRLE leaves the final value run implicit (returning nil or a
+// slice whose runs sum to fewer than n elements), so any positions not
+// accounted for by rle are a trailing run of values (tag 0).  We materialize
+// that run here so the result is self-describing and safe to concatenate with
+// concatRLEs.  Runs alternate none/value starting with a none run, so when the
+// number of existing runs is even (the next run would be a none run) we insert
+// an empty none run before the trailing value run.
+func completeRLE(rle []uint32, n uint32) []uint32 {
+	var sum uint32
+	for _, r := range rle {
+		sum += r
+	}
+	if sum >= n {
+		return rle
+	}
+	out := slices.Clone(rle)
+	if len(out)%2 == 0 {
+		out = append(out, 0)
+	}
+	return append(out, n-sum)
 }
 
 func concatRLEs(a, b []uint32) []uint32 {


### PR DESCRIPTION
Fixes #7140.

## Problem

A two-typed union column (`T|null`) can reach the CSUP writer's union builder as separate value and null batches. `unionBuilder.Write` (`vector/vbuild/union.go`) encodes each batch's tags as a run-length slice via `Union.TagsRLE`, whose **final value run is left implicit**: an all-values batch yields `nil` or `[0]`, and that trailing run length is not recoverable from the slice alone.

The previous code only expanded the `nil` result to `[0, vec.Len()]`. Since #7130 the incoming union carries an RLE, so `TagsRLE` now returns a non-nil `[0]` for an all-values batch, bypassing that fallback. `concatRLEs` then stitched the batches together without materializing the trailing value run, collapsing the runs and landing nulls on the wrong rows. CSUP output for such columns diverged from the (correct) Parquet output.

Minimal repro from the issue:

```
printf 'id,v\n0,10\n1,\n2,30\n' > repro.csv
super -f csup    -o repro.csup    -c "put v := v::float32::(float32|null)" repro.csv
super -f parquet -o repro.parquet -c "put v := v::float32::(float32|null)" repro.csv
super -f sup -c "sort id" repro.csup      # was: nulls/values misaligned
super -f sup -c "sort id" repro.parquet   # correct reference
```

## Fix

Materialize the implicit trailing value run with a small `completeRLE` helper so every per-batch RLE covers exactly `vec.Len()` elements (is self-describing) before it is concatenated. `concatRLEs` is already correct on self-describing inputs, so no other change is needed. This generalizes the old `nil -> [0, len]` special case to also cover the non-nil incomplete `[0]` form.

## Test

Adds `sio/csupio/ztests/issue-7140.yaml`, a script ztest that writes the column both to CSUP and Parquet and asserts the sorted CSUP output matches the correct Parquet output. Verified the test fails on the unpatched binary and passes with the fix.

Also spot-checked all-null, all-value, null-first, null-last, alternating, adjacent-null, single-row, larger randomized (500-row), and `string|null` cases: CSUP now matches Parquet in every case. `go test ./vector/... ./csup/... ./runtime/vam/...` and the `sio/csupio` ztests pass; remaining ztest failures in the tree are pre-existing environment gaps (`minio`, `gentoken`, `mockzui` not installed).
