### PR TITLE
hashjoin: Keep fusion values in output

### DIFF
--- a/runtime/vam/op/hashjoin.go
+++ b/runtime/vam/op/hashjoin.go
@@ -276,12 +276,12 @@ func (j *hashJoin) wrap(l, r *super.Value) super.Value {
 	j.builder.Reset()
 	var fields []super.Field
 	if l != nil {
-		left := l.Under()
+		left := l.Deunion()
 		fields = append(fields, super.Field{Name: j.leftAlias, Type: left.Type()})
 		j.builder.Append(left.Bytes())
 	}
 	if r != nil {
-		right := r.Under()
+		right := r.Deunion()
 		fields = append(fields, super.Field{Name: j.rightAlias, Type: right.Type()})
 		j.builder.Append(right.Bytes())
 
@@ -326,5 +326,6 @@ func (b *bufPuller) pull(done bool) (vector.Any, error) {
 }
 
 func hashKey(val super.Value) string {
+	val = val.Deunion()
 	return string(binary.LittleEndian.AppendUint32(val.Bytes(), uint32(val.Type().ID())))
 }

--- a/runtime/ztests/op/join-fusion.yaml
+++ b/runtime/ztests/op/join-fusion.yaml
@@ -1,0 +1,27 @@
+script: |
+  echo // hash join
+  super -s -c 'from a.sup | inner join (from b.sup) on left.a=right.b | values left | sort'
+  echo // nested loop join
+  super -s -c 'from a.sup | inner join (from b.sup) on left.a<right.b | values left | sort'
+
+inputs:
+  - name: a.sup
+    data: |
+      fusion({a:1::(int64|string),b?:_::string},<{a:int64}>)
+      fusion({a:2::(int64|string),b?:"note1"},<{a:int64,b:string}>)
+      fusion({a:"bar"::(int64|string),b?:"note2"},<{a:string,b:string}>)
+  - name: b.sup
+    data: |
+      {b:1}
+      {b:3}
+      {b:"bar"}
+
+outputs:
+  - name: stdout
+    data: |
+      // hash join
+      {a:1}
+      {a:"bar",b:"note2"}
+      // nested loop join
+      {a:1}
+      {a:2,b:"note1"}


### PR DESCRIPTION
This commit changes the hash join operator so that the left and right values are only deunioned and any fusion values are kept intact. It also fixes the hashkey function so hashed values are deunioned beforehand.