### PR TITLE
union.TagsRLE: Only build if dynamic.Tags is non nil

### DIFF
--- a/vector/union.go
+++ b/vector/union.go
@@ -141,7 +141,7 @@ func (u *Union) Tags() []uint32 {
 }
 
 func (u *Union) TagsRLE() []uint32 {
-	if u.rle == nil {
+	if u.dynamic.Tags != nil && u.rle == nil {
 		if len(u.Typ.Types) != 2 {
 			panic("union tags RLEs can have only two types")
 		}

--- a/vector/union_test.go
+++ b/vector/union_test.go
@@ -38,3 +38,9 @@ func TestNewUnionFromRLEVerifyPanics(t *testing.T) {
 		NewUnionFromRLE(utyp, nil, []Any{intVec, ipVec})
 	})
 }
+
+func TestUnionAllZerosTagsRLE(t *testing.T) {
+	utyp := super.NewContext().MustLookupTypeUnion([]super.Type{super.TypeInt64, super.TypeNull})
+	u := NewUnionFromRLE(utyp, nil, []Any{NewInt(super.TypeInt64, []int64{1, 2}), NewEmpty(super.TypeNull)})
+	require.Zero(t, u.TagsRLE())
+}


### PR DESCRIPTION
This commit fixes an issue with union.TagsRLE() which was returning the wrong value on union RLEs with all zeros encoded. Only build RLE if dynamic.Tags is not nil.

Closes #7140