### PR TITLE
vbuild.Array|Set|Map: Push views

### DIFF
--- a/vector/vbuild/array.go
+++ b/vector/vbuild/array.go
@@ -25,11 +25,7 @@ func (a *arraySetBuilder) Write(vec vector.Any) {
 	if n == 0 {
 		return
 	}
-	var index []uint32
-	if view, ok := vec.(*vector.View); ok {
-		vec = view.Any
-		index = view.Index
-	}
+	vec = vector.PushView(vec)
 	var offsets []uint32
 	switch vec := vec.(type) {
 	case *vector.Array:
@@ -42,11 +38,7 @@ func (a *arraySetBuilder) Write(vec vector.Any) {
 		panic(vec)
 	}
 	for i := range n {
-		idx := i
-		if index != nil {
-			idx = index[i]
-		}
-		a.len += offsets[idx+1] - offsets[idx]
+		a.len += offsets[i+1] - offsets[i]
 		a.offsets = append(a.offsets, a.len)
 	}
 }

--- a/vector/vbuild/map.go
+++ b/vector/vbuild/map.go
@@ -27,20 +27,11 @@ func (m *mapBuilder) Write(vec vector.Any) {
 	if n == 0 {
 		return
 	}
-	var index []uint32
-	if view, ok := vec.(*vector.View); ok {
-		index = view.Index
-		vec = view.Any
-	}
-	vmap := vec.(*vector.Map)
+	vmap := vector.PushView(vec).(*vector.Map)
 	m.keys.Write(vmap.Keys)
 	m.vals.Write(vmap.Values)
 	for i := range n {
-		idx := i
-		if index != nil {
-			idx = index[i]
-		}
-		m.len += vmap.Offsets[idx+1] - vmap.Offsets[idx]
+		m.len += vmap.Offsets[i+1] - vmap.Offsets[i]
 		m.offsets = append(m.offsets, m.len)
 	}
 }


### PR DESCRIPTION
In vbuild for arrays, sets and maps, views were not getting pushed down onto the inner elements and this was causing invalid vector forms for lists with zero element entries. Use vector.PushView to fix this problem.