### PR TITLE
put: defuse before eval

### DIFF
--- a/runtime/vam/expr/putter.go
+++ b/runtime/vam/expr/putter.go
@@ -6,27 +6,32 @@ import (
 )
 
 type putter struct {
-	sctx *super.Context
-	e    Evaluator
+	sctx   *super.Context
+	e      Evaluator
+	defuse *Defuse
 }
 
 // NewPutter wraps e to implement the behavior of the put operator, which emits
 // an error when an input value is not a record.
 func NewPutter(sctx *super.Context, e Evaluator) Evaluator {
-	return &putter{sctx, e}
+	return &putter{sctx, e, NewDefuse(sctx)}
 }
 
 func (p *putter) Eval(vec vector.Any) vector.Any {
-	return vector.Apply(vector.ApplyRipFusions, p.eval, vec)
+	// XXX At some point we should do something more optimized than calling
+	// defuse.Eval but something like this is needed to do puts on fused
+	// records while keeping the original shape.
+	return vector.Apply(vector.ApplyNone, p.eval, p.defuse.Eval(vec))
 }
 
 func (p *putter) eval(vecs ...vector.Any) vector.Any {
 	vec := vecs[0]
-	if k := vec.Type().Kind(); k != super.RecordKind {
-		if k == super.ErrorKind {
-			return vec
-		}
+	switch vec.Kind() {
+	case vector.KindRecord:
+		return p.e.Eval(vec)
+	case vector.KindError:
+		return vec
+	default:
 		return vector.NewWrappedError(p.sctx, "put: not a record", vec)
 	}
-	return p.e.Eval(vec)
 }

--- a/runtime/ztests/op/put-fusion.yaml
+++ b/runtime/ztests/op/put-fusion.yaml
@@ -5,5 +5,5 @@ input: |
   fusion({x?:_::int64,y?:2},<{y:int64}>)
 
 output: |
-  {x:10,y?:_::int64}
-  {x:10,y?:2}
+  {x:10}
+  {y:2,x:10}


### PR DESCRIPTION
Add a call to defuse before put eval so we do not lose the shape of fusion values.