### PR TITLE
fjson arrays: Keep fused values in arrays

### DIFF
--- a/sio/fjsonio/jsonvec/materialize.go
+++ b/sio/fjsonio/jsonvec/materialize.go
@@ -98,9 +98,6 @@ func (m *materializer) makeUnionSubtypes(tags []uint32, dynamic [][]uint32, fixe
 
 func (m *materializer) array(a *Array) (vector.Any, []uint32) {
 	inner, ids := m.value(a.Inner)
-	// Unwrap fusion since the inner subtype IDs are redundant with
-	// the subtypes of a parent array.
-	inner = vector.Super(inner)
 	arrayType := m.sctx.LookupTypeArray(inner.Type())
 	array := vector.NewArray(arrayType, a.Offsets, inner)
 	if ids == nil {

--- a/sio/fjsonio/ztests/array.yaml
+++ b/sio/fjsonio/ztests/array.yaml
@@ -37,3 +37,16 @@ input: &input |
   []
 
 output: *input
+
+---
+
+# Test array with fusion records
+spq: pass
+
+input-flags: '-i fjson'
+output-flags: '-f json'
+
+input: &input |
+  [{"a":1},{"a":2,"b":3}]
+
+output: *input


### PR DESCRIPTION
This commit removes code in the array portion of fjson materialize that would use the super value for the arrays inner elements rather than the fused values. Removing the fused information made it impossible to recover the original values.