### PR TITLE
runtime/vam/expr: fix Defuse handling of none-valued fields

### DIFF
--- a/runtime/vam/expr/defuse.go
+++ b/runtime/vam/expr/defuse.go
@@ -72,6 +72,7 @@ func (d *Defuse) defuseRecord(vec vector.Any) vector.Any {
 	return vector.Apply(vector.ApplyNone, func(vecs ...vector.Any) vector.Any {
 		n := vecs[len(vecs)-1].Len()
 		vecs = vecs[:len(vecs)-1]
+		fieldVecs := vecs[:0]
 		var fields []super.Field
 		for i, f := range rec.Typ.Fields {
 			vec := vecs[i]
@@ -79,9 +80,10 @@ func (d *Defuse) defuseRecord(vec vector.Any) vector.Any {
 				continue
 			}
 			fields = append(fields, super.NewField(f.Name, vec.Type()))
+			fieldVecs = append(fieldVecs, vec)
 		}
 		typ := d.sctx.MustLookupTypeRecord(fields)
-		return vector.NewRecord(typ, vecs, n)
+		return vector.NewRecord(typ, fieldVecs, n)
 	}, vecs...)
 }
 

--- a/runtime/ztests/expr/function/defuse.yaml
+++ b/runtime/ztests/expr/function/defuse.yaml
@@ -102,10 +102,13 @@ spq: defuse(this)
 input: |
   fusion({a?:1,b?:_::int64,c?:_::int64},<{a:int64}>)
   fusion({a?:_::int64,b?:1,c?:2},<{b:int64,c:int64}>)
+  // None-valued record fields.
+  [{a:fusion(_::(int64|none),<none>)},{a:fusion(_::(string|none),<none>)}]
 
 output: |
   {a:1}
   {b:1,c:2}
+  [{},{}]
 
 ---
 
@@ -293,17 +296,3 @@ output: |
   [1,2,"foo"]
   set[1,2]
   set[1,2,"foo"]
-
----
-
-spq: defuse(this)
-
-input: |
-  [{key:["a"],value:fusion(1::(int64|null|none),<int64>)},{key:["b"],value:fusion(null::(string|null|none),<null>)}]
-  [{key:["a"],value:fusion(_::(int64|null|none),<none>)},{key:["b"],value:fusion(_::(string|null|none),<none>)},{key:["foo"],value?:null}]
-  [{key:["a"],value:fusion(1::(int64|null|none),<int64|null>)},{key:["b"],value:fusion(null::(string|null|none),<string|null>)}]
-
-output: |
-  [{key:["a"],value:1},{key:["b"],value:null}]
-  [{key:["a"]},{key:["b"]},{key:["foo"],value?:null}]
-  [{key:["a"],value:1::(int64|null)},{key:["b"],value:null::(string|null)}]

--- a/runtime/ztests/expr/function/defuse.yaml
+++ b/runtime/ztests/expr/function/defuse.yaml
@@ -293,3 +293,17 @@ output: |
   [1,2,"foo"]
   set[1,2]
   set[1,2,"foo"]
+
+---
+
+spq: defuse(this)
+
+input: |
+  [{key:["a"],value:fusion(1::(int64|null|none),<int64>)},{key:["b"],value:fusion(null::(string|null|none),<null>)}]
+  [{key:["a"],value:fusion(_::(int64|null|none),<none>)},{key:["b"],value:fusion(_::(string|null|none),<none>)},{key:["foo"],value?:null}]
+  [{key:["a"],value:fusion(1::(int64|null|none),<int64|null>)},{key:["b"],value:fusion(null::(string|null|none),<string|null>)}]
+
+output: |
+  [{key:["a"],value:1},{key:["b"],value:null}]
+  [{key:["a"]},{key:["b"]},{key:["foo"],value?:null}]
+  [{key:["a"],value:1::(int64|null)},{key:["b"],value:null::(string|null)}]


### PR DESCRIPTION
Defuse.defuseRecord can produce a vector.Record with more field vectors than fields (as specified by the super.Type) because it incorrectly includes vectors for non-valued fields.