### PR TITLE
Add array_agg()

### DIFF
--- a/book/src/super-sql/operators/aggregate.md
+++ b/book/src/super-sql/operators/aggregate.md
@@ -182,8 +182,8 @@ array:=collect(v) filter (k=="foo")
 {k:"foo",v:3}
 {k:"baz",v:4}
 # expected output
-{key:"bar",set:set[2],array:null}
-{key:"baz",set:set[4],array:null}
+{key:"bar",set:set[2],array:[]}
+{key:"baz",set:set[4],array:[]}
 {key:"foo",set:set[3],array:[1,3]}
 ```
 

--- a/runtime/vam/expr/agg/agg.go
+++ b/runtime/vam/expr/agg/agg.go
@@ -33,6 +33,10 @@ func NewPattern(op string, distinct, hasarg bool) (Pattern, error) {
 		pattern = func() Func {
 			return &avg{}
 		}
+	case "array_agg":
+		pattern = func() Func {
+			return &arrayAgg{}
+		}
 	case "blend":
 		pattern = func() Func {
 			return newFuse(false)

--- a/runtime/vam/expr/agg/collect.go
+++ b/runtime/vam/expr/agg/collect.go
@@ -61,7 +61,8 @@ func nullsMask(vec vector.Any) *roaring.Bitmap {
 
 func (c *collect) Result(sctx *super.Context) vector.Any {
 	if c.builder == nil {
-		return vector.NewNull(1)
+		atyp := sctx.LookupTypeArray(super.TypeNone)
+		return vector.NewArray(atyp, []uint32{0, 0}, vector.NewNone(0))
 	}
 	vec := c.builder.Build()
 	if dynamic, ok := vec.(*vector.Dynamic); ok {
@@ -77,9 +78,18 @@ func (c *collect) ConsumeAsPartial(partial vector.Any) {
 }
 
 func (c *collect) ResultAsPartial(sctx *super.Context) vector.Any {
-	if c.builder == nil {
-		atyp := sctx.LookupTypeArray(super.TypeNone)
-		return vector.NewArray(atyp, []uint32{0, 0}, vector.NewNone(0))
-	}
 	return c.Result(sctx)
+}
+
+// arrayAgg is the same as collect, except if nothing was collected it returns
+// null instead of an empty array.
+type arrayAgg struct {
+	collect
+}
+
+func (a *arrayAgg) Result(sctx *super.Context) vector.Any {
+	if a.collect.builder == nil {
+		return vector.NewNull(1)
+	}
+	return a.collect.Result(sctx)
 }

--- a/runtime/ztests/op/aggregate/array_agg.yaml
+++ b/runtime/ztests/op/aggregate/array_agg.yaml
@@ -1,0 +1,19 @@
+spq: aggregate array_agg(this)
+
+input: |
+  {a:1}
+  {a:2}
+  null
+  {b:1.5}
+  error("missing")
+  error("quiet")
+  type foo=int64
+  1::foo
+  fusion(1::(int64|null),<int64>)
+  fusion(null::(int64|null),<null>)
+
+output-flags: -fusion
+
+output: |
+  type foo=int64
+  [{a:1},{a:2},{b:1.5},error("missing"),1::foo,fusion(1::(int64|null),<int64>)]

--- a/runtime/ztests/op/aggregate/distinct-null.yaml
+++ b/runtime/ztests/op/aggregate/distinct-null.yaml
@@ -1,8 +1,8 @@
 spq: |
-  avg(distinct this), count(distinct this), collect(distinct this), sum(distinct this)
+  avg(distinct this), array_agg(distinct this), count(distinct this), collect(distinct this), sum(distinct this)
 
 input: |
   null
 
 output: |
-  {avg:null,count:0,collect:null,sum:null}
+  {avg:null,array_agg:null,count:0,collect:[],sum:null}

--- a/runtime/ztests/op/aggregate/scalar-empty.yaml
+++ b/runtime/ztests/op/aggregate/scalar-empty.yaml
@@ -1,9 +1,9 @@
 spq: |
   where false
-  | count(*), sum(this), and(this), or(this), min(this), avg(this), collect(this)
+  | count(*), sum(this), and(this), or(this), min(this), avg(this), collect(this), array_agg(this)
 
 output: |
-  {count:0,sum:null,and:null,or:null,min:null,avg:null,collect:null}
+  {count:0,sum:null,and:null,or:null,min:null,avg:null,collect:[],array_agg:null}
 
 ---
 


### PR DESCRIPTION
This commit adds the array_agg aggregation expression which is the same as collect() except it returns null when nothing has been collected. The collect() aggregate expression has been changed to return an empty array when nothing has been collected.