### PR TITLE
collect(), array_agg(): Collect null values

### DIFF
--- a/runtime/vam/expr/agg/any.go
+++ b/runtime/vam/expr/agg/any.go
@@ -30,7 +30,7 @@ func firstNonNullSlot(vec vector.Any) int {
 		return -1
 	}
 	switch vec.Kind() {
-	case vector.KindNull:
+	case vector.KindNull, vector.KindNone:
 		return -1
 	case vector.KindFusion:
 		return firstNonNullSlot(vector.Super(vec))

--- a/runtime/vam/expr/agg/collect.go
+++ b/runtime/vam/expr/agg/collect.go
@@ -18,42 +18,42 @@ func (c *collect) Consume(vec vector.Any) {
 }
 
 func (c *collect) consume(vecs ...vector.Any) vector.Any {
-	vec := filterNulls(vecs[0])
+	vec := filterNones(vecs[0])
 	if vec.Len() == 0 {
-		return vector.NewNull(vecs[0].Len())
+		return vector.NewNone(vecs[0].Len())
 	}
 	if c.builder == nil {
 		c.builder = vbuild.NewDynamicBuilder()
 	}
 	c.builder.Write(vec)
-	return vector.NewNull(vecs[0].Len())
+	return vector.NewNone(vecs[0].Len())
 }
 
-func filterNulls(vec vector.Any) vector.Any {
-	switch mask := nullsMask(vec); {
+func filterNones(vec vector.Any) vector.Any {
+	switch mask := nonesMask(vec); {
 	case mask.IsEmpty():
 		return vec
 	case mask.GetCardinality() == uint64(vec.Len()):
-		return vector.NewNull(0)
+		return vector.NewNone(0)
 	default:
 		return vector.ReversePick(vec, mask.ToArray())
 	}
 }
 
-func nullsMask(vec vector.Any) *roaring.Bitmap {
+func nonesMask(vec vector.Any) *roaring.Bitmap {
 	vec = vector.Apply(vector.ApplyRipFusions|vector.ApplyRipUnions, func(vecs ...vector.Any) vector.Any {
 		return vecs[0]
 	}, vec)
 	bm := roaring.New()
 	if dynamic, ok := vec.(*vector.Dynamic); ok {
 		for i, vec := range dynamic.Values {
-			if vec.Len() > 0 && vec.Kind() == vector.KindNull {
+			if vec.Len() > 0 && vec.Kind() == vector.KindNone {
 				bm.AddMany(dynamic.ReverseTagMap()[i])
 			}
 		}
 		return bm
 	}
-	if vec.Len() > 0 && vec.Kind() == vector.KindNull {
+	if vec.Len() > 0 && vec.Kind() == vector.KindNone {
 		bm.AddRange(0, uint64(vec.Len()))
 	}
 	return bm

--- a/runtime/vam/expr/agg/collectmap.go
+++ b/runtime/vam/expr/agg/collectmap.go
@@ -17,7 +17,7 @@ func newCollectMap() *collectMap {
 }
 
 func (c *collectMap) Consume(vec vector.Any) {
-	if k := vec.Kind(); k == vector.KindNull || k == vector.KindError {
+	if k := vec.Kind(); k == vector.KindNull || k == vector.KindError || k == vector.KindNone {
 		return
 	}
 	typ := vec.Type()

--- a/runtime/vam/expr/agg/count.go
+++ b/runtime/vam/expr/agg/count.go
@@ -10,7 +10,7 @@ type count struct {
 }
 
 func (a *count) Consume(vec vector.Any) {
-	if vec.Kind() == vector.KindNull {
+	if k := vec.Kind(); k == vector.KindNull || k == vector.KindNone {
 		return
 	}
 	a.count += int64(vec.Len())

--- a/runtime/vam/expr/agg/fuse.go
+++ b/runtime/vam/expr/agg/fuse.go
@@ -70,7 +70,7 @@ func (f *fuse) Result(sctx *super.Context) vector.Any {
 
 func (f *fuse) ConsumeAsPartial(partial vector.Any) {
 	kind := partial.Kind()
-	if kind == vector.KindNull {
+	if kind == vector.KindNull || kind == vector.KindNone {
 		return
 	}
 	if kind != vector.KindType {

--- a/runtime/vam/expr/agg/union.go
+++ b/runtime/vam/expr/agg/union.go
@@ -17,7 +17,7 @@ func newUnion() *union {
 }
 
 func (u *union) Consume(vec vector.Any) {
-	if vec.Kind() == vector.KindNull {
+	if k := vec.Kind(); k == vector.KindNull || k == vector.KindNone {
 		return
 	}
 	switch vec := vec.(type) {

--- a/runtime/vam/expr/aggregator.go
+++ b/runtime/vam/expr/aggregator.go
@@ -51,11 +51,11 @@ func (a *Aggregator) Eval(this vector.Any) vector.Any {
 	bools, _ := BoolMask(where)
 	if bools.IsEmpty() {
 		// everything is filtered.
-		return vector.NewNull(vec.Len())
+		return vector.NewNone(vec.Len())
 	}
 	if bools.GetCardinality() != uint64(vec.Len()) {
 		index := bools.ToArray()
-		nulls := vector.NewNull(vec.Len() - uint32(len(index)))
+		nulls := vector.NewNone(vec.Len() - uint32(len(index)))
 		vec = vector.Combine(nulls, index, vector.Pick(vec, index))
 	}
 	if a.NoRip {

--- a/runtime/ztests/expr/issue-5759.yaml
+++ b/runtime/ztests/expr/issue-5759.yaml
@@ -4,4 +4,4 @@ spq: unnest this | collect(this)
 input: '[null,1,"a"]'
 
 output: |
-  [1,"a"]
+  [null,1,"a"]

--- a/runtime/ztests/op/aggregate/array_agg.yaml
+++ b/runtime/ztests/op/aggregate/array_agg.yaml
@@ -16,4 +16,14 @@ output-flags: -fusion
 
 output: |
   type foo=int64
-  [{a:1},{a:2},{b:1.5},error("missing"),1::foo,fusion(1::(int64|null),<int64>)]
+  [{a:1},{a:2},null,{b:1.5},error("missing"),1::foo,fusion(1::(int64|null),<int64>),fusion(null::(int64|null),<null>)]
+
+---
+
+# Test empty array_agg
+spq: array_agg(this) filter (false)
+
+input: '1'
+
+output: |
+  null

--- a/runtime/ztests/op/aggregate/collect.yaml
+++ b/runtime/ztests/op/aggregate/collect.yaml
@@ -16,4 +16,14 @@ output-flags: -fusion
 
 output: |
   type foo=int64
-  [{a:1},{a:2},{b:1.5},error("missing"),1::foo,fusion(1::(int64|null),<int64>)]
+  [{a:1},{a:2},null,{b:1.5},error("missing"),1::foo,fusion(1::(int64|null),<int64>),fusion(null::(int64|null),<null>)]
+
+---
+
+# Test empty collect
+spq: collect(this) filter (false)
+
+input: '1'
+
+output: |
+  []

--- a/runtime/ztests/op/aggregate/distinct-null.yaml
+++ b/runtime/ztests/op/aggregate/distinct-null.yaml
@@ -5,4 +5,4 @@ input: |
   null
 
 output: |
-  {avg:null,array_agg:null,count:0,collect:[],sum:null}
+  {avg:null,array_agg:[null],count:0,collect:[null],sum:null}

--- a/runtime/ztests/op/unnest-summarize.yaml
+++ b/runtime/ztests/op/unnest-summarize.yaml
@@ -6,5 +6,6 @@ input: |
   {a:[3,2,1]}
 
 output: |
+  null
   15
   6


### PR DESCRIPTION
This commit changes the behavior of collect() and array_agg() so that null values are collected and not discarded. Additionally this commit changes the internal logic of aggregator filters so they return none on filtered values and adjusts the downstream aggregators so they ignore none values.

Fixes #6960