### PR TITLE
vam/expr/agg: Make it so package can import vam/expr

### DIFF
--- a/compiler/rungen/vop.go
+++ b/compiler/rungen/vop.go
@@ -11,6 +11,7 @@ import (
 	"github.com/brimdata/super/pkg/field"
 	"github.com/brimdata/super/runtime/sam/expr"
 	vamexpr "github.com/brimdata/super/runtime/vam/expr"
+	vamagg "github.com/brimdata/super/runtime/vam/expr/agg"
 	vamop "github.com/brimdata/super/runtime/vam/op"
 	"github.com/brimdata/super/runtime/vam/op/aggregate"
 	"github.com/brimdata/super/sbuf"
@@ -428,5 +429,9 @@ func (b *Builder) compileVamAgg(agg *dag.AggExpr) (*vamexpr.Aggregator, error) {
 			return nil, err
 		}
 	}
-	return vamexpr.NewAggregator(name, agg.Distinct, arg, filter)
+	pattern, err := vamagg.NewPattern(name, agg.Distinct, agg.Expr != nil)
+	if err != nil {
+		return nil, err
+	}
+	return vamexpr.NewAggregator(name, agg.Distinct, arg, filter, pattern)
 }

--- a/runtime/vam/expr/agg/agg.go
+++ b/runtime/vam/expr/agg/agg.go
@@ -3,82 +3,72 @@ package agg
 import (
 	"fmt"
 
-	"github.com/brimdata/super"
-	"github.com/brimdata/super/vector"
+	"github.com/brimdata/super/runtime/vam/expr"
 )
 
-type Func interface {
-	Consume(vector.Any)
-	ConsumeAsPartial(vector.Any)
-	Result(*super.Context) vector.Any
-	ResultAsPartial(*super.Context) vector.Any
-}
-
-type Pattern func() Func
-
-func NewPattern(op string, distinct, hasarg bool) (Pattern, error) {
+func NewPattern(op string, distinct, hasarg bool) (expr.AggPattern, error) {
 	needarg := true
-	var pattern Pattern
+	var pattern expr.AggPattern
 	switch op {
 	case "count":
 		needarg = false
-		pattern = func() Func {
+		pattern = func() expr.AggFunc {
 			return &count{}
 		}
 	case "any":
-		pattern = func() Func {
+		pattern = func() expr.AggFunc {
 			return NewAny()
 		}
 	case "avg":
-		pattern = func() Func {
+		pattern = func() expr.AggFunc {
 			return &avg{}
 		}
 	case "array_agg":
-		pattern = func() Func {
+		pattern = func() expr.AggFunc {
 			return &arrayAgg{}
 		}
 	case "blend":
-		pattern = func() Func {
+		pattern = func() expr.AggFunc {
 			return newFuse(false)
 		}
 	case "dcount":
-		pattern = func() Func {
+		pattern = func() expr.AggFunc {
 			return newDCount()
 		}
 	case "fuse":
-		pattern = func() Func {
+		pattern = func() expr.AggFunc {
 			return newFuse(true)
 		}
 	case "sum":
-		pattern = func() Func {
+		pattern = func() expr.AggFunc {
 			return newMathReducer(mathSum)
 		}
 	case "min":
-		pattern = func() Func {
+		pattern = func() expr.AggFunc {
 			return newMathReducer(mathMin)
 		}
 	case "max":
-		pattern = func() Func {
+		pattern = func() expr.AggFunc {
 			return newMathReducer(mathMax)
 		}
 	case "union":
-		pattern = func() Func {
+		pattern = func() expr.AggFunc {
 			return newUnion()
 		}
 	case "collect":
-		pattern = func() Func {
+		pattern = func() expr.AggFunc {
 			return &collect{}
 		}
 	case "collect_map":
-		pattern = func() Func {
+		pattern = func() expr.AggFunc {
 			return newCollectMap()
 		}
 	case "and":
-		pattern = func() Func {
+		pattern = func() expr.AggFunc {
 			return &and{}
 		}
 	case "or":
-		pattern = func() Func {
+		pattern = func() expr.AggFunc {
 			return &or{}
 		}
 	default:
@@ -91,7 +81,7 @@ func NewPattern(op string, distinct, hasarg bool) (Pattern, error) {
 		switch op {
 		case "avg", "collect", "count", "sum":
 			// Distinct affects only these functions.
-			return func() Func {
+			return func() expr.AggFunc {
 				return newDistinct(pattern())
 			}, nil
 		}

--- a/runtime/vam/expr/agg/avg.go
+++ b/runtime/vam/expr/agg/avg.go
@@ -2,6 +2,7 @@ package agg
 
 import (
 	"github.com/brimdata/super"
+	"github.com/brimdata/super/runtime/vam/expr"
 	"github.com/brimdata/super/vector"
 )
 
@@ -10,7 +11,7 @@ type avg struct {
 	count uint64
 }
 
-var _ Func = (*avg)(nil)
+var _ expr.AggFunc = (*avg)(nil)
 
 func (a *avg) Consume(vec vector.Any) {
 	vec = vector.Under(vec)

--- a/runtime/vam/expr/agg/distinct.go
+++ b/runtime/vam/expr/agg/distinct.go
@@ -5,18 +5,19 @@ import (
 
 	"github.com/brimdata/super"
 	samagg "github.com/brimdata/super/runtime/sam/expr/agg"
+	"github.com/brimdata/super/runtime/vam/expr"
 	"github.com/brimdata/super/sbuf"
 	"github.com/brimdata/super/scode"
 	"github.com/brimdata/super/vector"
 )
 
 type distinct struct {
-	fun  Func
+	fun  expr.AggFunc
 	buf  []byte
 	seen map[string]struct{}
 }
 
-func newDistinct(f Func) Func {
+func newDistinct(f expr.AggFunc) expr.AggFunc {
 	return &distinct{fun: f, seen: map[string]struct{}{}}
 }
 

--- a/runtime/vam/expr/agg/math.go
+++ b/runtime/vam/expr/agg/math.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/runtime/sam/expr/coerce"
+	"github.com/brimdata/super/runtime/vam/expr"
 	"github.com/brimdata/super/sup"
 	"github.com/brimdata/super/vector"
 )
@@ -26,7 +27,7 @@ func newMathReducer(f *mathFunc) *mathReducer {
 	return &mathReducer{function: f}
 }
 
-var _ Func = (*mathReducer)(nil)
+var _ expr.AggFunc = (*mathReducer)(nil)
 
 func (m *mathReducer) Result(sctx *super.Context) vector.Any {
 	if m.mixedTypesErr {

--- a/runtime/vam/expr/aggregator.go
+++ b/runtime/vam/expr/aggregator.go
@@ -2,12 +2,20 @@ package expr
 
 import (
 	"github.com/brimdata/super"
-	"github.com/brimdata/super/runtime/vam/expr/agg"
 	"github.com/brimdata/super/vector"
 )
 
+type AggFunc interface {
+	Consume(vector.Any)
+	ConsumeAsPartial(vector.Any)
+	Result(*super.Context) vector.Any
+	ResultAsPartial(*super.Context) vector.Any
+}
+
+type AggPattern func() AggFunc
+
 type Aggregator struct {
-	Pattern  agg.Pattern
+	Pattern  AggPattern
 	Name     string
 	Distinct bool
 	Expr     Evaluator
@@ -15,11 +23,7 @@ type Aggregator struct {
 	NoRip    bool
 }
 
-func NewAggregator(name string, distinct bool, expr Evaluator, where Evaluator) (*Aggregator, error) {
-	pattern, err := agg.NewPattern(name, distinct, expr != nil)
-	if err != nil {
-		return nil, err
-	}
+func NewAggregator(name string, distinct bool, expr Evaluator, where Evaluator, pattern AggPattern) (*Aggregator, error) {
 	var norip bool
 	if fn, ok := pattern().(interface{ NoRip() bool }); ok {
 		norip = fn.NoRip()

--- a/runtime/vam/op/aggregate/aggtable.go
+++ b/runtime/vam/op/aggregate/aggtable.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/runtime/vam/expr"
-	"github.com/brimdata/super/runtime/vam/expr/agg"
 	"github.com/brimdata/super/scode"
 	"github.com/brimdata/super/vector"
 	"github.com/brimdata/super/vector/vbuild"
@@ -34,7 +33,7 @@ var _ aggTable = (*superTable)(nil)
 
 type aggRow struct {
 	keys  []super.Value
-	funcs []agg.Func
+	funcs []expr.AggFunc
 }
 
 func (s *superTable) update(keys []vector.Any, args []vector.Any) {

--- a/runtime/vam/op/aggregate/scalar.go
+++ b/runtime/vam/op/aggregate/scalar.go
@@ -4,7 +4,6 @@ import (
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/pkg/field"
 	"github.com/brimdata/super/runtime/vam/expr"
-	"github.com/brimdata/super/runtime/vam/expr/agg"
 	"github.com/brimdata/super/vector"
 	"github.com/brimdata/super/vector/vio"
 )
@@ -18,7 +17,7 @@ type scalarAggregate struct {
 	partialsIn  bool
 	partialsOut bool
 
-	funcs []agg.Func
+	funcs []expr.AggFunc
 }
 
 func NewScalar(parent vio.Puller, sctx *super.Context, aggs []*expr.Aggregator, aggNames []field.Path, aggExprs []expr.Evaluator, partialsIn, partialsOut bool) (vio.Puller, error) {
@@ -81,8 +80,8 @@ func (s *scalarAggregate) consume(vecs ...vector.Any) vector.Any {
 	return vector.NewNull(vecs[0].Len())
 }
 
-func newFuncs(aggs []*expr.Aggregator) []agg.Func {
-	var funcs []agg.Func
+func newFuncs(aggs []*expr.Aggregator) []expr.AggFunc {
+	var funcs []expr.AggFunc
 	for _, agg := range aggs {
 		funcs = append(funcs, agg.Pattern())
 	}


### PR DESCRIPTION
This commit shifts things around for aggregation expressions so that the "agg" package can import from package "expr" and not create an import cycle. This clears the way for adding defuse into collect which will be done in a subsequent pr.