### PR TITLE
Spots to recommend blend instead of fuse

### DIFF
--- a/book/src/command/output.md
+++ b/book/src/command/output.md
@@ -129,13 +129,13 @@ echo '{x:1}{s:"hello"}' | super -o out.parquet -f parquet -
 ```
 causes this error
 ```mdtest-output
-parquetio: encountered multiple types (consider 'fuse'): {x:int64} and {s:string}
+parquetio: encountered multiple types (consider 'blend'): {x:int64} and {s:string}
 ```
 
 To write heterogeneous data to a schema-based file format, you must
 convert the data to a monolithic type.  To handle this,
-you can either [fuse](../super-sql/operators/fuse.md)
-the data into a single fused type or you can specify
+you can either [blend](../super-sql/operators/blend.md)
+the data into a single type or you can specify
 the `-split` flag to indicate a destination directory that receives
 a separate output file for each output type.
 

--- a/sio/arrowio/writer.go
+++ b/sio/arrowio/writer.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	ErrMultipleTypes   = errors.New("arrowio: encountered multiple types (consider 'fuse')")
+	ErrMultipleTypes   = errors.New("arrowio: encountered multiple types (consider 'blend')")
 	ErrNotRecord       = errors.New("arrowio: not a record")
 	ErrUnsupportedType = errors.New("arrowio: unsupported type")
 )

--- a/sio/arrowio/ztests/writer-errors.yaml
+++ b/sio/arrowio/ztests/writer-errors.yaml
@@ -9,7 +9,7 @@ script: |
 outputs:
   - name: stderr
     data: |
-        arrowio: encountered multiple types (consider 'fuse'): {a:int64} and {b:int64}
+        arrowio: encountered multiple types (consider 'blend'): {a:int64} and {b:int64}
         arrowio: not a record: 1
         arrowio: unsupported type: empty record
         arrowio: unsupported type: T

--- a/sio/parquetio/ztests/writer-errors.yaml
+++ b/sio/parquetio/ztests/writer-errors.yaml
@@ -9,7 +9,7 @@ script: |
 outputs:
   - name: stderr
     data: |
-        parquetio: encountered multiple types (consider 'fuse'): {a:int64} and {b:int64}
+        parquetio: encountered multiple types (consider 'blend'): {a:int64} and {b:int64}
         parquetio: not a record: 1
         parquetio: unsupported type: empty record
         parquetio: unsupported type: T


### PR DESCRIPTION
The `blend` operator now covers the use case of fitting heterogeneous data into a single type, such as needed before writing to schema-rigid formats like Parquet. In the past that was covered by `fuse`, so there was some lingering user-facing guidance to that effect. This makes sure we consistently point users at `blend`.