### PR TITLE
collect_map(): defuse input values

### DIFF
--- a/runtime/vam/expr/agg/agg.go
+++ b/runtime/vam/expr/agg/agg.go
@@ -62,7 +62,7 @@ func NewPattern(sctx *super.Context, op string, distinct, hasarg bool) (expr.Agg
 		}
 	case "collect_map":
 		pattern = func() expr.AggFunc {
-			return newCollectMap()
+			return newCollectMap(sctx)
 		}
 	case "and":
 		pattern = func() expr.AggFunc {

--- a/runtime/vam/expr/agg/collectmap.go
+++ b/runtime/vam/expr/agg/collectmap.go
@@ -3,6 +3,7 @@ package agg
 import (
 	"github.com/brimdata/super"
 	samagg "github.com/brimdata/super/runtime/sam/expr/agg"
+	"github.com/brimdata/super/runtime/vam/expr"
 	"github.com/brimdata/super/sbuf"
 	"github.com/brimdata/super/scode"
 	"github.com/brimdata/super/vector"
@@ -10,15 +11,23 @@ import (
 
 type collectMap struct {
 	samCollectMap *samagg.CollectMap
+	defuse        *expr.Defuse
 }
 
-func newCollectMap() *collectMap {
-	return &collectMap{samagg.NewCollectMap()}
+func newCollectMap(sctx *super.Context) *collectMap {
+	return &collectMap{samagg.NewCollectMap(), expr.NewDefuse(sctx)}
 }
+
+func (*collectMap) NoRip() bool { return true }
 
 func (c *collectMap) Consume(vec vector.Any) {
+	vector.Apply(vector.ApplyRipUnions, c.consume, c.defuse.Eval(vec))
+}
+
+func (c *collectMap) consume(vecs ...vector.Any) vector.Any {
+	vec := vecs[0]
 	if k := vec.Kind(); k == vector.KindNull || k == vector.KindError || k == vector.KindNone {
-		return
+		return vec
 	}
 	typ := vec.Type()
 	var b scode.Builder
@@ -27,6 +36,7 @@ func (c *collectMap) Consume(vec vector.Any) {
 		vec.Serialize(&b, i)
 		c.samCollectMap.Consume(super.NewValue(typ, b.Bytes().Body()))
 	}
+	return vec
 }
 
 func (c *collectMap) Result(sctx *super.Context) vector.Any {

--- a/runtime/vam/expr/defuse.go
+++ b/runtime/vam/expr/defuse.go
@@ -125,8 +125,8 @@ func (d *Defuse) defuseSet(in vector.Any) vector.Any {
 
 func (d *Defuse) defuseMap(in vector.Any) vector.Any {
 	vmap := vector.PushView(in).(*vector.Map)
-	keys := d.eval(vmap.Values)
-	vals := d.eval(vmap.Values)
+	keys := flattenUnions(d.eval(vmap.Keys))
+	vals := flattenUnions(d.eval(vmap.Values))
 	if !vector.IsDynamic(keys) && !vector.IsDynamic(vals) {
 		typ := d.sctx.LookupTypeMap(keys.Type(), vals.Type())
 		return vector.NewMap(typ, vmap.Offsets, keys, vals)
@@ -157,6 +157,13 @@ func (d *Defuse) defuseMap(in vector.Any) vector.Any {
 		return vecs[0]
 	}
 	return vector.NewDynamic(tags, vecs)
+}
+
+func flattenUnions(vec vector.Any) vector.Any {
+	if d, ok := vec.(*vector.Dynamic); ok {
+		return vector.FlattenUnions(d)
+	}
+	return vec
 }
 
 func mergeSameTypes(vec vector.Any) vector.Any {

--- a/runtime/ztests/op/aggregate/collect_map.yaml
+++ b/runtime/ztests/op/aggregate/collect_map.yaml
@@ -37,11 +37,14 @@ input: |
   {k:127.0.0.1,v:127.0.0.1}
   {k:2.,v:2.}
   {k:["bar","baz"],v:["bar","baz"]}
+  // Fusion
+  {k:fusion("k"::(int64|string),<string>),v:fusion("v"::(null|string),<string>)}
 
 output: |
   type my_string = string
   map{
     1: 1,
+    "k": "v",
     "foo"::my_string: "bar",
     "zoo"::my_string: "zar"::my_string,
     127.0.0.1: 127.0.0.1,


### PR DESCRIPTION
Defuse input values for the collect_map() aggregation expression. Also fix an issue with defuse on map values where (1) values where set as the keys and (2) key value element unions where not getting unflattened which led to panics at runtime.