### PR TITLE
vector.DeoptionWithMissing: account for fusion values

### DIFF
--- a/vector/union.go
+++ b/vector/union.go
@@ -293,6 +293,24 @@ func DeoptionWithMissing(sctx *super.Context, vec Any) Any {
 			out = DeoptionWithMissing(sctx, out)
 			return out
 		}
+	case *Fusion:
+		if hasOptionTypesOrNones([]Any{vec.Values}) {
+			types := vec.Subtypes.Types()
+			var index []uint32
+			for id, typ := range types {
+				if typ == super.TypeNone {
+					index = append(index, uint32(id))
+				}
+			}
+			if len(index) == 0 {
+				return vec
+			}
+			missing := NewMissing(sctx, uint32(len(index)))
+			if missing.Len() == vec.Len() {
+				return missing
+			}
+			return Combine(vec, index, missing)
+		}
 	}
 	return vec
 }


### PR DESCRIPTION
This commit adjust vector.DeoptionWithMissing to return error("missing") for none values within fusion values.